### PR TITLE
added corpora folder with potential source documents for the project

### DIFF
--- a/corpora/lovecraftWorks.txt
+++ b/corpora/lovecraftWorks.txt
@@ -1,0 +1,8711 @@
+
+                        THE COLOUR OUT OF SPACE
+
+                          By H. P. Lovecraft
+
+           [Transcriber's Note: This etext was produced from
+                    Amazing Stories September 1927.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+            _Here is a totally different story that we can
+           highly recommend to you. We could wax rhapsodical
+           in our praise, as the story is one of the finest
+         pieces of literature it has been our good fortune to
+            read. The theme is original, and yet fantastic
+            enough to make it rise head and shoulders above
+          many contemporary scientifiction stories. You will
+             not regret having read this marvellous tale._
+
+
+West of Arkham the hills rise wild, and there are valleys with deep
+woods that no axe has ever cut. There are dark narrow glens where the
+trees slope fantastically, and where thin brooklets trickle without
+ever having caught the glint of sunlight. On the gentler slopes there
+are farms, ancient and rocky, with squat, moss-coated cottages brooding
+eternally over old New England secrets in the lee of great ledges; but
+these are all vacant now, the wide chimneys crumbling and the shingled
+sides bulging perilously beneath low gambrel roofs.
+
+The old folk have gone away, and foreigners do not like to live there.
+French-Canadians have tried it, Italians have tried it, and the Poles
+have come and departed. It is not because of anything that can be seen
+or heard or handled, but because of something that is imagined. The
+place is not good for imagination, and does not bring restful dreams at
+night. It must be this which keeps the foreigners away, for old Ammi
+Pierce has never told them of anything he recalls from the strange
+days. Ammi, whose head has been a little queer for years, is the only
+one who still remains, or who ever talks of the strange days; and he
+dares to do this because his house is so near the open fields and the
+travelled roads around Arkham.
+
+There was once a road over the hills and through the valleys, that ran
+straight where the blasted heath is now; but people ceased to use it
+and a new road was laid curving far toward the south. Traces of the
+old one can still be found amidst the weeds of a returning wilderness,
+and some of them will doubtless linger even when half the hollows are
+flooded for the new reservoir. Then the dark woods will be cut down and
+the blasted heath will slumber far below blue waters whose surface will
+mirror the sky and ripple in the sun. And the secrets of the strange
+days will be one with the deep's secrets; one with the hidden lore of
+old ocean, and all the mystery of primal earth.
+
+When I went into the hills and vales to survey for the new reservoir
+they told me the place was evil. They told me this in Arkham, and
+because that is a very old town full of witch legends I thought the
+evil must be something which grandmas had whispered to children
+through centuries. The name "blasted heath" seemed to me very odd
+and theatrical, and I wondered how it had come into the folklore of
+a Puritan people. Then I saw that dark westward tangle of glens and
+slopes for myself, and ceased to wonder at anything besides its own
+elder mystery. It was morning when I saw it, but shadow lurked always
+there. The trees grew too thickly, and their trunks were too big for
+any healthy New England wood. There was too much silence in the dim
+alleys between them, and the floor was too soft with the dank moss and
+mattings of infinite years of decay.
+
+In the open spaces, mostly along the line of the old road, there were
+little hillside farms; sometimes with all the buildings standing,
+sometimes with only one or two, and sometimes with only a lone chimney
+or fast-filling cellar. Weeds and briers reigned, and furtive wild
+things rustled in the undergrowth. Upon everything was a haze of
+restlessness and oppression; a touch of the unreal and the grotesque,
+as if some vital element of perspective or chiaroscuro were awry. I did
+not wonder that the foreigners would not stay, for this was no region
+to sleep in. It was too much like a landscape of Salvator Rosa; too
+much like some forbidden woodcut in a tale of terror.
+
+But even all this was not so bad as the blasted heath. I knew it the
+moment I came upon it at the bottom of a spacious valley; for no other
+name could fit such thing, or any other thing fit such a name. It
+was as if the poet had coined the phrase from having seen this one
+particular region. It must, I thought as I viewed it, be the outcome
+of a fire; but why had nothing new ever grown over those five acres of
+grey desolation that sprawled open to the sky like a great spot eaten
+by acid in the woods and fields? It lay largely to the north of the
+ancient road line, but encroached a little on the other side. I felt
+an odd reluctance about approaching, and did so at last only because
+my business took me through and past it. There was no vegetation of
+any kind on that broad expanse, but only a fine grey dust or ash which
+no wind seemed ever to blow about. The trees near it were sickly
+and stunted, and many dead trunks stood or lay rotting at the rim.
+As I walked hurriedly by I saw the tumbled bricks and stones of an
+old chimney and cellar on my right, and the yawning black maw of an
+abandoned well whose stagnant vapours played strange tricks with the
+hues of the sunlight. Even the long, dark woodland climb beyond seemed
+welcome in contrast, and I marvelled no more at the frightened whispers
+of Arkham people. There had been no house or ruin near; even in the
+old days the place must have been lonely and remote. And at twilight,
+dreading to repass that ominous spot, I walked circuitously back to the
+town by the curving road on the south. I vaguely wished some clouds
+would gather, for an odd timidity about the deep skyey voids above had
+crept into my soul.
+
+In the evening I asked old people in Arkham about the blasted heath,
+and what was meant by that phrase "strange days" which so many
+evasively muttered. I could not, however, get any good answers, except
+that all the mystery was much more recent than I had dreamed. It was
+not a matter of old legendry at all, but something within the lifetime
+of those who spoke. It had happened in the 'eighties, and a family had
+disappeared or was killed. Speakers would not be exact; and because
+they all told me to pay no attention to old Ammi Pierce's crazy tales,
+I sought him out the next morning, having heard that he lived alone in
+the ancient tottering cottage where the trees first begin to get very
+thick. It was a fearsomely ancient place, and had begun to exude the
+faint miasmal odour which clings about houses that have stood too long.
+Only with persistent knocking could I rouse the aged man, and when he
+shuffled timidly to the door I could tell he was not glad to see me. He
+was not so feeble as I had expected; but his eyes drooped in a curious
+way, and his unkempt clothing and white beard made him seem very worn
+and dismal.
+
+Not knowing just how he could best be launched on his tales, I feigned
+a matter of business; told him of my surveying, and asked vague
+questions about the district. He was far brighter and more educated
+than I had been led to think, and before I knew it had grasped quite
+as much of the subject as any man I had talked with in Arkham. He was
+not like other rustics I had known in the sections where reservoirs
+were to be. From him there were no protests at the miles of old wood
+and farmland to be blotted out, though perhaps there would have been
+had not his home lain outside the bounds of the future lake. Relief
+was all that he showed; relief at the doom of the dark ancient valleys
+through which he had roamed all his life. They were better under water
+now--better under water since the strange days. And with this opening
+his husky voice sank low, while his body leaned forward and his right
+forefinger began to point shakily and impressively.
+
+       *       *       *       *       *
+
+It was then that I heard the story, and as the rambling voice scraped
+and whispered on I shivered again and again despite the summer day.
+Often I had to recall the speaker from ramblings, piece out scientific
+points which he knew only by a fading parrot memory of professors'
+talk, or bridge over gaps, where his sense of logic and continuity
+broke down. When he was done I did not wonder that his mind had snapped
+a trifle, or that the folk of Arkham would not speak much of the
+blasted heath. I hurried back before sunset to my hotel, unwilling to
+have the stars come out above me in the open; and the next day returned
+to Boston to give up my position. I could not go into that dim chaos
+of old forest and slope again, or face another time that grey blasted
+heath where the black well yawned deep beside the tumbled bricks and
+stones. The reservoir will soon be built now, and all those elder
+secrets will lie safe forever under watery fathoms. But even then I do
+not believe I would like to visit that country by night--at least not
+when the sinister stars are out; and nothing could bribe me to drink
+the new city water of Arkham.
+
+It all began, old Ammi said, with the meteorite. Before that time there
+had been no wild legends at all since the witch trials, and even then
+these western woods were not feared half so much as the small island
+in the Miskatonic where the devil held court beside a curious stone
+altar older than the Indians. These were not haunted woods, and their
+fantastic dusk was never terrible till the strange days. Then there
+had come that white noontide cloud, that string of explosions in the
+air, and that pillar of smoke from the valley far in the wood. And by
+night all Arkham had heard of the great rock that fell out of the sky
+and bedded itself in the ground beside the well at the Nahum Gardner
+place. That was the house which had stood where the blasted heath was
+to come--the trim white Nahum Gardner house amidst its fertile gardens
+and orchards.
+
+Nahum had come to town to tell people about the stone, and had dropped
+in at Ammi Pierce's on the way. Ammi was forty then, and all the queer
+things were fixed very strongly in his mind. He and his wife had gone
+with the three professors from Miskatonic University who hastened out
+the next morning to see the weird visitor from unknown stellar space,
+and had wondered why Nahum had called it so large the day before. It
+had shrunk, Nahum said as he pointed out the big brownish mound above
+the ripped earth and charred grass near the archaic well-sweep in his
+front yard; but the wise men answered that stones do not shrink. Its
+heat lingered persistently, and Nahum declared it had glowed faintly in
+the night. The professors tried it with a geologist's hammer and found
+it was oddly soft. It was, in truth, so soft as to be almost plastic;
+and they gouged rather than chipped a specimen to take back to the
+college for testing. They took it in an old pail borrowed from Nahum's
+kitchen, for even the small piece refused to grow cool. On the trip
+back they stopped at Ammi's to rest, and seemed thoughtful when Mrs.
+Pierce remarked that the fragment was growing smaller and burning the
+bottom of the pail. Truly, it was not large, but perhaps they had taken
+less than they thought.
+
+The day after that--all this was in June of '82--the professors had
+trooped out again in a great excitement. As they passed Ammi's they
+told him what queer things the specimen had done, and how it had
+faded wholly away when they put it in a glass beaker. The beaker had
+gone, too, and the wise men talked of the strange stone's affinity
+for silicon. It had acted quite unbelievably in that well-ordered
+laboratory; doing nothing at all and showing no occluded gases when
+heated on charcoal, being wholly negative in the borax bead, and soon
+proving itself absolutely non-volatile at any producible temperature,
+including that of the oxy-hydrogen blowpipe. On an anvil it appeared
+highly malleable, and in the dark its luminosity was very marked.
+Stubbornly refusing to grow cool, it soon had the college in a state
+of real excitement; and when upon heating before the spectroscope it
+displayed shining bands unlike any known colours of the normal spectrum
+there was much breathless talk of new elements, bizarre optical
+properties, and other things which puzzled men of science are wont to
+say when faced by the unknown.
+
+Hot as it was, they tested it in a crucible with all the proper
+reagents. Water did nothing. Hydrochloric acid was the same. Nitric
+acid and even aqua regia merely hissed and spattered against its torrid
+invulnerability. Ammi had difficulty in recalling all these things, but
+recognized some solvents as I mentioned them in the usual order of use.
+There were ammonia and caustic soda, alcohol and ether, nauseous carbon
+disulphide and a dozen others; but although the weight grew steadily
+less as time passed, and the fragment seemed to be slightly cooling,
+there was no change in the solvents to show that they had attacked
+the substance at all. It was a metal, though, beyond a doubt. It was
+magnetic, for one thing; and after its immersion in the acid solvents
+there seemed to be faint traces of the WidmÃ¤nstÃ¤tten figures found
+on meteoric iron. When the cooling had grown very considerable, the
+testing was carried on in glass; and it was in a glass beaker that they
+left all the chips made of the original fragment during the work. The
+next morning both chips and beaker were gone without trace, and only a
+charred spot marked the place on the wooden shelf where they had been.
+
+All this the professors told Ammi as they paused at his door, and
+once more he went with them to see the stony messenger from the
+stars, though this time his wife did not accompany him. It had now
+most certainly shrunk, and even the sober professors could not doubt
+the truth of what they saw. All around the dwindling brown lump near
+the well was a vacant space, except where the earth had caved in;
+and whereas it had been a good seven feet across the day before, it
+was now scarcely five. It was still hot, and the sages studied its
+surface curiously as they detached another and larger piece with hammer
+and chisel. They gouged deeply this time, and as they pried away
+the smaller mass they saw that the core of the thing was not quite
+homogeneous.
+
+       *       *       *       *       *
+
+They had uncovered what seemed to be the side of a large coloured
+globule embedded in the substance. The colour, which resembled some
+of the bands in the meteor's strange spectrum, was almost impossible
+to describe; and it was only by analogy that they called it colour at
+all. Its texture was glossy, and upon tapping it appeared to promise
+both brittleness and hollowness. One of the professors gave it a smart
+blow with a hammer, and it burst with a nervous little pop. Nothing was
+emitted, and all trace of the thing vanished with the puncturing. It
+left behind a hollow spherical space about three inches across, and all
+thought it probable that others would be discovered as the enclosing
+substance wasted away.
+
+Conjecture was vain; so after a futile attempt to find additional
+globules by drilling, the seekers left again with their new
+specimen--which proved, however, as baffling in the laboratory as
+its predecessor. Aside from being almost plastic, having heat,
+magnetism, and slight luminosity, cooling slightly in powerful acids,
+possessing an unknown spectrum, wasting away in air, and attacking
+silicon compounds with mutual destruction as a result, it presented
+no identifying features whatsoever; and at the end of the tests the
+college scientists were forced to own that they could not place it. It
+was nothing of this earth, but a piece of the great outside; and as
+such dowered with outside properties and obedient to outside laws.
+
+That night there was a thunderstorm, and when the professors went out
+to Nahum's the next day they met with a bitter disappointment. The
+stone, magnetic as it had been, must have had some peculiar electrical
+property; for it had "drawn the lightning," as Nahum said, with a
+singular persistence. Six times within an hour the farmer saw the
+lightning strike the furrow in the front yard, and when the storm was
+over nothing remained but a ragged pit by the ancient well-sweep,
+half-chocked with caved-in earth. Digging had borne no fruit, and the
+scientists verified the fact of the utter vanishment. The failure was
+total; so that nothing was left to do but go back to the laboratory and
+test again the disappearing fragment left carefully cased in lead. That
+fragment lasted a week, at the end of which nothing of value had been
+learned of it. When it had gone, no residue was left behind, and in
+time the professors felt scarcely sure they had indeed seen with waking
+eyes that cryptic vestige of the fathomless gulfs outside; that lone,
+weird message from other universes and other realms of matter, force,
+and entity.
+
+As was natural, the Arkham papers made much of the incident with its
+collegiate sponsoring, and sent reporters to talk with Nahum Gardner
+and his family. At least one Boston daily also sent a scribe, and Nahum
+quickly became a kind of local celebrity. He was a lean, genial person
+of about fifty, living with his wife and three sons on the pleasant
+farmstead in the valley. He and Ammi exchanged visits frequently, as
+did their wives; and Ammi had nothing but praise for him after all
+these years. He seemed slightly proud of the notice his place had
+attracted, and talked often of the meteorite in the succeeding weeks.
+That July and August were hot; and Nahum worked hard at his haying in
+the ten-acre pasture across Chapman's Brook; his rattling wain wearing
+deep ruts in the shadowy lanes between. The labour tired him more than
+it had in other years, and he felt that age was beginning to tell on
+him.
+
+Then fell the time of fruit and harvest. The pears and apples slowly
+ripened, and Nahum vowed that his orchards were prospering as never
+before. The fruit was growing to phenomenal size and unwonted gloss,
+and in such abundance that extra barrels were ordered to handle the
+future crop. But with the ripening came sore disappointment, for of all
+that gorgeous array of specious lusciousness not one single jot was
+fit to eat. Into the fine flavour of the pears and apples had crept
+a stealthy bitterness and sickishness, so that even the smallest of
+bites induced a lasting disgust. It was the same with the melons and
+tomatoes, and Nahum sadly saw that his entire crop was lost. Quick to
+connect events, he declared that the meteorite had poisoned the soil,
+and thanked Heaven that most of the other crops were in the upland lot
+along the road.
+
+       *       *       *       *       *
+
+Winter came early, and was very cold. Ammi saw Nahum less often than
+usual, and observed that he had begun to look worried. The rest of his
+family too, seemed to have grown taciturn; and were far from steady
+in their churchgoing or their attendance at the various social events
+of the countryside. For this reserve or melancholy no cause could be
+found, though all the household confessed now and then to poorer health
+and a feeling of vague disquiet. Nahum himself gave the most definite
+statement of anyone when he said he was disturbed about certain
+footprints in the snow. They were the usual winter prints of red
+squirrels, white rabbits, and foxes, but the brooding farmer professed
+to see something not quite right about their nature and arrangement.
+He was never specific, but appeared to think that they were not as
+characteristic of the anatomy and habits of squirrels and rabbits and
+foxes as they ought to be. Ammi listened without interest to this talk
+until one night when he drove past Nahum's house in his sleigh on the
+way back from Clark's Corners. There had been a moon, and a rabbit had
+run across the road; and the leaps of that rabbit were longer than
+either Ammi or his horse liked. The latter, indeed, had almost run away
+when brought up by a firm rein. Thereafter Ammi gave Nahum's tales
+more respect, and wondered why the Gardner dogs seemed so cowed and
+quivering every morning. They had, it developed, nearly lost the spirit
+to bark.
+
+In February the McGregor boys from Meadow Hill were out shooting
+woodchucks, and not far from the Gardner place bagged a very peculiar
+specimen. The proportions of its body seemed slightly altered in a
+queer way impossible to describe, while its face had taken on an
+expression which no one ever saw in a woodchuck before. The boys were
+genuinely frightened, and threw the thing away at once, so that only
+their grotesque tales of it ever reached the people of the countryside.
+But the shying of horses near Nahum's house had now become an
+acknowledged thing, and all the basis for a cycle of whispered legend
+was fast taking form.
+
+People vowed that the snow melted faster around Nahum's than it did
+anywhere else, and early in March there was an awed discussion in
+Potter's general store at Clark's Corners. Stephen Rice had driven past
+Gardner's in the morning, and had noticed the skunk-cabbages coming
+up through the mud by the woods across the road. Never were things of
+such size seen before, and they held strange colours that could not
+be put into any words. Their shapes were monstrous, and the horse had
+snorted at an odour which struck Stephen as wholly unprecedented. That
+afternoon several persons drove past to see the abnormal growth, and
+all agreed that plants of that kind ought never to sprout in a healthy
+world. The bad fruit of the fall before was freely mentioned, and it
+went from mouth to mouth that there was poison in Nahum's ground. Of
+course it was the meteorite; and remembering how strange the men from
+the college had found that stone to be, several farmers spoke about the
+matter to them.
+
+One day they paid Nahum a visit; but having no love of wild tales and
+folklore were very conservative in what they inferred. The plants were
+certainly odd, but all skunk-cabbages are more or less odd in shape
+and hue. Perhaps some mineral element from the stone had entered the
+soil, but it would soon be washed away. And as for the footprints and
+frightened horses--of course this was mere country talk which such
+a phenomenon as the aerolite would be certain to start. There was
+really nothing for serious men to do in cases of wild gossip, for
+superstitious rustics will say and believe anything. And so all through
+the strange days the professors stayed away in contempt. Only one
+of them, when given two phials of dust for analysis in a police job
+over a year and a half later, recalled that the queer colour of that
+skunk-cabbage had been very like one of the anomalous bands of light
+shown by the meteor fragment in the college spectroscope, and like the
+brittle globule found imbedded in the stone from the abyss. The samples
+in this analysis case gave the same odd bands at first, though later
+they lost the property.
+
+The trees budded prematurely around Nahum's, and at night they swayed
+ominously in the wind. Nahum's second son Thaddeus, a lad of fifteen,
+swore that they swayed also when there was no wind; but even the
+gossips would not credit this. Certainly, however, restlessness was
+in the air. The entire Gardner family developed the habit of stealthy
+listening, though not for any sound which they could consciously
+name. The listening was, indeed, rather a product of moments when
+consciousness seemed half to slip away. Unfortunately such moments
+increased week by week, till it became common speech that "something
+was wrong with all Nahum's folks." When the early saxifrage came out it
+had another strange colour; not quite like that of the skunk-cabbage,
+but plainly related and equally unknown to anyone who saw it. Nahum
+took some blossoms to Arkham and showed them to the editor of the
+_Gazette_, but that dignitary did no more than write a humorous article
+about them, in which the dark fears of rustics were held up to polite
+ridicule. It was a mistake of Nahum's to tell a stolid city man about
+the way the great, overgrown mourning-cloak butterflies behaved in
+connection with these saxifrages.
+
+April brought a kind of madness to the country folk, and began that
+disuse of the road past Nahum's which led to its ultimate abandonment.
+It was next the vegetation. All the orchard trees blossomed forth in
+strange colours, and through the stony soil of the yard and adjacent
+pasturage there sprang up a bizarre growth which only a botanist could
+connect with the proper flora of the region. No sane wholesome colours
+were anywhere to be seen except in the green grass and leafage; but
+everywhere were those hectic and prismatic variants of some diseased,
+underlying primary tone without a place among the known tints of earth.
+The "Dutchman's breeches" became a thing of sinister menace, and the
+bloodroots grew insolent in their chromatic perversion. Ammi and the
+Gardners thought that most of the colours had a sort of haunting
+familiarity, and decided that they reminded one of the brittle globule
+in the meteor. Nahum ploughed and sowed the ten-acre pasture and the
+upland lot, but did nothing with the land around the house. He knew it
+would be of no use, and hoped that the summer's strange growths would
+draw all the poison from the soil. He was prepared for almost anything
+now, and had grown used to the sense of something near him waiting
+to be heard. The shunning of his house by neighbours told on him, of
+course; but it told on his wife more. The boys were better off, being
+at school each day; but they could not help being frightened by the
+gossip. Thaddeus, an especially sensitive youth, suffered the most.
+
+       *       *       *       *       *
+
+In May the insects came, and Nahum's place became a nightmare of
+buzzing and crawling. Most of the creatures seemed not quite usual in
+their aspects and motions, and their nocturnal habits contradicted all
+former experience. The Gardners took to watching at night--watching in
+all directions at random for something they could not tell what. It was
+then that they all owned that Thaddeus had been right about the trees.
+Mrs. Gardner was the next to see it from the window as she watched the
+swollen boughs of a maple against a moonlit sky. The boughs surely
+moved, and there was no wind. It must be the sap. Strangeness had come
+into everything growing now. Yet it was none of Nahum's family at all
+who made the next discovery. Familiarity had dulled them, and what they
+could not see was glimpsed by a timid windmill salesman from Bolton who
+drove by one night in ignorance of the country legends. What he told in
+Arkham was given a short paragraph in the _Gazette_; and it was there
+that all the farmers, Nahum included, saw it first. The night had been
+dark and the buggy-lamps faint, but around a farm in the valley which
+everyone knew from the account must be Nahum's, the darkness had been
+less thick. A dim though distinct luminosity seemed to inhere in all
+the vegetation, grass, leaves, and blossoms alike, while at one moment
+a detached piece of the phosphorescence appeared to stir furtively in
+the yard near the barn.
+
+The grass had so far seemed untouched, and the cows were freely
+pastured in the lot near the house, but toward the end of May the milk
+began to be bad. Then Nahum had the cows driven to the uplands, after
+which this trouble ceased. Not long after this the change in grass and
+leaves became apparent to the eye. All the verdure was going grey,
+and was developing a highly singular quality of brittleness. Ammi
+was now the only person who ever visited the place, and his visits
+were becoming fewer and fewer. When school closed the Gardners were
+virtually cut off from the world, and sometimes let Ammi do their
+errands in town. They were failing curiously both physically and
+mentally, and no one was surprised when the news of Mrs. Gardner's
+madness stole around.
+
+It happened in June, about the anniversary of the meteor's fall, and
+the poor woman screamed about things in the air which she could not
+describe. In her raving there was not a single specific noun, but
+only verbs and pronouns. Things moved and changed and fluttered, and
+ears tingled to impulses which were not wholly sounds. Something
+was taken away--she was being drained of something--something was
+fastening itself on her that ought not to be--someone must make it
+keep off--nothing was ever still in the night--the walls and windows
+shifted. Nahum did not send her to the county asylum, but let her
+wander about the house as long as she was harmless to herself and
+others. Even when her expression changed he did nothing. But when the
+boys grew afraid of her, and Thaddeus nearly fainted at the way she
+made faces at him, he decided to keep her locked in the attic. By July
+she had ceased to speak and crawled on all fours, and before that month
+was over Nahum got the mad notion that she was slightly luminous in the
+dark, as he now clearly saw was the case with the nearby vegetation.
+
+It was a little before this that the horses had stampeded. Something
+had aroused them in the night, and their neighing and kicking in their
+stalls had been terrible. There seemed virtually nothing to do to calm
+them, and when Nahum opened the stable door they all bolted out like
+frightened woodland deer. It took a week to track all four, and when
+found they were seen to be quite useless and unmanageable. Something
+had snapped in their brains, and each one had to be shot for its own
+good. Nahum borrowed a horse from Ammi for his haying, but found it
+would not approach the barn. It shied, balked, and whinnied, and in
+the end he could do nothing but drive it into the yard while the men
+used their own strength to get the heavy wagon near enough the hayloft
+for convenient pitching. And all the while the vegetation was turning
+grey and brittle. Even the flowers whose hues had been so strange
+were graying now, and the fruit was coming out grey and dwarfed and
+tasteless. The asters and goldenrod bloomed grey and distorted, and
+the roses and zinnias and hollyhocks in the front yard were such
+blasphemous-looking things that Nahum's oldest boy Zenas cut them down.
+The strangely puffed insects died about that time, even the bees that
+had left their hives and taken to the woods.
+
+By September all the vegetation was fast crumbling to a greyish
+powder, and Nahum feared that the trees would die before the poison
+was out of the soil. His wife now had spells of terrific screaming,
+and he and the boys were in a constant state of nervous tension.
+They shunned people now, and when school opened the boys did not go.
+But it was Ammi, on one of his rare visits, who first realized that
+the well water was no longer good. It had an evil taste that was not
+exactly fetid nor exactly salty, and Ammi advised his friend to dig
+another well on higher ground to use till the soil was good again.
+Nahum, however, ignored the warning, for he had by that time become
+calloused to strange and unpleasant things. He and the boys continued
+to use the tainted supply, drinking it as listlessly and mechanically
+as they ate their meagre and ill-cooked meals and did their thankless
+and monotonous chores through the aimless days. There was something of
+stolid resignation about them all, as if they walked half in another
+world between lines of nameless guards to a certain and familiar doom.
+
+Thaddeus went mad in September after a visit to the well. He had gone
+with a pail and had come back empty-handed, shrieking and waving his
+arms, and sometimes lapsing into an inane titter or a whisper about
+"the moving colours down there." Two in one family was pretty bad,
+but Nahum was very brave about it. He let the boy run about for a
+week until he began stumbling and hurting himself, and then he shut
+him in an attic room across the hall from his mother's. The way they
+screamed at each other from behind their locked doors was very
+terrible, especially to little Merwin, who fancied they talked in some
+terrible language that was not of earth. Merwin was getting frightfully
+imaginative, and his restlessness was worse after the shutting away of
+the brother who had been his greatest playmate.
+
+Almost at the same time the mortality among the livestock commenced.
+Poultry turned greyish and died very quickly, their meat being found
+dry and noisome upon cutting. Hogs grew inordinately fat, then suddenly
+began to undergo loathsome changes which no one could explain. Their
+meat was of course useless, and Nahum was at his wit's end. No rural
+veterinary would approach his place, and the city veterinary from
+Arkham was openly baffled. The swine began growing grey and brittle
+and falling to pieces before they died, and their eyes and muzzles
+developed singular alterations. It was very inexplicable, for they had
+never been fed from the tainted vegetation. Then something struck the
+cows. Certain areas or sometimes the whole body would be uncannily
+shrivelled or compressed, and atrocious collapses or disintegrations
+were common. In the last stages--and death was always the result--there
+would be a greying and turning brittle like that which beset the hogs.
+There could be no question of poison, for all the cases occurred in a
+locked and undisturbed barn. No bites of prowling things could have
+brought the virus, for what live beast of earth can pass through solid
+obstacles? It must be only natural disease--yet what disease could
+wreak such results was beyond any mind's guessing. When the harvest
+came there was not an animal surviving on the place, for the stock
+and poultry were dead and the dogs had run away. These dogs, three
+in number, had all vanished one night and were never heard of again.
+The five cats had left some time before, but their going was scarcely
+noticed since there now seemed to be no mice, and only Mrs. Gardner had
+made pets of the graceful felines.
+
+       *       *       *       *       *
+
+On the nineteenth of October Nahum staggered into Ammi's house with
+hideous news. The death had come to poor Thaddeus in his attic room,
+and it had come in a way which could not be told. Nahum had dug a grave
+in the railed family plot behind the farm, and had put therein what
+he found. There could have been nothing from outside, for the small
+barred window and locked door were intact; but it was much as it had
+been in the barn. Ammi and his wife consoled the stricken man as best
+they could, but shuddered as they did so. Stark terror seemed to cling
+round the Gardners and all they touched, and the very presence of one
+in the house was a breath from regions unnamed and unnameable. Ammi
+accompanied Nahum home with the greatest reluctance, and did what he
+might to calm the hysterical sobbing of little Merwin. Zenas needed no
+calming. He had come of late to do nothing but stare into space and
+obey what his father told him; and Ammi thought that his fate was very
+merciful. Now and then Merwin's screams were answered faintly from the
+attic, and in response to an inquiring look Nahum said that his wife
+was getting very feeble. When night approached, Ammi managed to get
+away; for not even friendship could make him stay in that spot when the
+faint glow of the vegetation began and the trees may or may not have
+swayed without wind. It was really lucky for Ammi that he was not more
+imaginative. Even as things were, his mind was bent ever so slightly;
+but had he been able to connect and reflect upon all the portents
+around him he must inevitably have turned a total maniac. In the
+twilight he hastened home, the screams of the mad woman and the nervous
+child ringing horrible in his ears.
+
+Three days later Nahum burst into Ammi's kitchen in the early morning,
+and in the absence of his host stammered out a desperate tale once
+more, while Mrs. Pierce listened in a clutching fright. It was little
+Merwin this time. He was gone. He had gone out late at night with a
+lantern and pail for water, and had never come back. He'd been going
+to pieces for days, and hardly knew what he was about. Screamed at
+everything. There had been a frantic shriek from the yard then, but
+before the father could get to the door the boy was gone. There was no
+glow from the lantern he had taken, and of the child himself no trace.
+At the time Nahum thought the lantern and pail were gone too; but when
+dawn came, and the man had plodded back from his all-night search of
+the woods and fields, he had found some very curious things near the
+well. There was a crushed and apparently somewhat melted mass of iron
+which had certainly been the lantern; while a bent pail and twisted
+iron hoops beside it, both half-fused, seemed to hint at the remnants
+of the pail. That was all. Nahum was past imagining, Mrs. Pierce was
+blank, and Ammi, when he had reached home and heard the tale, could
+give no guess. Merwin was gone, and there would be no use in telling
+the people around, who shunned all Gardners now. No use, either, in
+telling the city people at Arkham who laughed at everything. Thad was
+gone, and now Merwin was gone. Something was creeping and creeping and
+waiting to be seen and heard. Nahum would go soon, and he wanted Ammi
+to look after his wife and Zenas if they survived him. It must all be a
+judgment of some sort; though he could not fancy what for, since he had
+always walked uprightly in the Lord's ways so far as he knew.
+
+For over two weeks Ammi saw nothing of Nahum; and then, worried about
+what might have happened, he overcame his fears and paid the Gardner
+place a visit. There was no smoke from the great chimney, and for a
+moment the visitor was apprehensive of the worst. The aspect of the
+whole farm was shocking--greyish withered grass and leaves on the
+ground, vines falling in brittle wreckage from archaic walls and
+gables, and great bare trees clawing up at the grey November sky with
+a studied malevolence which Ammi could not but feel had come from some
+subtle change in the tilt of the branches. But Nahum was alive, after
+all. He was weak, and lying in a couch in the low-ceiled kitchen,
+but perfectly conscious and able to give simple orders to Zenas. The
+room was deadly cold; and as Ammi visibly shivered, the host shouted
+huskily to Zenas for more wood. Wood, indeed, was sorely needed; since
+the cavernous fireplace was unlit and empty, with a cloud of soot
+blowing about in the chill wind that came down the chimney. Presently
+Nahum asked him if the extra wood had made him any more comfortable,
+and then Ammi saw what had happened. The stoutest cord had broken at
+last, and the hapless farmer's mind was proof against more sorrow.
+
+Questioning tactfully, Ammi could get no clear data at all about the
+missing Zenas. "In the well--he lives in the well--" was all that the
+clouded father would say. Then there flashed across the visitor's mind
+a sudden thought of the mad wife, and he changed his line of inquiry.
+"Nabby? Why, here she is!" was the surprised response of poor Nahum,
+and Ammi soon saw that he must search for himself. Leaving the harmless
+babbler on the couch, he took the keys from their nail beside the door
+and climbed the creaking stairs to the attic. It was very close and
+noisome up there, and no sound could be heard from any direction. Of
+the four doors in sight, only one was locked, and on this he tried
+various keys on the ring he had taken. The third key proved the right
+one, and after some fumbling Ammi threw open the low white door.
+
+It was quite dark inside, for the window was small and half-obscured
+by the crude wooden bars; and Ammi could see nothing at all on the
+wide-planked floor. The stench was beyond enduring, and before
+proceeding further he had to retreat to another room and return
+with his lungs filled with breathable air. When he did enter he saw
+something dark in the corner, and upon seeing it more clearly he
+screamed outright. While he screamed he thought a momentary cloud
+eclipsed the window, and a second later he felt himself brushed as if
+by some hateful current of vapour. Strange colours danced before his
+eyes; and had not a present horror numbed him he would have thought of
+the globule in the meteor that the geologist's hammer had shattered,
+and of the morbid vegetation that had sprouted in the spring. As it
+was he thought only of the blasphemous monstrosity which confronted
+him, and which all too clearly had shared the nameless fate of young
+Thaddeus and the livestock. But the terrible thing about the horror was
+that it very slowly and perceptibly moved as it continued to crumble.
+
+       *       *       *       *       *
+
+Ammi would give me no added particulars of this scene, but the shape
+in the corners does not re-appear in his tale as a moving object.
+There are things which cannot be mentioned, and what is done in common
+humanity is sometimes cruelly judged by the law. I gathered that no
+moving thing was left in that attic room, and that to leave anything
+capable of motion there would have been a deed so monstrous as to damn
+any accountable being to eternal torment. Anyone but a stolid farmer
+would have fainted or gone mad, but Ammi walked conscious through that
+low doorway and locked the accursed secret behind him. There would be
+Nahum to deal with now; he must be fed and tended, and removed to some
+place where he could be cared for.
+
+Commencing his descent of the dark stairs, Ammi heard a thud below him.
+He even thought a scream had been suddenly choked off, and recalled
+nervously the clammy vapour which had brushed by him in that frightful
+room above. What presence had his cry and entry started up? Halted by
+some vague fear, he heard still further sounds below. Indubitably there
+was a sort of heavy dragging, and a most detestably sticky noise as
+of some fiendish and unclean species of suction. With an associative
+sense goaded to feverish heights, he thought unaccountably of what he
+had seen upstairs. Good God! What eldritch dream-world was this into
+which he had blundered? He dared move neither backward nor forward, but
+stood there trembling at the black curve of the boxed-in staircase.
+Every trifle of the scene burned itself into his brain. The sounds, the
+sense of dread expectancy, the darkness, the steepness of the narrow
+steps--and merciful Heaven!--the faint but unmistakable luminosity of
+all the woodwork in sight; steps, sides, exposed laths, and beams alike.
+
+Then there burst forth a frantic whinny from Ammi's horse outside,
+followed at once by a clatter which told of a frenzied runaway. In
+another moment horse and buggy had gone beyond earshot, leaving the
+frightened man on the dark stairs to guess what had sent them. But that
+was not all. There had been another sound out there. A sort of liquid
+splash--water--it must have been the well. He had left Hero untied
+near it, and a buggy-wheel must have brushed the coping and knocked in
+a stone. And still the pale phosphorescense glowed in that detestably
+ancient woodwork. God! how old the house was! Most of it built before
+1700.
+
+A feeble scratching on the floor downstairs now sounded distinctly, and
+Ammi's grip tightened on a heavy stick he had picked up in the attic
+for some purpose. Slowly nerving himself, he finished his descent and
+walked boldly toward the kitchen. But he did not complete the walk,
+because what he sought was no longer there. It had come to meet him,
+and it was still alive after a fashion. Whether it had crawled or
+whether it had been dragged by any external forces, Ammi could not
+say; but the death had been at it. Everything had happened in the last
+half-hour, but collapse, greying, and disintegration were already far
+advanced. There was a horrible brittleness, and dry fragments were
+scaling off. Ammi could not touch it, but looked horrifiedly into the
+distorted parody that had been a face. "What was it, Nahum--what
+was it?" He whispered, and the cleft, bulging lips were just able to
+crackle out a final answer.
+
+"Nothin' ... nothin' ... the colour ... it burns ... cold an' wet, but
+it burns ... it lived in the well.... I seen it ... a kind o' smoke ...
+jest like the flowers last spring ... the well shone at night.... Thad
+an' Merwin an' Zenas ... everything alive ... suckin' the life out of
+everything ... in that stone ... it must o' come in that stone ...
+pizened the whole place ... dun't know what it wants ... that round
+thing them men from the college dug outen the stone ... they smashed
+it ... it was that same colour ... jest the same, like the flowers an'
+plants ... must a' ben more of 'em ... seeds ... seeds ... they
+growed ... I seen it the fust time this week ... must a' got strong
+on Zenas ... he was a big boy, full o' life ... it beats down your
+mind an' then gits ye ... burns ye up ... in the well water ... you
+was right about that ... evil water ... Zenas never come back from the
+well ... can't git away ... draws ye ... ye know summ'at's comin', but
+'tain't no use ... I seen it time an' agin Zenas was took ... whar's
+Nabby, Ammi? ... my head's no good ... dun't know how long sence I fed
+her ... it'll git her ef we ain't keerful ... jest a colour ... her
+face is gittin' to hev that colour sometimes towards night ... an' it
+burns an' sucks ... it come from some place whar things ain't as they
+is here ... one o' them professors said so ... he was right ... look
+out, Ammi, it'll do suthin' more ... sucks the life out...."
+
+But that was all. That which spoke could speak no more because it had
+completely caved in. Ammi laid a red checked tablecloth over what was
+left and reeled out the back door into the fields. He climbed the slope
+to the ten-acre pasture and stumbled home by the north road and the
+woods. He could not pass that well from which his horses had run away.
+He had looked at it through the window, and had seen that no stone
+was missing from the rim. Then the lurching buggy had not dislodged
+anything after all--the splash had been something else--something which
+went into the well after it had done with poor Nahum....
+
+When Ammi reached his house the horses and buggy had arrived before
+him and thrown his wife into fits of anxiety. Reassuring her without
+explanations, he set out at once for Arkham and notified the
+authorities that the Gardner family was no more. He indulged in no
+details, but merely told of the deaths of Nahum and Nabby, that of
+Thaddeus being already known, and mentioned that the cause seemed to
+be the same strange ailment which had killed the livestock. He also
+stated that Merwin and Zenas had disappeared. There was considerable
+questioning at the police station, and in the end Ammi was compelled
+to take three officers to the Gardner farm, together with the coroner,
+the medical examiner, and the veterinary who had treated the diseased
+animals. He went much against his will, for the afternoon was advancing
+and he feared the fall of night over that accursed place, but it was
+some comfort to have so many people with him.
+
+The six men drove out in a democrat-wagon, following Ammi's buggy, and
+arrived at the pest-ridden farmhouse about four o'clock. Used as the
+officers were to gruesome experiences, not one remained unmoved at
+what was found in the attic and under the red checked tablecloth on
+the floor below. The whole aspect of the farm with its grey desolation
+was terrible enough, but those two crumbling objects were beyond all
+bounds. No one could look long at them, and even the medical examiner
+admitted that there was very little to examine. Specimens could be
+analysed, of course, so he busied himself in obtaining them--and here
+it develops that a very puzzling aftermath occurred at the college
+laboratory where the two phials of dust were finally taken. Under the
+spectroscope both samples gave off an unknown spectrum, in which many
+of the baffling bands were precisely like those which the strange
+meteor had yielded in the previous year. The property of emitting this
+spectrum vanished in a month, the dust thereafter consisting mainly of
+alkaline phosphates and carbonates.
+
+       *       *       *       *       *
+
+Ammi would not have told the men about the well if he had thought they
+meant to do anything then and there. It was getting toward sunset, and
+he was anxious to be away. But he could not help glancing nervously
+at the stony curb by the great sweep, and when a detective questioned
+him he admitted that Nahum had feared something down there--so much so
+that he had never even thought of searching it for Merwin or Zenas.
+After that nothing would do but that they empty and explore the well
+immediately, so Ammi had to wait trembling while pail after pail of
+rank water was hauled up and splashed on the soaking ground outside.
+The men sniffed in disgust at the fluid, and toward the last held their
+noses against the foetor they were uncovering. It was not so long a
+job as they had feared it would be, since the water was phenomenally
+low. There is no need to speak too exactly of what they found. Merwin
+and Zenas were both there, in part, though the vestiges were mainly
+skeletal. There were also a small deer and a large dog in about the
+same state, and a number of bones of smaller animals. The ooze and
+slime at the bottom seemed inexplicably porous and bubbling, and a man
+who descended on hand-holds with a long pole found that he could sink
+the wooden shaft to any depth in the mud of the floor without meeting
+any solid obstruction.
+
+Twilight had now fallen, and lanterns were brought from the house.
+Then, when it was seen that nothing further could be gained from the
+well, everyone went indoors and conferred in the ancient sitting-room
+while the intermittent light of a spectral half-moon played wanly on
+the grey desolation outside. The men were frankly nonplussed by the
+entire case, and could find no convincing common element to link the
+strange vegetable conditions, the unknown disease of livestock and
+humans, and the unaccountable deaths of Merwin and Zenas in the tainted
+well. They had heard the common country talk, it is true; but could not
+believe that anything contrary to natural law had occurred. No doubt
+the meteor had poisoned the soil, but the illness of person and animals
+who had eaten nothing grown in that soil was another matter. Was it the
+well water? Very possibly. It might be a good idea to analyse it. But
+what peculiar madness could have made both boys jump into the well?
+Their deeds were so similar--and the fragments showed that they had
+both suffered from the grey brittle death. Why was everything so grey
+and brittle?
+
+It was the coroner, seated near a window overlooking the yard, who
+first noticed the glow about the well. Night had fully set in, and all
+the abhorrent grounds seemed faintly luminous with more than the fitful
+moonbeams; but this new glow was something definite and distinct, and
+appeared to shoot up from the black pit like a softened ray from a
+searchlight, giving dull reflections in the little ground pools where
+the water had been emptied. It had a very queer colour, and as all the
+men clustered round the window Ammi gave a violent start. For this
+strange beam of ghastly miasma was to him of no unfamiliar hue. He had
+seen that colour before, and feared to think what it might mean. He
+had seen it in the nasty brittle globule in that aerolite two summers
+ago, had seen it in the crazy vegetation of the springtime, and had
+thought he had seen it for an instant that very morning against the
+small barred window of that terrible attic room where nameless things
+had happened. It had flashed there a second, and a clammy and hateful
+current of vapour had brushed past him--and then poor Nahum had been
+taken by something of that colour. He had said so at the last--said it
+was like the globule and the plants. After that had come the runaway
+in the yard and the splash in the well--and now that well was belching
+forth to the night a pale insidious beam of the same demoniac tint.
+
+It does credit to the alertness of Ammi's mind that he puzzled even
+at that tense moment over a point which was essentially scientific.
+He could not but wonder at his gleaning of the same impression from
+a vapour glimpsed in the daytime, against a window opening in the
+morning sky, and from a nocturnal exhalation seen as a phosphorescent
+mist against the black and blasted landscape. It wasn't right--it was
+against Nature--and he thought of those terrible last words of his
+stricken friend, "It come from some place whar things ain't as they is
+here ... one o' them professors said so...."
+
+All three horses outside, tied to a pair of shrivelled saplings by
+the road, were now neighing and pawing frantically. The wagon driver
+started for the door to do something, but Ammi laid a shaky hand on his
+shoulder. "Dun't go out thar," he whispered. "They's more to this nor
+what we know. Nahum said somethin' lived in the well that sucks your
+life out. He said it must be some'at growed from a round ball like one
+we all seen in the meteor stone that fell a year ago June. Sucks an'
+burns, he said, an' is jest a cloud of colour like that light out thar
+now, that ye can hardly see an' can't tell what it is. Nahum thought it
+feeds on everything livin' an' gits stronger all the time. He said he
+seen it this last week. It must be somethin' from away off in the sky
+like the men from the college last year says the meteor stone was. The
+way it's made an' the way it works ain't like no way o' God's world.
+It's some'at from beyond."
+
+So the men paused indecisively as the light from the well grew stronger
+and the hitched horses pawed and whinnied in increasing frenzy. It was
+truly an awful moment; with terror in that ancient and accursed house
+itself, four monstrous sets of fragments--two from the house and two
+from the well--in the woodshed behind, and that shaft of unknown and
+unholy iridescence from the slimy depths in front. Ammi had restrained
+the driver on impulse, forgetting how uninjured he himself was after
+the clammy brushing of that coloured vapour in the attic room, but
+perhaps it is just as well that he acted as he did. No one will ever
+know what was abroad that night; and though the blasphemy from beyond
+had not so far hurt any human of unweakened mind, there is no telling
+what it might not have done at that last moment, and with its seemingly
+increased strength and the special signs of purpose it was soon to
+display beneath the half-clouded moonlit sky.
+
+       *       *       *       *       *
+
+All at once one of the detectives at the window gave a short, sharp
+gasp. The others looked at him, and then quickly followed his own
+gaze upward to the point at which its idle straying had been suddenly
+arrested. There was no need for words. What had been disputed in
+country gossip was disputable no longer, and it is because of the
+thing which every man of that party agreed in whispering later on,
+that strange days are never talked about in Arkham. It is necessary to
+premise that there was no wind at that hour of the evening. One did
+arise not long afterward, but there was absolutely none then. Even
+the dry tips of the lingering hedge-mustard, grey and blighted, and
+the fringe on the roof of the standing democrat-wagon were unstirred.
+And yet amid that tense, godless calm the high bare boughs of all
+the trees in the yard were moving. They were twitching morbidly and
+spasmodically, clawing in convulsive and epileptic madness at the
+moonlit clouds; scratching impotently in the noxious air as if jerked
+by some allied and bodiless line of linkage with sub-terrene horrors
+writhing and struggling below the black roots.
+
+Not a man breathed for several seconds. Then a cloud of darker depth
+passed over the moon, and the silhouette of clutching branches faded
+out momentarily. At this there was a general cry; muffled with awe,
+but husky and almost identical from every throat. For the terror had
+not faded with the silhouette, and in a fearsome instant of deeper
+darkness the watchers saw wriggling at the treetop height a thousand
+tiny points of faint and unhallowed radiance, tipping each bough like
+the fire of St. Elmo or the flames that come down on the apostles'
+heads at Pentecost. It was a monstrous constellation of unnatural
+light, like a glutted swarm of corpse-fed fireflies dancing hellish
+sarabands over an accursed marsh; and its colour was that same nameless
+intrusion which Ammi had come to recognise and dread. All the while
+the shaft of phosphorescence from the well was getting brighter and
+brighter, bringing to the minds of the huddled men, a sense of doom and
+abnormality which far outraced any image their conscious minds could
+form. It was no longer _shining_ out; it was _pouring_ out; and as the
+shapeless stream of unplaceable colour left the well it seemed to flow
+directly into the sky.
+
+[Illustration: ... and in the fearsome instant of deeper darkness, the
+watchers saw wriggling at that treetop height, a thousand tiny points
+of faint and unhallowed radiance, tipping each bough like the fire
+of St. Elmo ... and all the while the shaft of phosphorescence from
+the well was getting brighter and brighter and bringing to the minds
+of the huddled men, a sense of doom and abnormality.... It was no
+longer shining out; it was pouring out; and as the shapeless stream of
+unplaceable colour left the well, it seemed to flow directly into the
+sky.]
+
+The veterinary shivered, and walked to the front door to drop the heavy
+extra bar across it. Ammi shook no less, and had to tug and point for
+lack of a controllable voice when he wished to draw notice to the
+growing luminosity of the trees. The neighing and stamping of the
+horses had become utterly frightful, but not a soul of that group in
+the old house would have ventured forth for any earthly reward. With
+the moments the shining of the trees increased, while their restless
+branches seemed to strain more and more toward verticality. The wood
+of the well-sweep was shining now, and presently a policeman dumbly
+pointed to some wooden sheds and beehives near the stone wall on the
+west. They were commencing to shine, too, though the tethered vehicles
+of the visitors seemed so far unaffected. Then there was a wild
+commotion and clopping in the road, and as Ammi quenched the lamp for
+better seeing they realized that the span of frantic grays had broken
+their sapling and run off with the democrat-wagon.
+
+The shock served to loosen several tongues, and embarrassed whispers
+were exchanged. "It spreads on everything organic that's been around
+here," muttered the medical examiner. No one replied, but the man who
+had been in the well gave a hint that his long pole must have stirred
+up something intangible. "It was awful," he added. "There was no bottom
+at all. Just ooze and bubbles and the feeling of something lurking
+under there." Ammi's horse still pawed and screamed deafeningly in
+the road outside, and nearly drowned its owner's faint quaver as he
+mumbled his formless reflections. "It come from that stone--it growed
+down thar--it got everything livin'--it fed itself on 'em, mind and
+body--Thad an' Merwin, Zenas an' Nabby--Nahum was the last--they all
+drunk the water--it got strong on 'em--it come from beyond, whar things
+ain't like they be here--now it's goin' home--"
+
+At this point, as the column of unknown colour flared suddenly stronger
+and began to weave itself into fantastic suggestions of shape which
+each spectator later described differently, there came from poor
+tethered Hero such a sound as no man before or since ever heard from
+a horse. Every person in that low-pitched sitting-room stopped his
+ears, and Ammi turned away from the window in horror and nausea. Words
+could not convey it--when Ammi looked out again the hapless beast lay
+huddled inert on the moonlit ground between the splintered shafts of
+the buggy. That was the last of Hero till they buried him next day.
+But the present was no time to mourn, for almost at this instant a
+detective silently called attention to something terrible in the very
+room with them. In the absence of the lamplight it was clear that a
+faint phosphorescence had begun to pervade the entire apartment. It
+glowed on the broad-planked floor where the rag carpet left it bare,
+and shimmered over the sashes of the small-paned windows. It ran up
+and down the exposed corner-posts, coruscated about the shelf and
+mantel, and infected the very doors and furniture. Each minute saw it
+strengthen, and at last it was very plain that healthy living things
+must leave that house.
+
+Ammi showed them the back door and the path up through the fields to
+the ten-acre pasture. They walked and stumbled as in a dream, and did
+not dare look back till they were far away on the high ground. They
+were glad of the path, for they could not have gone the front way, by
+that well. It was bad enough passing the glowing barn and sheds, and
+those shining orchard trees with their gnarled, fiendish contours; but
+thank Heaven the branches did their worst twisting high up. The moon
+went under some very black clouds as they crossed the rustic bridge
+over Chapman's Brook, and it was blind groping from there to the open
+meadows.
+
+       *       *       *       *       *
+
+When they looked back toward the valley and the distant Gardner place
+at the bottom they saw a fearsome sight. All the farm was shining
+with the hideous unknown blend of colour; trees, buildings, and even
+such grass and herbage as had not been wholly changed to lethal grey
+brittleness. The boughs were all straining skyward, tipped with tongues
+of foul flame, and lambent tricklings of the same monstrous fire were
+creeping about the ridgepoles of the house, barn and sheds. It was a
+scene from a vision of Fuseli, and over all the rest reigned that riot
+of luminous amorphousness, that alien and undimensioned rainbow of
+cryptic poison from the well--seething, feeling, lapping, reaching,
+scintillating, straining, and malignly bubbling in its cosmic and
+unrecognizable chromaticism.
+
+Then without warning the hideous thing shot vertically up toward the
+sky like a rocket or meteor, leaving behind no trail and disappearing
+through a round and curiously regular hole in the clouds before any
+man could gasp or cry out. No watcher can ever forget that sight, and
+Ammi stared blankly at the stars of Cygnus, Deneb twinkling above the
+others, where the unknown colour had melted into the Milky Way. But his
+gaze was the next moment called swiftly to earth by the crackling in
+the valley. It was just that. Only a wooden ripping and crackling, and
+not an explosion, as so many others of the party vowed. Yet the outcome
+was the same, for in one feverish kaleidoscopic instant there burst up
+from that doomed and accursed farm a gleamingly eruptive cataclysm of
+unnatural sparks and substance; blurring the glance of the few who saw
+it, and sending forth to the zenith a bombarding cloudburst of such
+coloured and fantastic fragments as our universe must needs disown.
+Through quickly re-closing vapours they followed the great morbidity
+that had vanished, and in another second they had vanished too. Behind
+and below was only a darkness to which the men dared not return, and
+all about was a mounting wind which seemed to sweep down in black,
+frore gusts from interstellar space. It shrieked and howled, and lashed
+the fields and distorted woods in a mad cosmic frenzy, till soon the
+trembling party realized it would be no use waiting for the moon to
+show what was left down there at Nahum's.
+
+Too awed even to hint theories, the seven shaking men trudged back
+toward Arkham by the north road. Ammi was worse than his fellows,
+and begged them to see him inside his own kitchen, instead of
+keeping straight on to town. He did not wish to cross the blighted,
+wind-whipped woods alone to his home on the main road. For he had had
+an added shock that the others were spared, and was crushed for ever
+with a brooding fear he dared not even mention for many years to come.
+As the rest of the watchers on that tempestuous hill had stolidly set
+their faces toward the road, Ammi had looked back an instant at the
+shadowed valley of desolation so lately sheltering his ill-starred
+friend. And from that stricken, far-away spot he had seen something
+feebly rise, only to sink down again upon the place from which the
+great shapeless horror had shot into the sky. It was just a colour--but
+not any colour of our earth or heavens. And because Ammi recognized
+that colour, and knew that this last faint remnant must still lurk down
+there in the well, he has never been quite right since.
+
+Ammi would never go near the place again. It is forty-four years now
+since the horror happened, but he has never been there, and will be
+glad when the new reservoir blots it out. I shall be glad, too, for I
+do not like the way the sunlight changed colour around the mouth of
+that abandoned well I passed. I hope the water will always be very
+deep--but even so, I shall never drink it. I do not think I shall visit
+the Arkham country hereafter. Three of the men who had been with Ammi
+returned the next morning to see the ruins by daylight, but there were
+not any real ruins. Only the bricks of the chimney, the stones of the
+cellar, some mineral and metallic litter here and there, and the rim
+of that nefandous well. Save for Ammi's dead horse, which they towed
+away and buried, and the buggy which they shortly returned to him,
+everything that had ever been living had gone. Five eldritch acres of
+dusty grey desert remained, nor has anything ever grown there since.
+To this day it sprawls open to the sky like a great spot eaten by acid
+in the woods and fields, and the few who have ever dared glimpse it in
+spite of the rural tales have named it "the blasted heath."
+
+       *       *       *       *       *
+
+The rural tales are queer. They might be even queerer if city men
+and college chemists could be interested enough to analyze the water
+from that disused well, or the grey dust that no wind seems ever to
+disperse. Botanists, too, ought to study the stunted flora on the
+borders of that spot, for they might shed light on the country notion
+that the blight is spreading--little by little, perhaps an inch a year.
+People say the colour of the neighboring herbage is not quite right
+in the spring, and that wild things leave queer prints in the light
+winter snow. Snow never seems quite so heavy on the blasted heath as
+it is elsewhere. Horses--the few that are left in this motor age--grow
+skittish in the silent valley; and hunters cannot depend on their dogs
+too near the splotch of greyish dust.
+
+They say the mental influences are very bad, too; numbers went queer in
+the years after Nahum's taking, and always they lacked the power to get
+away. Then the stronger-minded folk all left the region, and only the
+foreigners tried to live in the crumbling old homesteads. They could
+not stay, though; and one sometimes wonders what insight beyond ours
+their wild, weird stories of whispered magic have given them. Their
+dreams at night, they protest, are very horrible in that grotesque
+country; and surely the very look of the dark realm is enough to stir
+a morbid fancy. No traveler has ever escaped a sense of strangeness in
+those deep ravines, and artists shiver as they paint thick woods whose
+mystery is as much of the spirits as of the eye. I myself am curious
+about the sensation I derived from my one lone walk before Ammi told
+me his tale. When twilight came I had vaguely wished some clouds would
+gather, for odd timidity about the deep skyey voids above had crept
+into my soul.
+
+Do not ask me for my opinion. I do not know--that is all. There was no
+one but Ammi to question; for Arkham people will not talk about the
+strange days, and all three professors who saw the aerolite and its
+coloured globule are dead. There were other globules--depend upon that.
+One must have fed itself and escaped, and probably there was another
+which was too late. No doubt it is still down the well--I know there
+was something wrong with the sunlight I saw above that miasmal brink.
+The rustics say the blight creeps an inch a year, so perhaps there is
+a kind of growth or nourishment even now. But whatever demon hatchling
+is there, it must be tethered to something or else it would quickly
+spread. Is it fastened to the roots of those trees that claw the air?
+One of the current Arkham tales is about fat oaks that shine and move
+as they ought not to do at night.
+
+What it is, only God knows. In terms of matter I suppose the thing
+Ammi described would be called a gas, but this gas obeyed laws that
+are not of our cosmos. This was no fruit of such worlds and suns as
+shine on the telescopes and photographic plates of our observatories.
+This was no breath from the skies whose motions and dimensions our
+astronomers measure or deem too vast to measure. It was just a colour
+out of space--a frightful messenger from unformed realms of infinity
+beyond all Nature as we know it; from realms whose mere existence stuns
+the brain and numbs us with the black extra-cosmic gulfs it throws open
+before our frenzied eyes.
+
+I doubt very much if Ammi consciously lied to me, and I do not think
+his tale was all a freak of madness as the townsfolk had forewarned.
+Something terrible came to the hills and valleys on that meteor,
+and something terrible--though I know not in what proportion--still
+remains. I shall be glad to see the water come. Meanwhile I hope
+nothing will happen to Ammi. He saw so much of the thing--and its
+influence was so insidious. Why has he never been able to move away?
+How clearly he recalled those dying words of Nahum's--"can't git
+away--draws ye--ye know summ'at's comin', but 'tain't no use--" Ammi is
+such a good old man--when the reservoir gang gets to work I must write
+the chief engineer to keep a sharp watch on him. I would hate to think
+of him as the grey, twisted, brittle monstrosity which persists more
+and more in troubling my sleep.
+
+The CALL of CTHULHU
+
+By H.P. LOVECRAFT
+
+[Transcriber's Note: This etext was produced from
+Weird Tales, February 1928.
+Extensive research did not uncover any evidence that
+the U.S. copyright on this publication was renewed.]
+
+
+    "Of such great powers or beings there may be conceivably a
+    survival ... a survival of a hugely remote period when ...
+    consciousness was manifested, perhaps, in shapes and forms long
+    since withdrawn before the tide of advancing humanity ... forms
+    of which poetry and legend alone have caught a flying memory
+    and called them gods, monsters, mythical beings of all sorts
+    and kinds...."
+
+                                                --_Algernon Blackwood._
+
+
+[Illustration: "The ring of worshipers moved in endless bacchanale
+between the ring of bodies and the ring of fire."][1]
+
+[Footnote 1: Found among the papers of the late Francis Wayland
+Thurston, of Boston.]
+
+
+
+
+                       _1. The Horror in Clay._
+
+The most merciful thing in the world, I think, is the inability of the
+human mind to correlate all its contents. We live on a placid island
+of ignorance in the midst of black seas of infinity, and it was not
+meant that we should voyage far. The sciences, each straining in its
+own direction, have hitherto harmed us little; but some day the piecing
+together of dissociated knowledge will open up such terrifying vistas
+of reality, and of our frightful position therein, that we shall either
+go mad from the revelation or flee from the deadly light into the peace
+and safety of a new dark age.
+
+Theosophists have guessed at the awesome grandeur of the cosmic cycle
+wherein our world and human race form transient incidents. They have
+hinted at strange survivals in terms which would freeze the blood if
+not masked by a bland optimism. But it is not from them that there
+came the single glimpse of forbidden eons which chills me when I think
+of it and maddens me when I dream of it. That glimpse, like all dread
+glimpses of truth, flashed out from an accidental piecing together of
+separated things--in this case an old newspaper item and the notes of
+a dead professor. I hope that no one else will accomplish this piecing
+out; certainly, if I live, I shall never knowingly supply a link in
+so hideous a chain. I think that the professor, too, intended to keep
+silent regarding the part he knew, and that he would have destroyed his
+notes had not sudden death seized him.
+
+My knowledge of the thing began in the winter of 1926-27 with the death
+of my grand-uncle, George Gammell Angell, Professor Emeritus of Semitic
+languages in Brown University, Providence, Rhode Island. Professor
+Angell was widely known as an authority on ancient inscriptions, and
+had frequently been resorted to by the heads of prominent museums; so
+that his passing at the age of ninety-two may be recalled by many.
+Locally, interest was intensified by the obscurity of the cause of
+death. The professor had been stricken whilst returning from the
+Newport boat; falling suddenly, as witnesses said, after having been
+jostled by a nautical-looking negro who had come from one of the queer
+dark courts on the precipitous hillside which formed a short cut from
+the waterfront to the deceased's home in Williams Street. Physicians
+were unable to find any visible disorder, but concluded after perplexed
+debate that some obscure lesion of the heart, induced by the brisk
+ascent of so steep a hill by so elderly a man, was responsible for
+the end. At the time I saw no reason to dissent from this dictum, but
+latterly I am inclined to wonder--and more than wonder.
+
+As my granduncle's heir and executor, for he died a childless widower,
+I was expected to go over his papers with some thoroughness; and for
+that purpose moved his entire set of files and boxes to my quarters in
+Boston. Much of the material which I correlated will be later published
+by the American Archeological Society, but there was one box which I
+found exceedingly puzzling, and which I felt much averse from showing
+to other eyes. It had been locked, and I did not find the key till
+it occurred to me to examine the personal ring which the professor
+carried always in his pocket. Then, indeed, I succeeded in opening it,
+but when I did so seemed only to be confronted by a greater and more
+closely locked barrier. For what could be the meaning of the queer clay
+bas-relief and the disjointed jottings, ramblings, and cuttings which I
+found? Had my uncle, in his latter years, become credulous of the most
+superficial impostures? I resolved to search out the eccentric sculptor
+responsible for this apparent disturbance of an old man's peace of mind.
+
+The bas-relief was a rough rectangle less than an inch thick and about
+five by six inches in area; obviously of modern origin. Its designs,
+however, were far from modern in atmosphere and suggestion; for,
+although the vagaries of cubism and futurism are many and wild, they do
+not often reproduce that cryptic regularity which lurks in prehistoric
+writing. And writing of some kind the bulk of these designs seemed
+certainly to be; though my memory, despite much familiarity with the
+papers and collections of my uncle, failed in any way to identify this
+particular species, or even hint at its remotest affiliations.
+
+Above these apparent hieroglyphics was a figure of evidently pictorial
+intent, though its impressionistic execution forbade a very clear
+idea of its nature. It seemed to be a sort of monster, or symbol
+representing a monster, of a form which only a diseased fancy could
+conceive. If I say that my somewhat extravagant imagination yielded
+simultaneous pictures of an octopus, a dragon, and a human caricature,
+I shall not be unfaithful to the spirit of the thing. A pulpy,
+tentacled head surmounted a grotesque and scaly body with rudimentary
+wings; but it was the _general outline_ of the whole which made it most
+shockingly frightful. Behind the figure was a vague suggestion of a
+Cyclopean architectural background.
+
+The writing accompanying this oddity was, aside from a stack of
+press cuttings, in Professor Angell's most recent hand; and made no
+pretense to literary style. What seemed to be the main document was
+headed "_CTHULHU CULT_" in characters painstakingly printed to avoid
+the erroneous reading of a word so unheard-of. This manuscript was
+divided into two sections, the first of which was headed "1925--Dream
+and Dream Work of H. A. Wilcox, 7 Thomas St., Providence, R. I.," and
+the second, "Narrative of Inspector John R. Legrasse, 121 Bienville
+St., New Orleans, La., at 1908 A. A. S. Mtg--Notes on Same, & Prof.
+Webb's Acct." The other manuscript papers were all brief notes, some
+of them accounts of the queer dreams of different persons, some of
+them citations from theosophical books and magazines (notably W.
+Scott-Eliott's _Atlantis and the Lost Lemuria_), and the rest comments
+on long-surviving secret societies and hidden cults, with references
+to passages in such mythological and anthropological source-books
+as Frazer's _Golden Bough_ and Miss Murray's _Witch-Cult in Western
+Europe_. The cuttings largely alluded to outré mental illnesses and
+outbreaks of group folly or mania in the spring of 1925.
+
+       *       *       *       *       *
+
+The first half of the principal manuscript told a very peculiar
+tale. It appears that on March 1st, 1925, a thin, dark young man of
+neurotic and excited aspect had called upon Professor Angell bearing
+the singular clay bas-relief, which was then exceedingly damp and
+fresh. His card bore the name of Henry Anthony Wilcox, and my uncle
+had recognized him as the youngest son of an excellent family slightly
+known to him, who had latterly been studying sculpture at the Rhode
+Island School of Design and living alone at the Fleur-de-Lys Building
+near that institution. Wilcox was a precocious youth of known genius
+but great eccentricity, and had from childhood excited attention
+through the strange stories and odd dreams he was in the habit of
+relating. He called himself "psychically hypersensitive", but the staid
+folk of the ancient commercial city dismissed him as merely "queer".
+Never mingling much with his kind, he had dropped gradually from social
+visibility, and was now known only to a small group of esthetes from
+other towns. Even the Providence Art Club, anxious to preserve its
+conservatism, had found him quite hopeless.
+
+On the occasion of the visit, ran the professor's manuscript, the
+sculptor abruptly asked for the benefit of his host's archeological
+knowledge in identifying the hieroglyphics on the bas-relief. He
+spoke in a dreamy, stilted manner which suggested pose and alienated
+sympathy; and my uncle showed some sharpness in replying, for the
+conspicuous freshness of the tablet implied kinship with anything but
+archeology. Young Wilcox's rejoinder, which impressed my uncle enough
+to make him recall and record it verbatim, was of a fantastically
+poetic cast which must have typified his whole conversation, and which
+I have since found highly characteristic of him. He said, "It is new,
+indeed, for I made it last night in a dream of strange cities; and
+dreams are older than brooding Tyre, or the contemplative Sphinx, or
+garden-girdled Babylon."
+
+It was then that he began that rambling tale which suddenly played upon
+a sleeping memory and won the fevered interest of my uncle. There had
+been a slight earthquake tremor the night before, the most considerable
+felt in New England for some years; and Wilcox's imagination had been
+keenly affected. Upon retiring, he had had an unprecedented dream of
+great Cyclopean cities of Titan blocks and sky-flung monoliths, all
+dripping with green ooze and sinister with latent horror. Hieroglyphics
+had covered the walls and pillars, and from some undetermined point
+below had come a voice that was not a voice; a chaotic sensation which
+only fancy could transmute into sound, but which he attempted to render
+by the almost unpronounceable jumble of letters, "_Cthulhu fhtagn_".
+
+This verbal jumble was the key to the recollection which excited and
+disturbed Professor Angell. He questioned the sculptor with scientific
+minuteness; and studied with almost frantic intensity the bas-relief
+on which the youth had found himself working, chilled and clad only
+in his nightclothes, when waking had stolen bewilderingly over him.
+My uncle blamed his old age, Wilcox afterward said, for his slowness
+in recognizing both hieroglyphics and pictorial design. Many of his
+questions seemed highly out of place to his visitor, especially those
+which tried to connect the latter with strange cults or societies;
+and Wilcox could not understand the repeated promises of silence
+which he was offered in exchange for an admission of membership in
+some widespread mystical or paganly religious body. When Professor
+Angell became convinced that the sculptor was indeed ignorant of any
+cult or system of cryptic lore, he besieged his visitor with demands
+for future reports of dreams. This bore regular fruit, for after the
+first interview the manuscript records daily calls of the young man,
+during which he related startling fragments of nocturnal imagery whose
+burden was always some terrible Cyclopean vista of dark and dripping
+stone, with a subterrene voice or intelligence shouting monotonously
+in enigmatical sense-impacts uninscribable save as gibberish. The two
+sounds most frequently repeated are those rendered by the letters
+"_Cthulhu_" and "_R'lyeh_".
+
+On March 23rd, the manuscript continued, Wilcox failed to appear; and
+inquiries at his quarters revealed that he had been stricken with an
+obscure sort of fever and taken to the home of his family in Waterman
+Street. He had cried out in the night, arousing several other artists
+in the building, and had manifested since then only alternations of
+unconsciousness and delirium. My uncle at once telephoned the family,
+and from that time forward kept close watch of the case; calling
+often at the Thayer Street office of Dr. Tobey, whom he learned to
+be in charge. The youth's febrile mind, apparently, was dwelling on
+strange things; and the doctor shuddered now and then as he spoke of
+them. They included not only a repetition of what he had formerly
+dreamed, but touched wildly on a gigantic thing "miles high" which
+walked or lumbered about. He at no time fully described this object,
+but occasional frantic words, as repeated by Dr. Tobey, convinced the
+professor that it must be identical with the nameless monstrosity
+he had sought to depict in his dream-sculpture. Reference to this
+object, the doctor added, was invariably a prelude to the young man's
+subsidence into lethargy. His temperature, oddly enough, was not
+greatly above normal; but the whole condition was otherwise such as to
+suggest true fever rather than mental disorder.
+
+On April 2nd at about 3 p. m. every trace of Wilcox's malady suddenly
+ceased. He sat upright in bed, astonished to find himself at home and
+completely ignorant of what had happened in dream or reality since the
+night of March 22nd. Pronounced well by his physician, he returned
+to his quarters in three days; but to Professor Angell he was of no
+further assistance. All traces of strange dreaming had vanished with
+his recovery, and my uncle kept no record of his night-thoughts after a
+week of pointless and irrelevant accounts of thoroughly usual visions.
+
+       *       *       *       *       *
+
+Here the first part of the manuscript ended, but references to certain
+of the scattered notes gave me much material for thought--so much, in
+fact, that only the ingrained skepticism then forming my philosophy
+can account for my continued distrust of the artist. The notes in
+question were those descriptive of the dreams of various persons
+covering the same period as that in which young Wilcox had had his
+strange visitations. My uncle, it seems, had quickly instituted a
+prodigiously far-flung body of inquiries amongst nearly all the friends
+whom he could question without impertinence, asking for nightly reports
+of their dreams, and the dates of any notable visions for some time
+past. The reception of his request seems to have been varied; but
+he must, at the very least, have received more responses than any
+ordinary man could have handled without a secretary. This original
+correspondence was not preserved, but his notes formed a thorough and
+really significant digest. Average people in society and business--New
+England's traditional "salt of the earth"--gave an almost completely
+negative result, though scattered cases of uneasy but formless
+nocturnal impressions appear here and there, always between March
+23rd and April 2nd--the period of young Wilcox's delirium. Scientific
+men were little more affected, though four cases of vague description
+suggest fugitive glimpses of strange landscapes, and in one case there
+is mentioned a dread of something abnormal.
+
+It was from the artists and poets that the pertinent answers came,
+and I know that panic would have broken loose had they been able to
+compare notes. As it was, lacking their original letters, I half
+suspected the compiler of having asked leading questions, or of having
+edited the correspondence in corroboration of what he had latently
+resolved to see. That is why I continued to feel that Wilcox, somehow
+cognizant of the old data which my uncle had possessed, had been
+imposing on the veteran scientist. These responses from esthetes told
+a disturbing tale. From February 28th to April 2nd a large proportion
+of them had dreamed very bizarre things, the intensity of the dreams
+being immeasurably the stronger during the period of the sculptor's
+delirium. Over a fourth of those who reported anything, reported
+scenes and half-sounds not unlike those which Wilcox had described;
+and some of the dreamers confessed acute fear of the gigantic nameless
+thing visible toward the last. One case, which the note describes with
+emphasis, was very sad. The subject, a widely known architect with
+leanings toward theosophy and occultism, went violently insane on
+the date of young Wilcox's seizure, and expired several months later
+after incessant screamings to be saved from some escaped denizen of
+hell. Had my uncle referred to these cases by name instead of merely
+by number, I should have attempted some corroboration and personal
+investigation; but as it was, I succeeded in tracing down only a
+few. All of these, however, bore out the notes in full. I have often
+wondered if all the objects of the professor's questioning felt as
+puzzled as did this fraction. It is well that no explanation shall ever
+reach them.
+
+The press cuttings, as I have intimated, touched on cases of panic,
+mania, and eccentricity during the given period. Professor Angell
+must have employed a cutting bureau, for the number of extracts was
+tremendous, and the sources scattered throughout the globe. Here
+was a nocturnal suicide in London, where a lone sleeper had leaped
+from a window after a shocking cry. Here likewise a rambling letter
+to the editor of a paper in South America, where a fanatic deduces
+a dire future from visions he has seen. A dispatch from California
+describes a theosophist colony as donning white robes en masse for some
+"glorious fulfilment" which never arrives, whilst items from India
+speak guardedly of serious native unrest toward the end of March.
+Voodoo orgies multiply in Haiti, and African outposts report ominous
+mutterings. American officers in the Philippines find certain tribes
+bothersome about this time, and New York policemen are mobbed by
+hysterical Levantines on the night of March 22-23. The west of Ireland,
+too, is full of wild rumor and legendry, and a fantastic painter named
+Ardois-Bonnot hangs a blasphemous _Dream Landscape_ in the Paris spring
+salon of 1926. And so numerous are the recorded troubles in insane
+asylums that only a miracle can have stopped the medical fraternity
+from noting strange parallelisms and drawing mystified conclusions.
+A weird bunch of cuttings, all told; and I can at this date scarcely
+envisage the callous rationalism with which I set them aside. But I
+was then convinced that young Wilcox had known of the older matters
+mentioned by the professor.
+
+
+
+
+                 _2. The Tale of Inspector Legrasse._
+
+
+The older matters which had made the sculptor's dream and bas-relief so
+significant to my uncle formed the subject of the second half of his
+long manuscript. Once before, it appears, Professor Angell had seen the
+hellish outlines of the nameless monstrosity, puzzled over the unknown
+hieroglyphics, and heard the ominous syllables which can be rendered
+only as "_Cthulhu_"; and all this in so stirring and horrible a
+connection that it is small wonder he pursued young Wilcox with queries
+and demands for data.
+
+This earlier experience had come in 1908, seventeen years before,
+when the American Archeological Society held its annual meeting in
+St. Louis. Professor Angell, as befitted one of his authority and
+attainments, had had a prominent part in all the deliberations; and was
+one of the first to be approached by the several outsiders who took
+advantage of the convocation to offer questions for correct answering
+and problems for expert solution.
+
+The chief of these outsiders, and in a short time the focus of interest
+for the entire meeting, was a commonplace-looking middle-aged man
+who had traveled all the way from New Orleans for certain special
+information unobtainable from any local source. His name was John
+Raymond Legrasse, and he was by profession an inspector of police. With
+him he bore the subject of his visit, a grotesque, repulsive, and
+apparently very ancient stone statuette whose origin he was at a loss
+to determine.
+
+It must not be fancied that Inspector Legrasse had the least interest
+in archeology. On the contrary, his wish for enlightenment was prompted
+by purely professional considerations. The statuette, idol, fetish,
+or whatever it was, had been captured some months before in the
+wooded swamps south of New Orleans during a raid on a supposed voodoo
+meeting; and so singular and hideous were the rites connected with
+it, that the police could not but realize that they had stumbled on a
+dark cult totally unknown to them, and infinitely more diabolic than
+even the blackest of the African voodoo circles. Of its origin, apart
+from the erratic and unbelievable tales extorted from the captured
+members, absolutely nothing was to be discovered; hence the anxiety
+of the police for any antiquarian lore which might help them to place
+the frightful symbol, and through it track down the cult to its
+fountain-head.
+
+Inspector Legrasse was scarcely prepared for the sensation which his
+offering created. One sight of the thing had been enough to throw the
+assembled men of science into a state of tense excitement, and they
+lost no time in crowding around him to gaze at the diminutive figure
+whose utter strangeness and air of genuinely abysmal antiquity hinted
+so potently at unopened and archaic vistas. No recognized school of
+sculpture had animated this terrible object, yet centuries and even
+thousands of years seemed recorded in its dim and greenish surface of
+unplaceable stone.
+
+The figure, which was finally passed slowly from man to man for close
+and careful study, was between seven and eight inches in height, and of
+exquisitely artistic workmanship. It represented a monster of vaguely
+anthropoid outline, but with an octopuslike head whose face was a mass
+of feelers, a scaly, rubbery-looking body, prodigious claws on hind
+and fore feet, and long, narrow wings behind. This thing, which seemed
+instinct with a fearsome and unnatural malignancy, was of a somewhat
+bloated corpulence, and squatted evilly on a rectangular block or
+pedestal covered with undecipherable characters. The tips of the wings
+touched the back edge of the block, the seat occupied the center,
+whilst the long, curved claws of the doubled-up, crouching hind legs
+gripped the front edge and extended a quarter of the way down toward
+the bottom of the pedestal. The cephalopod head was bent forward, so
+that the ends of the facial feelers brushed the backs of huge forepaws
+which clasped the croucher's elevated knees. The aspect of the whole
+was abnormally lifelike, and the more subtly fearful because its source
+was so totally unknown. Its vast, awesome, and incalculable age was
+unmistakable; yet not one link did it show with any known type of art
+belonging to civilization's youth--or indeed to any other time.
+
+Totally separate and apart, its very material was a mystery; for the
+soapy, greenish-black stone with its golden or iridescent flecks and
+striations resembled nothing familiar to geology or mineralogy. The
+characters along the base were equally baffling; and no member present,
+despite a representation of half the world's expert learning in this
+field, could form the least notion of even their remotest linguistic
+kinship. They, like the subject and material, belonged to something
+horribly remote and distinct from mankind as we know it; something
+frightfully suggestive of old and unhallowed cycles of life in which
+our world and our conceptions have no part.
+
+And yet, as the members severally shook their heads and confessed
+defeat at the inspector's problem, there was one man in that gathering
+who suspected a touch of bizarre familiarity in the monstrous shape and
+writing, and who presently told with some diffidence of the odd trifle
+he knew. This person was the late William Channing Webb, professor of
+anthropology in Princeton University, and an explorer of no slight note.
+
+Professor Webb had been engaged, forty-eight years before, in a tour
+of Greenland and Iceland in search of some Runic inscriptions which
+he failed to unearth; and whilst high up on the West Greenland coast
+had encountered a singular tribe or cult of degenerate Eskimos whose
+religion, a curious form of devil-worship, chilled him with its
+deliberate bloodthirstiness and repulsiveness. It was a faith of which
+other Eskimos knew little, and which they mentioned only with shudders,
+saying that it had come down from horribly ancient eons before ever the
+world was made. Besides nameless rites and human sacrifices there were
+certain queer hereditary rituals addressed to a supreme elder devil or
+_tornasuk_; and of this Professor Webb had taken a careful phonetic
+copy from an aged _angekok_ or wizard-priest, expressing the sounds in
+Roman letters as best he knew how. But just now of prime significance
+was the fetish which this cult had cherished, and around which they
+danced when the aurora leaped high over the ice cliffs. It was, the
+professor stated, a very crude bas-relief of stone, comprising a
+hideous picture and some cryptic writing. And as far as he could tell,
+it was a rough parallel in all essential features of the bestial thing
+now lying before the meeting.
+
+These data, received with suspense and astonishment by the assembled
+members, proved doubly exciting to Inspector Legrasse; and he began at
+once to ply his informant with questions. Having noted and copied an
+oral ritual among the swamp cult-worshipers his men had arrested, he
+besought the professor to remember as best he might the syllables taken
+down amongst the diabolist Eskimos. There then followed an exhaustive
+comparison of details, and a moment of really awed silence when both
+detective and scientist agreed on the virtual identity of the phrase
+common to two hellish rituals so many worlds of distance apart. What,
+in substance, both the Eskimo wizards and the Louisiana swamp-priests
+had chanted to their kindred idols was something very like this--the
+word-divisions being guessed at from traditional breaks in the phrase
+as chanted aloud:
+
+        "_Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn._"
+
+Legrasse had one point in advance of Professor Webb, for several among
+his mongrel prisoners had repeated to him what older celebrants had
+told them the words meant. This text, as given, ran something like this:
+
+         "In his house at R'lyeh dead Cthulhu waits dreaming."
+
+       *       *       *       *       *
+
+And now, in response to a general urgent demand, Inspector Legrasse
+related as fully as possible his experience with the swamp worshipers;
+telling a story to which I could see my uncle attached profound
+significance. It savored of the wildest dreams of myth-maker and
+theosophist, and disclosed an astonishing degree of cosmic imagination
+among such half-castes and pariahs as might be least expected to
+possess it.
+
+On November 1st, 1907, there had come to New Orleans police a frantic
+summons from the swamp and lagoon country to the south. The squatters
+there, mostly primitive but good-natured descendants of Lafitte's men,
+were in the grip of stark terror from an unknown thing which had stolen
+upon them in the night. It was voodoo, apparently, but voodoo of a more
+terrible sort than they had ever known; and some of their women and
+children had disappeared since the malevolent tom-tom had begun its
+incessant beating far within the black haunted woods where no dweller
+ventured. There were insane shouts and harrowing screams, soul-chilling
+chants and dancing devil-flames; and, the frightened messenger added,
+the people could stand it no more.
+
+So a body of twenty police, filling two carriages and an automobile,
+had set out in the late afternoon with the shivering squatter as a
+guide. At the end of the passable road they alighted, and for miles
+splashed on in silence through the terrible cypress woods where day
+never came. Ugly roots and malignant hanging nooses of Spanish moss
+beset them, and now and then a pile of dank stones or fragments of a
+rotting wall intensified by its hint of morbid habitation a depression
+which every malformed tree and every fungous islet combined to create.
+At length the squatter settlement, a miserable huddle of huts, hove in
+sight; and hysterical dwellers ran out to cluster around the group of
+bobbing lanterns. The muffled beat of tom-toms was now faintly audible
+far, far ahead; and a curdling shriek came at infrequent intervals
+when the wind shifted. A reddish glare, too, seemed to filter through
+the pale undergrowth beyond endless avenues of forest night. Reluctant
+even to be left alone again, each one of the cowed squatters refused
+point-blank to advance another inch toward the scene of unholy
+worship, so Inspector Legrasse and his nineteen colleagues plunged on
+unguided into black arcades of horror that none of them had ever trod
+before.
+
+The region now entered by the police was one of traditionally evil
+repute, substantially unknown and untraversed by white men. There were
+legends of a hidden lake unglimpsed by mortal sight, in which dwelt a
+huge, formless white polypous thing with luminous eyes; and squatters
+whispered that bat-winged devils flew up out of caverns in inner
+earth to worship it at midnight. They said it had been there before
+D'Iberville, before La Salle, before the Indians, and before even the
+wholesome beasts and birds of the woods. It was nightmare itself, and
+to see it was to die. But it made men dream, and so they knew enough to
+keep away. The present voodoo orgy was, indeed, on the merest fringe
+of this abhorred area, but that location was bad enough; hence perhaps
+the very place of the worship had terrified the squatters more than the
+shocking sounds and incidents.
+
+Only poetry or madness could do justice to the noises heard by
+Legrasse's men as they plowed on through the black morass toward the
+red glare and the muffled tom-toms. There are vocal qualities peculiar
+to men, and vocal qualities peculiar to beasts; and it is terrible
+to hear the one when the source should yield the other. Animal fury
+and orgiastic license here whipped themselves to demoniac heights by
+howls and squawking ecstasies that tore and reverberated through those
+nighted woods like pestilential tempests from the gulfs of hell. Now
+and then the less organized ululations would cease, and from what
+seemed a well-drilled chorus of hoarse voices would rise in singsong
+chant that hideous phrase or ritual:
+
+        "_Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn._"
+
+Then the men, having reached a spot where the trees were thinner, came
+suddenly in sight of the spectacle itself. Four of them reeled, one
+fainted, and two were shaken into a frantic cry which the mad cacophony
+of the orgy fortunately deadened. Legrasse dashed swamp water on the
+face of the fainting man, and all stood trembling and nearly hypnotized
+with horror.
+
+In a natural glade of the swamp stood a grassy island of perhaps an
+acre's extent, clear of trees and tolerably dry. On this now leaped and
+twisted a more indescribable horde of human abnormality than any but a
+Sime or an Angarola could paint. Void of clothing, this hybrid spawn
+were braying, bellowing and writhing about a monstrous ring-shaped
+bonfire; in the center of which, revealed by occasional rifts in the
+curtain of flame, stood a great granite monolith some eight feet in
+height; on top of which, incongruous in its diminutiveness, rested the
+noxious carven statuette. From a wide circle of ten scaffolds set up
+at regular intervals with the flame-girt monolith as a center hung,
+head downward, the oddly marred bodies of the helpless squatters who
+had disappeared. It was inside this circle that the ring of worshipers
+jumped and roared, the general direction of the mass motion being from
+left to right in endless bacchanale between the ring of bodies and the
+ring of fire.
+
+It may have been only imagination and it may have been only echoes
+which induced one of the men, an excitable Spaniard, to fancy he heard
+antiphonal responses to the ritual from some far and unillumined spot
+deeper within the wood of ancient legendry and horror. This man, Joseph
+D. Galvez, I later met and questioned; and he proved distractingly
+imaginative. He indeed went so far as to hint of the faint beating of
+great wings, and of a glimpse of shining eyes and a mountainous white
+bulk beyond the remotest trees--but I suppose he had been hearing too
+much native superstition.
+
+Actually, the horrified pause of the men was of comparatively brief
+duration. Duty came first; and although there must have been nearly a
+hundred mongrel celebrants in the throng, the police relied on their
+firearms and plunged determinedly into the nauseous rout. For five
+minutes the resultant din and chaos were beyond description. Wild
+blows were struck, shots were fired, and escapes were made; but in
+the end Legrasse was able to count some forty-seven sullen prisoners,
+whom he forced to dress in haste and fall into line between two rows
+of policemen. Five of the worshipers lay dead, and two severely
+wounded ones were carried away on improvised stretchers by their
+fellow-prisoners. The image on the monolith, of course, was carefully
+removed and carried back by Legrasse.
+
+Examined at headquarters after a trip of intense strain and weariness,
+the prisoners all proved to be men of a very low, mixed-blooded, and
+mentally aberrant type. Most were seamen, and a sprinkling of negroes
+and mulattoes, largely West Indians or Brava Portuguese from the Cape
+Verde Islands, gave a coloring of voodooism to the heterogeneous cult.
+But before many questions were asked, it became manifest that something
+far deeper and older than negro fetishism was involved. Degraded and
+ignorant as they were, the creatures held with surprizing consistency
+to the central idea of their loathsome faith.
+
+They worshiped, so they said, the Great Old Ones who lived ages before
+there were any men, and who came to the young world out of the sky.
+Those Old Ones were gone now, inside the earth and under the sea; but
+their dead bodies had told their secrets in dreams to the first man,
+who formed a cult which had never died. This was that cult, and the
+prisoners said it had always existed and always would exist, hidden in
+distant wastes and dark places all over the world until the time when
+the great priest Cthulhu, from his dark house in the mighty city of
+R'lyeh under the waters, should rise and bring the earth again beneath
+his sway. Some day he would call, when the stars were ready, and the
+secret cult would always be waiting to liberate him.
+
+Meanwhile no more must be told. There was a secret which even torture
+could not extract. Mankind was not absolutely alone among the conscious
+things of earth, for shapes came out of the dark to visit the faithful
+few. But these were not the Great Old Ones. No man had ever seen the
+Old Ones. The carven idol was great Cthulhu, but none might say whether
+or not the others were precisely like him. No one could read the old
+writing now, but things were told by word of mouth. The chanted ritual
+was not the secret--that was never spoken aloud, only whispered. The
+chant meant only this: "In his house at R'lyeh dead Cthulhu waits
+dreaming."
+
+       *       *       *       *       *
+
+Only two of the prisoners were found sane enough to be hanged, and
+the rest were committed to various institutions. All denied a part
+in the ritual murders, and averred that the killing had been done
+by Black-winged Ones which had come to them from their immemorial
+meeting-place in the haunted wood. But of those mysterious allies no
+coherent account could ever be gained. What the police did extract
+came mainly from an immensely aged mestizo named Castro, who claimed
+to have sailed to strange ports and talked with undying leaders of the
+cult in the mountains of China.
+
+Old Castro remembered bits of hideous legend that paled the
+speculations of theosophists and made man and the world seem recent
+and transient indeed. There had been eons when other Things ruled on
+the earth, and They had had great cities. Remains of Them, he said the
+deathless Chinamen had told him, were still to be found as Cyclopean
+stones on islands in the Pacific. They all died vast epochs of time
+before man came, but there were arts which could revive Them when the
+stars had come round again to the right positions in the cycle of
+eternity. They had, indeed, come themselves from the stars, and brought
+Their images with Them.
+
+These Great Old Ones, Castro continued, were not composed altogether
+of flesh and blood. They had shape--for did not this star-fashioned
+image prove it?--but that shape was not made of matter. When the stars
+were right, They could plunge from world to world through the sky;
+but when the stars were wrong, They could not live. But although They
+no longer lived, They would never really die. They all lay in stone
+houses in Their great city of R'lyeh, preserved by the spells of mighty
+Cthulhu for a glorious resurrection when the stars and the earth might
+once more be ready for Them. But at that time some force from outside
+must serve to liberate Their bodies. The spells that preserved Them
+intact likewise prevented Them from making an initial move, and They
+could only lie awake in the dark and think whilst uncounted millions
+of years rolled by. They knew all that was occurring in the universe,
+for Their mode of speech was transmitted thought. Even now They talked
+in Their tombs. When, after infinities of chaos, the first men came,
+the Great Old Ones spoke to the sensitive among them by molding their
+dreams; for only thus could Their language reach the fleshly minds of
+mammals.
+
+Then, whispered Castro, those first men formed the cult around small
+idols which the Great Ones showed them; idols brought in dim eras
+from dark stars. That cult would never die till the stars came right
+again, and the secret priests would take great Cthulhu from His tomb
+to revive His subjects and resume His rule of earth. The time would
+be easy to know, for then mankind would have become as the Great Old
+Ones; free and wild and beyond good and evil, with laws and morals
+thrown aside and all men shouting and killing and reveling in joy. Then
+the liberated Old Ones would teach them new ways to shout and kill
+and revel and enjoy themselves, and all the earth would flame with a
+holocaust of ecstasy and freedom. Meanwhile the cult, by appropriate
+rites, must keep alive the memory of those ancient ways and shadow
+forth the prophecy of their return.
+
+In the elder time chosen men had talked with the entombed Old Ones in
+dreams, but then something had happened. The great stone city R'lyeh,
+with its monoliths and sepulchers, had sunk beneath the waves; and the
+deep waters, full of the one primal mystery through which not even
+thought can pass, had cut off the spectral intercourse. But memory
+never died, and high priests said that the city would rise again when
+the stars were right. Then came out of the earth the black spirits of
+earth, moldy and shadowy, and full of dim rumors picked up in caverns
+beneath forgotten sea-bottoms. But of them old Castro dared not speak
+much. He cut himself off hurriedly, and no amount of persuasion or
+subtlety could elicit more in this direction. The _size_ of the Old
+Ones, too, he curiously declined to mention. Of the cult, he said that
+he thought the center lay amid the pathless deserts of Arabia, where
+Irem, the City of Pillars, dreams hidden and untouched. It was not
+allied to the European witch-cult, and was virtually unknown beyond its
+members. No book had ever really hinted of it, though the deathless
+Chinamen said that there were double meanings in the _Necronomicon_
+of the mad Arab Abdul Alhazred which the initiated might read as they
+chose, especially the much-discussed couplet:
+
+    "That is not dead which can eternal lie,
+    And with strange eons even death may die."
+
+Legrasse, deeply impressed and not a little bewildered, had inquired
+in vain concerning the historic affiliations of the cult. Castro,
+apparently, had told the truth when he said that it was wholly
+secret. The authorities at Tulane University could shed no light upon
+either cult or image, and now the detective had come to the highest
+authorities in the country and met with no more than the Greenland tale
+of Professor Webb.
+
+       *       *       *       *       *
+
+The feverish interest aroused at the meeting by Legrasse's tale,
+corroborated as it was by the statuette, is echoed in the subsequent
+correspondence of those who attended, although scant mention occurs in
+the formal publication of the society. Caution is the first care of
+those accustomed to face occasional charlatanry and imposture. Legrasse
+for some time lent the image to Professor Webb, but at the latter's
+death it was returned to him and remains in his possession, where I
+viewed it not long ago. It is truly a terrible thing, and unmistakably
+akin to the dream-sculpture of young Wilcox.
+
+That my uncle was excited by the tale of the sculptor I did not
+wonder, for what thoughts must arise upon hearing, after a knowledge
+of what Legrasse had learned of the cult, of a sensitive young man
+who had _dreamed_ not only the figure and exact hieroglyphics of the
+swamp-found image and the Greenland devil tablet, but had come _in his
+dreams_ upon at least three of the precise words of the formula uttered
+alike by Eskimo diabolists and mongrel Louisianans? Professor Angell's
+instant start on an investigation of the utmost thoroughness was
+eminently natural; though privately I suspected young Wilcox of having
+heard of the cult in some indirect way, and of having invented a series
+of dreams to heighten and continue the mystery at my uncle's expense.
+The dream-narratives and cuttings collected by the professor were, of
+course, strong corroboration; but the rationalism of my mind and the
+extravagance of the whole subject led me to adopt what I thought the
+most sensible conclusions. So, after thoroughly studying the manuscript
+again and correlating the theosophical and anthropological notes with
+the cult narrative of Legrasse, I made a trip to Providence to see
+the sculptor and give him the rebuke I thought proper for so boldly
+imposing upon a learned and aged man.
+
+Wilcox still lived alone in the Fleur-de-Lys Building in Thomas
+Street, a hideous Victorian imitation of Seventeenth Century Breton
+architecture which flaunts its stuccoed front amidst the lovely
+Colonial houses on the ancient hill, and under the very shadow of the
+finest Georgian steeple in America. I found him at work in his rooms,
+and at once conceded from the specimens scattered about that his genius
+is indeed profound and authentic. He will, I believe, be heard from
+sometime as one of the great decadents; for he has crystallized in clay
+and will one day mirror in marble those nightmares and fantasies which
+Arthur Machen evokes in prose, and Clark Ashton Smith makes visible in
+verse and in painting.
+
+Dark, frail, and somewhat unkempt in aspect, he turned languidly at my
+knock and asked me my business without rising. When I told him who I
+was, he displayed some interest; for my uncle had excited his curiosity
+in probing his strange dreams, yet had never explained the reason for
+the study. I did not enlarge his knowledge in this regard, but sought
+with some subtlety to draw him out.
+
+In a short time I became convinced of his absolute sincerity, for he
+spoke of the dreams in a manner none could mistake. They and their
+subconscious residuum had influenced his art profoundly, and he showed
+me a morbid statue whose contours almost made me shake with the potency
+of its black suggestion. He could not recall having seen the original
+of this thing except in his own dream bas-relief, but the outlines had
+formed themselves insensibly under his hands. It was, no doubt, the
+giant shape he had raved of in delirium. That he really knew nothing of
+the hidden cult, save from what my uncle's relentless catechism had let
+fall, he soon made clear; and again I strove to think of some way in
+which he could possibly have received the weird impressions.
+
+He talked of his dreams in a strangely poetic fashion; making me
+see with terrible vividness the damp Cyclopean city of slimy green
+stone--whose _geometry_, he oddly said, was _all wrong_--and hear
+with frightened expectancy the ceaseless, half-mental calling from
+underground: "_Cthulhu fhtagn_," "_Cthulhu fhtagn_."
+
+These words had formed part of that dread ritual which told of dead
+Cthulhu's dream-vigil in his stone vault at R'lyeh, and I felt deeply
+moved despite my rational beliefs. Wilcox, I was sure, had heard of
+the cult in some casual way, and had soon forgotten it amidst the mass
+of his equally weird reading and imagining. Later, by virtue of its
+sheer impressiveness, it had found subconscious expression in dreams,
+in the bas-relief, and in the terrible statue I now beheld; so that his
+imposture upon my uncle had been a very innocent one. The youth was of
+a type, at once slightly affected and slightly ill-mannered, which I
+could never like; but I was willing enough now to admit both his genius
+and his honesty. I took leave of him amicably, and wish him all the
+success his talent promises.
+
+The matter of the cult still remained to fascinate me, and at times
+I had visions of personal fame from researches into its origin and
+connections. I visited New Orleans, talked with Legrasse and others
+of that old-time raiding-party, saw the frightful image, and even
+questioned such of the mongrel prisoners as still survived. Old Castro,
+unfortunately, had been dead for some years. What I now heard so
+graphically at first hand, though it was really no more than a detailed
+confirmation of what my uncle had written, excited me afresh; for I
+felt sure that I was on the track of a very real, very secret, and
+very ancient religion whose discovery would make me an anthropologist
+of note. My attitude was still one of absolute materialism, _as I wish
+it still were_, and I discounted with almost inexplicable perversity
+the coincidence of the dream notes and odd cuttings collected by
+Professor Angell.
+
+One thing which I began to suspect, and which I now fear I _know_, is
+that my uncle's death was far from natural. He fell on a narrow hill
+street leading up from an ancient waterfront swarming with foreign
+mongrels, after a careless push from a negro sailor. I did not forget
+the mixed blood and marine pursuits of the cult-members in Louisiana,
+and would not be surprized to learn of secret methods and poison
+needles as ruthless and as anciently known as the cryptic rites and
+beliefs. Legrasse and his men, it is true, have been let alone; but in
+Norway a certain seaman who saw things is dead. Might not the deeper
+inquiries of my uncle after encountering the sculptor's data have come
+to sinister ears? I think Professor Angell died because he knew too
+much, or because he was likely to learn too much. Whether I shall go as
+he did remains to be seen, for I have learned much now.
+
+
+
+
+                    _3. The Madness from the Sea._
+
+
+If heaven ever wishes to grant me a boon, it will be a total effacing
+of the results of a mere chance which fixed my eye on a certain stray
+piece of shelf-paper. It was nothing on which I would naturally have
+stumbled in the course of my daily round, for it was an old number of
+an Australian journal, _Sydney Bulletin_ for April 18, 1925. It had
+escaped even the cutting bureau which had at the time of its issuance
+been avidly collecting material for my uncle's research.
+
+I had largely given over my inquiries into what Professor Angell called
+the "Cthulhu Cult," and was visiting a learned friend of Paterson,
+New Jersey, the curator of a local museum and a mineralogist of note.
+Examining one day the reserve specimens roughly set on the storage
+shelves in a rear room of the museum, my eye was caught by an odd
+picture in one of the old papers spread beneath the stones. It was the
+_Sydney Bulletin_ I have mentioned, for my friend has wide affiliations
+in all conceivable foreign parts; and the picture was a half-tone cut
+of a hideous stone image almost identical with that which Legrasse had
+found in the swamp.
+
+Eagerly clearing the sheet of its precious contents, I scanned the item
+in detail; and was disappointed to find it of only moderate length.
+What it suggested, however, was of portentous significance to my
+flagging quest; and I carefully tore it out for immediate action. It
+read as follows:
+
+                     MYSTERY DERELICT FOUND AT SEA
+
+    _Vigilant_ Arrives With Helpless Armed New Zealand Yacht in Tow.
+    One Survivor and Dead Man Found Aboard. Tale of Desperate Battle
+    and Deaths at Sea. Rescued Seaman Refuses Particulars of Strange
+    Experience. Odd Idol Found in His Possession. Inquiry to Follow.
+
+        *       *       *       *       *
+
+    The Morrison Co.'s freighter _Vigilant_, bound from Valparaiso,
+    arrived this morning at its wharf in Darling Harbour, having in tow
+    the battled and disabled but heavily armed steam yacht _Alert_ of
+    Dunedin, N. Z., which was sighted April 12th in S. Latitude 34° 21',
+    W. Longitude 152° 17', with one living and one dead man aboard.
+
+    The _Vigilant_ left Valparaiso March 25th, and on April 2d was
+    driven considerably south of her course by exceptionally heavy
+    storms and monster waves. On April 12th the derelict was sighted;
+    and though apparently deserted, was found upon boarding to contain
+    one survivor in a half-delirious condition and one man who had
+    evidently been dead for more than a week.
+
+    The living man was clutching a horrible stone idol of unknown
+    origin, about a foot in height, regarding whose nature authorities
+    at Sydney University, the Royal Society, and the Museum in College
+    Street all profess complete bafflement, and which the survivor says
+    he found in the cabin of the yacht, in a small carved shrine of
+    common pattern.
+
+    This man, after recovering his senses, told an exceedingly strange
+    story of piracy and slaughter. He is Gustaf Johansen, a Norwegian
+    of some intelligence, and had been second mate of the two-masted
+    schooner _Emma_ of Auckland, which sailed for Callao February 20th,
+    with a complement of eleven men.
+
+    The _Emma_, he says, was delayed and thrown widely south of her
+    course by the great storm of March 1st, and on March 22d, in S.
+    Latitude 49° 51´, W. Longitude 128° 34´, encountered the _Alert_,
+    manned by a queer and evil-looking crew of Kanakas and half-castes.
+    Being ordered peremptorily to turn back, Capt. Collins refused;
+    whereupon the strange crew began to fire savagely and without
+    warning upon the schooner with a peculiarly heavy battery of brass
+    cannon forming part of the yacht's equipment.
+
+    The _Emma's_ men showed fight, says the survivor, and though the
+    schooner began to sink from shots beneath the waterline they managed
+    to heave alongside their enemy and board her, grappling with the
+    savage crew on the yacht's deck, and being forced to kill them all,
+    the number being slightly superior, because of their particularly
+    abhorrent and desperate though rather clumsy mode of fighting.
+
+    Three of the _Emma's_ men, including Capt. Collins and First Mate
+    Green, were killed; and the remaining eight under Second Mate
+    Johansen proceeded to navigate the captured yacht, going ahead in
+    their original direction to see if any reason for their ordering
+    back had existed.
+
+    The next day, it appears, they raised and landed on a small island,
+    although none is known to exist in that part of the ocean; and six
+    of the men somehow died ashore, though Johansen is queerly reticent
+    about this part of his story and speaks only of their falling into
+    a rock chasm.
+
+    Later, it seems, he and one companion boarded the yacht and tried
+    to manage her, but were beaten about by the storm of April 2nd.
+
+    From that time till his rescue on the 12th, the man remembers
+    little, and he does not even recall when William Briden, his
+    companion, died. Briden's death reveals no apparent cause, and was
+    probably due to excitement or exposure.
+
+    Cable advices from Dunedin report that the _Alert_ was well known
+    there as an island trader, and bore an evil reputation along the
+    waterfront. It was owned by a curious group of half-castes whose
+    frequent meetings and night trips to the woods attracted no little
+    curiosity; and it had set sail in great haste just after the storm
+    and earth tremors of March 1st.
+
+    Our Auckland correspondent gives the _Emma_ and her crew an
+    excellent reputation, and Johansen is described as a sober and
+    worthy man.
+
+    The admiralty will institute an inquiry on the whole matter
+    beginning tomorrow, at which every effort will be made to induce
+    Johansen to speak more freely than he has done hitherto.
+
+       *       *       *       *       *
+
+This was all, together with the picture of the hellish image; but what
+a train of ideas it started in my mind! Here were new treasuries of
+data on the Cthulhu Cult, and evidence that it had strange interests
+at sea as well as on land. What motive prompted the hybrid crew to
+order back the _Emma_ as they sailed about with their hideous idol?
+What was the unknown island on which six of the _Emma's_ crew had
+died, and about which the mate Johansen was so secretive? What had the
+vice-admiralty's investigation brought out, and what was known of the
+noxious cult in Dunedin? And most marvelous of all, what deep and more
+than natural linkage of dates was this which gave a malign and now
+undeniable significance to the various turns of events so carefully
+noted by my uncle?
+
+March 1st--our February 28th according to the International Date
+Line--the earthquake and storm had come. From Dunedin the _Alert_ and
+her noisome crew had darted eagerly forth as if imperiously summoned,
+and on the other side of the earth poets and artists had begun to
+dream of a strange, dank Cyclopean city whilst a young sculptor had
+molded in his sleep the form of the dreaded Cthulhu. March 23rd the
+crew of the _Emma_ landed on an unknown island and left six men dead;
+and on that date the dreams of sensitive men assumed a heightened
+vividness and darkened with dread of a giant monster's malign pursuit,
+whilst an architect had gone mad and a sculptor had lapsed suddenly
+into delirium! And what of this storm of April 2nd--the date on which
+all dreams of the dank city ceased, and Wilcox emerged unharmed from
+the bondage of strange fever? What of all this--and of those hints of
+old Castro about the sunken, star-born Old Ones and their coming reign;
+their faithful cult _and their mastery of dreams_? Was I tottering on
+the brink of cosmic horrors beyond man's power to bear? If so, they
+must be horrors of the mind alone, for in some way the second of April
+had put a stop to whatever monstrous menace had begun its siege of
+mankind's soul.
+
+       *       *       *       *       *
+
+That evening, after a day of hurried cabling and arranging, I bade my
+host adieu and took a train for San Francisco. In less than a month
+I was in Dunedin; where, however, I found that little was known of
+the strange cult-members who had lingered in the old sea taverns.
+Waterfront scum was far too common for special mention; though there
+was vague talk about one inland trip these mongrels had made, during
+which faint drumming and red flame were noted on the distant hills.
+
+In Auckland I learned that Johansen had returned _with yellow hair
+turned white_ after a perfunctory and inconclusive questioning at
+Sydney, and had thereafter sold his cottage in West Street and sailed
+with his wife to his old home in Oslo. Of his stirring experience
+he would tell his friends no more than he had told the admiralty
+officials, and all they could do was to give me his Oslo address.
+
+After that I went to Sydney and talked profitlessly with seamen and
+members of the vice-admiralty court. I saw the _Alert_, now sold and
+in commercial use, at Circular Quay in Sydney Cove, but gained nothing
+from its non-committal bulk. The crouching image with its cuttlefish
+head, dragon body, scaly wings, and hieroglyphed pedestal, was
+preserved in the Museum at Hyde Park; and I studied it long and well,
+finding it a thing of balefully exquisite workmanship, and with the
+same utter mystery, terrible antiquity, and unearthly strangeness of
+material which I had noted in Legrasse's smaller specimen. Geologists,
+the curator told me, had found it a monstrous puzzle; for they vowed
+that the world held no rock like it. Then I thought with a shudder of
+what old Castro had told Legrasse about the primal Great Ones: "They
+had come from the stars, and had brought Their images with Them."
+
+Shaken with such a mental revolution as I had never before known, I
+now resolved to visit Mate Johansen in Oslo. Sailing for London, I
+re-embarked at once for the Norwegian capital; and one autumn day
+landed at the trim wharves in the shadow of the Egeberg.
+
+Johansen's address, I discovered, lay in the Old Town of King Harold
+Haardrada, which kept alive the name of Oslo during all the centuries
+that the greater city masqueraded as "Christiania." I made the brief
+trip by taxicab, and knocked with palpitant heart at the door of a neat
+and ancient building with plastered front. A sad-faced woman in black
+answered my summons, and I was stung with disappointment when she told
+me in halting English that Gustaf Johansen was no more.
+
+He had not long survived his return, said his wife, for the doings at
+sea in 1925 had broken him. He had told her no more than he had told
+the public, but had left a long manuscript--of "technical matters" as
+he said--written in English, evidently in order to safeguard her from
+the peril of casual perusal. During a walk through a narrow lane near
+the Gothenburg dock, a bundle of papers falling from an attic window
+had knocked him down. Two Lascar sailors at once helped him to his
+feet, but before the ambulance could reach him he was dead. Physicians
+found no adequate cause for the end, and laid it to heart trouble and a
+weakened constitution.
+
+I now felt gnawing at my vitals that dark terror which will never leave
+me till I, too, am at rest; "accidentally" or otherwise. Persuading the
+widow that my connection with her husband's "technical matters" was
+sufficient to entitle me to his manuscript, I bore the document away
+and began to read it on the London boat.
+
+It was a simple, rambling thing--a naive sailor's effort at a
+post-facto diary--and strove to recall day by day that last awful
+voyage. I can not attempt to transcribe it verbatim in all its
+cloudiness and redundance, but I will tell its gist enough to show why
+the sound of the water against the vessel's sides became so unendurable
+to me that I stopped my ears with cotton.
+
+Johansen, thank God, did not know quite all, even though he saw the
+city and the Thing, but I shall never sleep calmly again when I think
+of the horrors that lurk ceaselessly behind life in time and in space,
+and of those unhallowed blasphemies from elder stars which dream
+beneath the sea, known and favored by a nightmare cult ready and eager
+to loose them on the world whenever another earthquake shall heave
+their monstrous stone city again to the sun and air.
+
+       *       *       *       *       *
+
+Johansen's voyage had begun just as he told it to the vice-admiralty.
+The _Emma_, in ballast, had cleared Auckland on February 20th, and had
+felt the full force of that earthquake-born tempest which must have
+heaved up from the sea-bottom the horrors that filled men's dreams.
+Once more under control, the ship was making good progress when held
+up by the _Alert_ on March 22nd, and I could feel the mate's regret as
+he wrote of her bombardment and sinking. Of the swarthy cult-fiends
+on the _Alert_ he speaks with significant horror. There was some
+peculiarly abominable quality about them which made their destruction
+seem almost a duty, and Johansen shows ingenuous wonder at the charge
+of ruthlessness brought against his party during the proceedings of the
+court of inquiry. Then, driven ahead by curiosity in their captured
+yacht under Johansen's command, the men sight a great stone pillar
+sticking out of the sea, and in S. Latitude 47° 9', W. Longitude 126°
+43' come upon a coastline of mingled mud, ooze, and weedy Cyclopean
+masonry which can be nothing less than the tangible substance of
+earth's supreme terror--the nightmare corpse-city of R'lyeh, that
+was built in measureless eons behind history by the vast, loathsome
+shapes that seeped down from the dark stars. There lay great Cthulhu
+and his hordes, hidden in green slimy vaults and sending out at last,
+after cycles incalculable, the thoughts that spread fear to the dreams
+of the sensitive and called imperiously to the faithful to come on a
+pilgrimage of liberation and restoration. All this Johansen did not
+suspect, but God knows he soon saw enough!
+
+I suppose that only a single mountain-top, the hideous monolith-crowned
+citadel whereon great Cthulhu was buried, actually emerged from the
+waters. When I think of the _extent_ of all that may be brooding down
+there I almost wish to kill myself forthwith. Johansen and his men were
+awed by the cosmic majesty of this dripping Babylon of elder demons,
+and must have guessed without guidance that it was nothing of this or
+of any sane planet. Awe at the unbelievable size of the greenish stone
+blocks, at the dizzying height of the great carven monolith, and at the
+stupefying identity of the colossal statues and bas-reliefs with the
+queer image found in the shrine on the _Alert_, is poignantly visible
+in every line of the mate's frightened description.
+
+Without knowing what futurism is like, Johansen achieved something
+very close to it when he spoke of the city; for instead of describing
+any definite structure or building, he dwells only on the broad
+impressions of vast angles and stone surfaces--surfaces too great to
+belong to anything right or proper for this earth, and impious with
+horrible images and hieroglyphs. I mention his talk about _angles_
+because it suggests something Wilcox had told me of his awful dreams.
+He had said that the _geometry_ of the dream-place he saw was abnormal,
+non-Euclidean, and loathsomely redolent of spheres and dimensions apart
+from ours. Now an unlettered seaman felt the same thing whilst gazing
+at the terrible reality.
+
+Johansen and his men landed at a sloping mud-bank on this monstrous
+Acropolis, and clambered slipperily up over titan oozy blocks which
+could have been no mortal staircase. The very sun of heaven seemed
+distorted when viewed through the polarizing miasma welling out from
+this sea-soaked perversion, and twisted menace and suspense lurked
+leeringly in those crazily elusive angles of carven rock where a second
+glance showed concavity after the first showed convexity.
+
+Something very like fright had come over all the explorers before
+anything more definite than rock and ooze and weed was seen. Each
+would have fled had he not feared the scorn of the others, and it was
+only half-heartedly that they searched--vainly, as it proved--for some
+portable souvenir to bear away.
+
+It was Rodriguez the Portuguese who climbed up the foot of the monolith
+and shouted of what he had found. The rest followed him, and looked
+curiously at the immense carved door with the now familiar squid-dragon
+bas-relief. It was, Johansen said, like a great barn-door; and they all
+felt that it was a door because of the ornate lintel, threshold, and
+jambs around it, though they could not decide whether it lay flat like
+a trap-door or slantwise like an outside cellar-door. As Wilcox would
+have said, the geometry of the place was all wrong. One could not be
+sure that the sea and the ground were horizontal, hence the relative
+position of everything else seemed fantasmally variable.
+
+Briden pushed at the stone in several places without result. Then
+Donovan felt over it delicately around the edge, pressing each point
+separately as he went. He climbed interminably along the grotesque
+stone molding--that is, one would call it climbing if the thing was not
+after all horizontal--and the men wondered how any door in the universe
+could be so vast. Then, very softly and slowly, the acre-great panel
+began to give inward at the top; and they saw that it was balanced.
+
+Donovan slid or somehow propelled himself down or along the jamb and
+rejoined his fellows, and everyone watched the queer recession of the
+monstrously carven portal. In this fantasy of prismatic distortion it
+moved anomalously in a diagonal way, so that all the rules of matter
+and perspective seemed upset.
+
+The aperture was black with a darkness almost material. That
+tenebrousness was indeed a _positive quality_; for it obscured such
+parts of the inner walls as ought to have been revealed, and actually
+burst forth like smoke from its eon-long imprisonment, visibly
+darkening the sun as it slunk away into the shrunken and gibbous sky
+on flapping membranous wings. The odor arising from the newly opened
+depths was intolerable, and at length the quick-eared Hawkins thought
+he heard a nasty, slopping sound down there. Everyone listened, and
+everyone was listening still when It lumbered slobberingly into sight
+and gropingly squeezed Its gelatinous green immensity through the black
+doorway into the tainted outside air of that poison city of madness.
+
+Poor Johansen's handwriting almost gave out when he wrote of this. Of
+the six men who never reached the ship, he thinks two perished of pure
+fright in that accursed instant. The Thing can not be described--there
+is no language for such abysms of shrieking and immemorial lunacy,
+such eldritch contradictions of all matter, force, and cosmic order.
+A mountain walked or stumbled. God! What wonder that across the earth
+a great architect went mad, and poor Wilcox raved with fever in that
+telepathic instant? The Thing of the idols, the green, sticky spawn of
+the stars, had awaked to claim his own. The stars were right again, and
+what an age-old cult had failed to do by design, a band of innocent
+sailors had done by accident. After vigintillions of years great
+Cthulhu was loose again, and ravening for delight.
+
+Three men were swept up by the flabby claws before anybody turned. God
+rest them, if there be any rest in the universe. They were Donovan,
+Guerrera and Angstrom. Parker slipped as the other three were plunging
+frenziedly over endless vistas of green-crusted rock to the boat,
+and Johansen swears he was swallowed up by an angle of masonry which
+shouldn't have been there; an angle which was acute, but behaved as
+if it were obtuse. So only Briden and Johansen reached the boat, and
+pulled desperately for the _Alert_ as the mountainous monstrosity
+flopped down the slimy stones and hesitated floundering at the edge of
+the water.
+
+Steam had not been suffered to go down entirely, despite the departure
+of all hands for the shore; and it was the work of only a few moments
+of feverish rushing up and down between wheels and engines to get
+the _Alert_ under way. Slowly, amidst the distorted horrors of that
+indescribable scene, she began to churn the lethal waters; whilst on
+the masonry of that charnel shore that was not of earth the titan Thing
+from the stars slavered and gibbered like Polypheme cursing the fleeing
+ship of Odysseus. Then, bolder than the storied Cyclops, great Cthulhu
+slid greasily into the water and began to pursue with vast wave-raising
+strokes of cosmic potency. Briden looked back and went mad, laughing
+shrilly as he kept on laughing at intervals till death found him one
+night in the cabin whilst Johansen was wandering deliriously.
+
+But Johansen had not given out yet. Knowing that the Thing could
+surely overtake the _Alert_ until steam was fully up, he resolved
+on a desperate chance; and, setting the engine for full speed, ran
+lightning-like on deck and reversed the wheel. There was a mighty
+eddying and foaming in the noisome brine, and as the steam mounted
+higher and higher the brave Norwegian drove his vessel head on against
+the pursuing jelly which rose above the unclean froth like the stern
+of a demon galleon. The awful squid-head with writhing feelers came
+nearly up to the bowsprit of the sturdy yacht, but Johansen drove on
+relentlessly.
+
+There was a bursting as of an exploding bladder, a slushy nastiness
+as of a cloven sunfish, a stench as of a thousand opened graves, and
+a sound that the chronicler would not put on paper. For an instant
+the ship was befouled by an acrid and blinding green cloud, and then
+there was only a venomous seething astern; where--God in heaven!--the
+scattered plasticity of that nameless sky-spawn was nebulously
+_recombining_ in its hateful original form, whilst its distance widened
+every second as the _Alert_ gained impetus from its mounting steam.
+
+       *       *       *       *       *
+
+That was all. After that Johansen only brooded over the idol in the
+cabin and attended to a few matters of food for himself and the
+laughing maniac by his side. He did not try to navigate after the first
+bold flight, for the reaction had taken something out of his soul. Then
+came the storm of April 2nd, and a gathering of the clouds about his
+consciousness. There is a sense of spectral whirling through liquid
+gulfs of infinity, of dizzying rides through reeling universes on a
+comet's tail, and of hysterical plunges from the pit to the moon and
+from the moon back again to the pit, all livened by a cachinnating
+chorus of the distorted, hilarious elder gods and the green, bat-winged
+mocking imps of Tartarus.
+
+Out of that dream came rescue--the _Vigilant_, the vice-admiralty
+court, the streets of Dunedin, and the long voyage back home to the
+old house by the Egeberg. He could not tell--they would think him mad.
+He would write of what he knew before death came, but his wife must not
+guess. Death would be a boon if only it could blot out the memories.
+
+That was the document I read, and now I have placed it in the tin box
+beside the bas-relief and the papers of Professor Angell. With it shall
+go this record of mine--this test of my own sanity, wherein is pieced
+together that which I hope may never be pieced together again. I have
+looked upon all that the universe has to hold of horror, and even the
+skies of spring and the flowers of summer must ever afterward be poison
+to me. But I do not think my life will be long. As my uncle went, as
+poor Johansen went, so I shall go. I know too much, and the cult still
+lives.
+
+Cthulhu still lives, too, I suppose, again in that chasm of stone
+which has shielded him since the sun was young. His accursed city is
+sunken once more, for the _Vigilant_ sailed over the spot after the
+April storm; but his ministers on earth still bellow and prance and
+slay around idol-capped monoliths in lonely places. He must have been
+trapped by the sinking whilst within his black abyss, or else the world
+would by now be screaming with fright and frenzy. Who knows the end?
+What has risen may sink, and what has sunk may rise. Loathsomeness
+waits and dreams in the deep, and decay spreads over the tottering
+cities of men. A time will come--but I must not and can not think! Let
+me pray that, if I do not survive this manuscript, my executors may put
+caution before audacity and see that it meets no other eye.
+
+                       The Shadow Over Innsmouth
+
+                        _Horrifying Novelette_
+
+                          By H. P. LOVECRAFT
+
+                 _Unspeakable monstrousness over-hung
+                 the crumbling, stench-cursed town of
+               Innsmouth ... and folks there had somehow
+                   got out of the idea of dying...._
+
+           [Transcriber's Note: This etext was produced from
+                       Weird Tales January 1942.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+
+During the winter of 1927-28 Federal government officials made a
+strange and secret investigation of certain conditions in the ancient
+Massachusetts seaport of Innsmouth. The public first learned of it in
+February, when a vast series of raids and arrests occurred, followed by
+the deliberate burning and dynamiting--under suitable precautions--of
+an enormous number of crumbling, worm-eaten, and supposedly empty
+houses along the abandoned waterfront. Uninquiring souls let this
+occurrence pass as one of the major clashes in a spasmodic war on
+liquor.
+
+Keener news-followers, however, wondered at the prodigious number of
+arrests, the abnormally large force of men used in making them, and
+the secrecy surrounding the disposal of the prisoners. No trials, or
+even definite charges, were reported; nor were any of the captives
+seen thereafter in the regular jails of the nation. There were vague
+statements about disease and concentration camps, and later about
+dispersal in various naval and military prisons, but nothing positive
+ever developed.
+
+Complaints from many liberal organizations were met with long
+confidential discussions, and representatives were taken on trips
+to certain camps and prisons. As a result, these societies became
+surprisingly passive and reticent. Newspaper men were harder to
+manage, but seemed largely to cooperate with the government in the
+end. Only one paper--a tabloid always discounted because of its
+wild policy--mentioned the deep-diving submarine that discharged
+torpedoes downward in the marine abyss just beyond Devil Reef. That
+item, gathered by chance in a haunt of sailors, seemed indeed rather
+far-fetched; since the low, black reef lies a full mile and a half out
+from Innsmouth Harbor.
+
+But at last I am going to defy the ban on speech about this thing.
+Results, I am certain, are so thorough that no public harm save a shock
+of repulsion could ever accrue from a hinting of what was found by
+those horrified raiders at Innsmouth. For my contact with this affair
+has been closer than that of any other layman, and I have carried away
+impressions which are yet to drive me to drastic measures.
+
+It was I who fled frantically out of Innsmouth in the early morning
+hours of July 16, 1927, and whose frightened appeals for government
+inquiry and action brought on the whole reported episode. I was willing
+enough to stay mute while the affair was fresh and uncertain; but now
+that it is an old story, with public interest and curiosity gone, I
+have an odd craving to whisper about those few frightful hours in
+that ill-rumored and evilly-shadowed seaport of death and blasphemous
+abnormality.
+
+I never heard of Innsmouth till the day before I saw it for the first
+and--so far--last time. I was celebrating my coming of age by a tour
+of New England--sightseeing, antiquarian, and genealogical--and had
+planned to go directly from ancient Newburyport to Arkham, whence my
+mother's family was derived. I had no car, but was traveling by train,
+trolley, and motor-coach, always seeking the cheapest possible route.
+In Newburyport they told me that the steam train was the thing to
+take to Arkham; and it was only at the station ticket-office, when I
+demurred at the high fare, that I learned about Innsmouth. The stout,
+shrewd-faced agent, whose speech showed him to be no local man, seemed
+sympathetic toward my efforts at economy, and made a suggestion that
+none of my other informants had offered.
+
+"You _could_ take that old bus, I suppose," he said with a certain
+hesitation, "but it ain't thought much of hereabouts. It goes through
+Innsmouth--you may have heard about that--and so the people don't
+like it. Run by an Innsmouth fellow--Joe Sargent--but never gets any
+custom from here, or Arkham either, I guess. Leaves the Square--front
+of Hammond's Drug Store--at 10 A.M. and 7 P.M. unless they've changed
+lately. Looks like a terrible rattletrap--I've never been on it."
+
+That was the first I ever heard of shadowed Innsmouth. Any reference
+to a town not shown on common maps or listed in recent guidebooks
+would have interested me, and the agent's old manner of allusion
+roused something like real curiosity. So I asked the agent to tell me
+something about it.
+
+He was very deliberate, and spoke with an air of feeling slightly
+superior to what he said.
+
+"Innsmouth? Well, it's a queer kind of town down at the mouth of
+the Manuxet. Used to be almost a city--quite a port before the War
+of 1812--but all gone to pieces in the last hundred years or so. No
+railroad now--B. & M. never went through, and the branch line from
+Rowley was given up years ago.
+
+"More empty houses than there are people, I guess, and no business to
+speak of except fishing and lobstering. Everybody trades mostly either
+here or in Arkham or Ipswich. Once they had quite a few mills, but
+nothing's left now except one gold refinery running on the leanest kind
+of part time.
+
+"That refinery, though, used to be a big thing, and Old Man Marsh,
+who owns it, must be richer'n Croesus. Queer old duck, though, and
+sticks mighty close in his home. He's supposed to have developed
+some skin disease or deformity late in life that makes him keep out
+of sight. Grandson of Captain Obed Marsh, who founded the business.
+His mother seems to've been some kind of foreigner--they say a South
+Sea islander--so everybody raised Cain when he married an Ipswich
+girl fifty years ago. They always do that about Innsmouth people, and
+folks here and hereabouts always try to cover up any Innsmouth blood
+they have in 'em. But Marsh's children and grandchildren look just
+like anybody else so far's I can see. I've had 'em pointed out to me
+here--though, come to think of it, the elder children don't seem to be
+around lately. Never saw the old man.
+
+"And why is everybody so down on Innsmouth? Well, young fellow, you
+mustn't take too much stock in what people around here say. They're
+hard to get started, but once they do get started they never let
+up. They've been telling things about Innsmouth--whispering 'em,
+mostly--for the last hundred years, I guess, and I gather they're
+more scared than anything else. Some of the stories would make you
+laugh--about old Captain Marsh driving bargains with the devil and
+bringing imps out of hell to live in Innsmouth, or about some kind of
+devil-worship and awful sacrifices in some place near the wharves that
+people stumbled on around 1845 or there-abouts--but I come from Panton,
+Vermont, and that kind of story don't go down with me.
+
+"You ought to hear, though, what some of the old-timers tell about
+the black reef off the coast--Devil Reef, they call it. It's well
+above water a good part of the time, and never much below it, but at
+that you could hardly call it an island. The story is that there's a
+whole legion of devils seen sometimes on that reef--sprawled about,
+or darting in and out of some kind of caves near the top. It's a
+rugged, uneven thing, a good bit over a mile out, and toward the end of
+shipping days sailors used to make big detours just to avoid it.
+
+"That is, sailors that didn't hail from Innsmouth. One of the things
+they had against old Captain Marsh was that he was supposed to land on
+it sometimes at night when the tide was right. Maybe he did, for I dare
+say the rock formation was interesting, and it's just barely possible
+he was looking for pirate loot and maybe finding it; but there was talk
+of his dealing with demons there. Fact is, I guess on the whole it was
+really the captain that gave the bad reputation to the reef.
+
+"That was before the big epidemic of 1846, when over half the folks
+in Innsmouth was carried off. They never did quite figure out what
+the trouble was, but it was probably some foreign kind of disease
+brought from China or somewhere by the shipping. It surely was bad
+enough--there was riots over it, and all sorts of ghastly doings that I
+don't believe ever got outside of town--and it left the place in awful
+shape. Never came back--there can't be more'n 300 or 400 people living
+there now.
+
+"But the real thing behind the way folks feel is simply race
+prejudice--and I don't say I'm blaming those that hold it. I hate
+those Innsmouth folks myself, and I wouldn't care to go to their
+town. I s'pose you know--though I can see you're a Westerner by your
+talk--what a lot our New England ships used to have to do with queer
+ports in Africa, Asia, the South Seas, and everywhere else, and what
+queer kinds of people they sometimes brought back with 'em. You've
+probably heard about the Salem man that came home with a Chinese wife,
+and maybe you know there's still a bunch of Fiji Islanders somewhere
+around Cape Cod.
+
+"Well, there must be something like that back of the Innsmouth people.
+The place always was badly cut off from the rest of the country by
+marshes and creeks, and we can't be sure about the ins and outs of
+the matter; but it's pretty clear that old Captain Marsh must have
+brought home some odd specimens when he had all three of his ships in
+commission back in the twenties and thirties. There certainly is a
+strange kind of a streak in the Innsmouth folks today--I don't know how
+to explain it, but it sort of makes you crawl. You'll notice a little
+in Sargent if you take his bus. Some of 'em have queer narrow heads
+with flat noses and bulgy, starey eyes that never seem to shut, and
+their skin ain't quite right. Rough and scabby, and the sides of their
+necks are all shriveled or creased up. Get bald, too, very young. The
+older fellows look the worst--fact is, I don't believe I've ever seen
+a very old chap of that kind. Guess they must die of looking in the
+glass! Animals hate 'em--they used to have lots of horse trouble before
+autos came in.
+
+"Nobody can ever keep track of those people, and state school officials
+and census men have a devil of a time. You can bet that prying
+strangers ain't welcome around Innsmouth. I've heard personally of
+more'n one business or government man that's disappeared there, and
+there's loose talk of one who went crazy and is out at Danvers now.
+They must have fixed up some awful scare for that fellow.
+
+"That's why I wouldn't go at night if I was you. I've never been there
+and have no wish to go, but I guess a daytime trip couldn't hurt
+you--even though the people hereabouts will advise you not to make it.
+If you're just sightseeing, and looking for old-time stuff, Innsmouth
+ought to be quite a place for you."
+
+And so I spent part of that evening at the Newburyport Public Library
+looking up data about Innsmouth. The Essex County histories on the
+library shelves had very little to say, except that the town was
+founded in 1643, noted for shipbuilding before the Revolution, a seat
+of great marine prosperity in the early 19th century, and later a minor
+factory center using the Manuxet as power. The epidemic and riots of
+1846 were very sparsely treated, as if they formed a discredit to the
+country.
+
+References to decline were few, though the significance of the later
+record was unmistakable. After the Civil War all industrial life was
+confined to the Marsh Refining Company, and the marketing of gold
+ingots formed the only remaining bit of major commerce aside from the
+eternal fishing.
+
+Most interesting of all was a glancing reference to the strange jewelry
+vaguely associated with Innsmouth. It had evidently impressed the whole
+countryside more than a little, for mention was made of specimens in
+the museum of Miskatonic University at Arkham, and in the display room
+of the Newburyport Historical Society. I resolved to see the local
+sample--said to be a large, queerly-proportioned thing evidently meant
+for a tiara--if it could possibly be arranged.
+
+The librarian gave me a note of introduction to the curator of the
+Society, a Miss Anna Tilton, who lived nearby, and after a brief
+explanation that ancient gentlewoman was kind enough to pilot me into
+the closed building, since the hour was not outrageously late. The
+collection was a notable one indeed, but in my present mood I had eyes
+for nothing but the bizarre object which glistened in a corner cupboard
+under the electric lights.
+
+It took no excessive sensitiveness to beauty to make me literally gasp
+at the strange, unearthly splendor of the alien, opulent phantasy that
+rested there on a purple velvet cushion. The longer I looked, the more
+the thing fascinated me; and in this fascination there was a curiously
+disturbing element hardly to be classified or accounted for. I decided
+that it was the queer other-worldly quality of the art which made me
+uneasy. It was as if the workmanship were that of another planet.
+
+The patterns all hinted of remote secrets and unimaginable abysses in
+time and space, and the monotonously aquatic nature of the reliefs
+became almost sinister. Among these reliefs were fabulous monsters of
+abhorrent grotesqueness and malignity--wholly primal and awesomely
+ancestral.
+
+At times I fancied that every contour of these blasphemous fish-frogs
+was overflowing with the ultimate quintessence of unknown and inhuman
+evil.
+
+In odd contrast to the tiara's aspect was its brief and prosy history
+as related by Miss Tilton. It had been pawned for a ridiculous sum at
+a shop in State Street in 1873, by a drunken Innsmouth man shortly
+afterward killed in a brawl.
+
+Miss Tilton was inclined to believe that it formed part of some exotic
+pirate hoard discovered by old Captain Obed Marsh. This view was surely
+not weakened by the insistent offers of purchase at a high price
+which the Marshes began to make as soon as they knew of its presence,
+and which they repeated to this day despite the Society's unvarying
+determination not to sell.
+
+As the good lady showed me out of the building, she assured me that the
+rumors of devil-worship were partly justified by a peculiar secret cult
+which had gained force there and engulfed all the orthodox churches.
+
+It was called, she said, "The Esoteric Order of Dagon," and was
+undoubtedly a debased, quasi-pagan thing imported from the East a
+century before, at a time when Innsmouth fisheries seemed to be going
+barren. Its persistence among a simple people was quite natural in view
+of the sudden and permanent return of abundantly fine fishing, and it
+soon came to be the greatest influence on the town.
+
+All this, to the pious Miss Tilton, formed an excellent reason for
+shunning the ancient town of decay and desolation; but to me it was
+merely a fresh incentive; and I could scarcely sleep in my small room
+at the "Y" as the night wore away.
+
+
+
+
+                                  II
+
+
+Shortly before ten the next morning I stood with my one small valise
+in front of Hammond's Drug Store in old Market Square waiting for
+the Innsmouth bus. In a few moments a small motor-coach of extreme
+decrepitude and dirty gray color rattled down State Street, made a
+turn, and drew up at the curb beside me. I felt immediately that
+it was the right one; a guess which the half-illegible sign on the
+windshield--"_Arkham-Innsmouth-Newb'port_"--soon verified.
+
+There were only three passengers--dark, unkempt men of sullen visage
+and somewhat youthful cast--and when the vehicle stopped they clumsily
+shambled out and began walking up State Street in a silent, almost
+furtive fashion. The driver also alighted. This, I reflected, must be
+the Joe Sargent mentioned by the ticket-agent; and even before I had
+noticed any details there spread over me a wave of spontaneous aversion
+which could be neither checked nor explained.
+
+He was a thin, stoop-shouldered man not much under six feet tall,
+dressed in shabby blue civilian clothes and wearing a frayed gray golf
+cap. His age was perhaps thirty-five, but the odd, deep creases in the
+sides of his neck made him seem older when one did not study his dull,
+expressionless face. He had a narrow head, bulging, watery blue eyes
+that seemed never to wink, a flat nose, a receding forehead and chin,
+and singularly undeveloped ears. As he walked toward the bus I observed
+his peculiarly shambling gait and saw that his feet were inordinately
+immense. The more I studied them the more I wondered how he could buy
+any shoes to fit them.
+
+A certain greasiness about the fellow increased my dislike. He was
+evidently given to working or lounging around the fish docks, and
+carried with him much of their characteristic smell. Just what foreign
+blood was in him I could not even guess.
+
+I was sorry when I saw that there would be no other passengers on the
+bus. Somehow I did not like the idea of riding alone with this driver.
+But as the leaving time obviously approached I conquered my qualms and
+followed the man aboard, extending him a dollar bill and murmuring the
+single word "Innsmouth."
+
+At length the decrepit vehicle started with a jerk, and rattled noisily
+past the old brick buildings of State Street amidst a cloud of vapor
+from the exhaust.
+
+The day was warm and sunny, but the landscape of sand, sedge-grass,
+and stunted shrubbery became more and more desolate as we proceeded.
+Out the window I could see the blue water and the sandy line of Plum
+Island, and we presently drew very near the beach as our narrow road
+veered off from the main highway to Rowley and Ipswich.
+
+At last we lost sight of Plum Island and saw the vast expanse of the
+open Atlantic on our left. Our narrow course began to climb steeply,
+and I felt a singular sense of disquiet in looking at the lonely crest
+ahead where the rutted roadway met the sky. It was as if the bus were
+about to keep on its ascent leaving the sane earth altogether and
+merging with the unknown arcana of upper air and cryptical sky. The
+smell of the sea took on ominous implications, and the silent driver's
+bent, rigid back and narrow head became more and more hateful. As I
+looked at him I saw that the back of his head was almost as hairless
+as his face, having only a few straggling yellow strands upon a gray
+scabrous surface.
+
+Then we reached the crest and beheld the outspread valley beyond,
+where the Manuxet joins the sea just north of the long line of cliffs
+that culminate in Kingsport Head; all my attention was captured by the
+nearer panorama just below me. I had, I realized, come face to face
+with rumor-shadowed Innsmouth.
+
+It was a town of wide extent and dense construction, yet one with a
+portentous dearth of visible life. The vast huddle of sagging gambrel
+roofs and peaked gables conveyed with offensive clearness the idea
+of wormy decay, and as we approached along the now descending road I
+could see that many roofs had wholly caved in. Stretching inland I saw
+the rusted, grass-grown line of the abandoned railway, with leaning
+telegraph-poles now devoid of wires.
+
+Here and there the ruins of wharves jutted out from the shore to end
+in indeterminate rottenness, those farthest south seeming the most
+decayed. And far out at sea, despite a high tide, I glimpsed a long,
+black line scarcely rising above the water yet carrying a suggestion of
+odd latent malignancy. This, I knew, must be Devil Reef. As I looked,
+a subtle, curious sense of beckoning seemed superadded to the grim
+repulsion; and oddly enough, I found this overtone more disturbing than
+the primary impression.
+
+As the bus reached a lower level I began to catch the steady note of
+a waterfall through the unnatural stillness. The leaning, unpainted
+houses grew thicker, lined both sides of the road, and displayed more
+urban tendencies than did those we were leaving behind. The panorama
+ahead had contracted to a street scene, and in spots I could see
+where a cobblestone pavement and stretches of brick sidewalk had
+formerly existed. All the houses were apparently deserted, and there
+were occasional gaps where tumbledown chimneys and cellar walls told
+of buildings that had collapsed. Pervading everything was the most
+nauseous fishy odor imaginable.
+
+And I was not to reach my destination without one other very strong
+impression of poignantly disagreeable quality. The bus had come to a
+sort of open concourse or radial point with churches on two sides and
+the bedraggled remains of a circular green in the center, and I was
+looking at a large pillared hall on the right-hand junction ahead. The
+structure's once white paint was now gray and peeling, and the black
+and gold sign on the pediment was so faded that I could only with
+difficulty make out the words "Esoteric Order of Dagon."
+
+The door of the church basement was open, revealing a rectangle of
+blackness inside. And as I looked, a certain object crossed or seemed
+to cross that dark rectangle; burning into my brain a momentary
+conception of nightmare which was all the more maddening because
+analysis could not show a single nightmarish quality in it.
+
+It was a living object--the first except the driver that I had seen
+since entering the compact part of the town--and had I been in a
+steadier mood I would have found nothing whatever of terror in it.
+Clearly, as I realized a moment later, it was the pastor; clad in
+some peculiar vestments doubtless introduced since the Order of Dagon
+had modified the ritual of the local churches. The thing which had
+probably caught my first subconscious glance and supplied the touch of
+bizarre horror was the tall tiara he wore; an almost exact duplicate
+of the one Miss Tilton had shown me the previous evening. This, acting
+on my imagination, had supplied namelessly sinister qualities to the
+indeterminate face and robed, shambling form beneath it.
+
+A very thin sprinkling of repellent-looking youngish people now became
+visible on the sidewalks--lone individuals, and silent knots of two
+or three. The lower floors of the crumbling houses sometimes harbored
+small shops with dingy signs, and I noticed a parked truck or two as we
+rattled along. The sound of waterfalls became more and more distinct,
+and presently I saw a fairly deep river-gorge ahead, spanned by a wide,
+iron-railed highway bridge beyond which a large square opened out. Then
+we rolled into the large semicircular square across the river and drew
+up on the right-hand side in front of a tall, cupola-crowned building
+with remnants of yellow paint and with a half-effaced sign proclaiming
+it to be the Gilman House.
+
+I was glad to get out of that bus, and at once proceeded to check
+my valise in the shabby hotel lobby. There was only one person in
+sight--an elderly man without what I had come to call the "Innsmouth
+look"--and I decided not to ask him any of the questions which bothered
+me; remembering that odd things had been noticed in this hotel.
+Instead, I strolled out on the square, from which the bus had already
+gone, and studied the scene minutely and appraisingly.
+
+For some reason or other I chose to make my first inquiries at
+the chain grocery, whose personnel was not likely to be native to
+Innsmouth. I found a solitary boy of about seventeen in charge, and was
+pleased to note the brightness and affability which promised cheerful
+information. He seemed exceptionally eager to talk, and I soon gathered
+that he did not like the place, its fishy smell, or its furtive people.
+His family did not like him to work in Innsmouth, but the chain had
+transferred him there and he did not wish to give up his job.
+
+There was, he said, no public library or chamber of commerce in
+Innsmouth, but I could probably find my way about. The street I had
+come down was Federal. West of that were the fine old residence
+streets--Broad, Washington, Lafayette, and Adams--and east of it were
+the shoreward slums.
+
+Certain spots were almost forbidden territory, as he had learned at
+considerable cost. One must not, for example, linger much around the
+Marsh refinery, or around any of the still used churches, or around the
+pillared Order of Dagon Hall at New Church Green. Those churches were
+very odd--all violently disavowed by their respective denominations
+elsewhere, and apparently using the queerest kind of ceremonials and
+clerical vestments.
+
+As for the Innsmouth people--the youth hardly knew what to make of
+them. Their appearance--especially those staring, unwinking eyes which
+one never saw shut--was certainly shocking enough--and their voices
+were disgusting. It was awful to hear them chanting in their churches
+at night, and especially during their main festivals or revivals, which
+fell twice a year on April 30 and October 31.
+
+They were very fond of the water, and swam a great deal in both river
+and harbor. Swimming races out to Devil Reef were very common, and
+everyone in sight seemed well able to share in this arduous sport.
+
+It would be of no use, my informant said, to ask the natives anything
+about the place. The only one who would talk was a very aged but
+normal-looking man who lived at the poorhouse on the north rim of the
+town and spent his time walking about or lounging around the fire
+station. This hoary character, Zadok Allen, was 96 years old and
+somewhat touched in the head, besides being the town drunkard. He was a
+strange, furtive creature who constantly looked over his shoulder as
+if afraid of something, and when sober could not be persuaded to talk
+at all with strangers. He was, however, unable to resist any offer of
+his favorite poison; and once drunk would furnish the most astonishing
+fragments of whispered reminiscence.
+
+After all, though, little useful data could be gained from him; since
+his stories were all insane, incomplete hints of impossible marvels and
+horrors which could have no source save in his own distorted fancy.
+Nobody ever believed him, but the natives did not like him to drink
+and talk with any strangers; and it was not always safe to be seen
+questioning him. It was probably from him that some of the wildest
+popular whispers and delusions were derived.
+
+The Marshes, together with the other three gently bred families of the
+town--the Waites, the Gilmans, and the Eliots--were all very retiring.
+They lived in immense houses along Washington Street, and several were
+reputed to harbor in concealment certain kinsfolk whose personal aspect
+forbade public view, and whose deaths had been reported and recorded.
+
+Warning me that most of the street signs were down, the youth drew for
+my benefit a rough but ample and painstaking sketch map of the town's
+salient features. After a moment's study I felt sure that it would be
+of great help, and pocketed it with profuse thanks.
+
+Thus began my systematic though half-bewildered tour of Innsmouth's
+narrow, shadow-blighted ways. Crossing the bridge and turning toward
+the roar of the lower falls, I passed close to the Marsh refinery,
+which seemed oddly free from the noise of industry. This building
+stood on the steep river bluff near a bridge and an open confluence of
+streets which I took to be the earliest civic center, displaced after
+the Revolution by the present Town Square.
+
+Re-crossing the gorge on the Main Street bridge, I struck a region of
+utter desertion which somehow made me shudder. Collapsing huddles of
+gambrel roofs formed a jagged and fantastic skyline, above which rose
+the ghoulish, decapitated steeple of an ancient church.
+
+Fish Street was as deserted as Main, though it differed in having many
+brick and stone warehouses still in excellent shape. Water Street
+was almost its duplicate, save that there were great seaward gaps
+where wharves had been. Not a living thing did I see, except for the
+scattered fishermen on the distant breakwater, and not a sound did I
+hear save the lapping of the harbor tides and the roar of the falls in
+the Manuxet.
+
+I kept north along Main to Martin, then turning inland, crossing
+Federal Street safely north of the Green, and entering the decayed
+patrician neighborhood of northern Broad, Washington, Lafayette, and
+Adams Streets. Following Washington Street toward the river, I now
+faced a zone of former industry and commerce; noting the ruins of a
+factory ahead, and seeing others, with the traces of an old railway
+station and covered railway bridge beyond up the gorge on my right.
+
+The uncertain bridge now before me was posted with a warning sign,
+but I took the risk and crossed again to the south bank where traces
+of life reappeared. Furtive, shambling creatures stared cryptically
+in my direction, and more normal faces eyed me coldly and curiously.
+Innsmouth was rapidly becoming intolerable, and I turned down Paine
+Street toward the Square in the hope of getting some vehicle to take me
+to Arkham before the still-distant starting time of that sinister bus.
+
+It was then that I saw the tumbledown fire station on my left,
+and noticed the red-faced, bushy-bearded, watery-eyed old man in
+nondescript rags who sat on a bench in front of it talking with a pair
+of unkempt but not abnormal-looking firemen. This, of course, must be
+Zadok Allen, the half-crazed, liquorish non-agenarian whose tales of
+old Innsmouth and its shadow were so hideous and incredible.
+
+
+
+
+                                  III
+
+
+I had been assured that the old man could do nothing but hint at wild,
+disjointed, and incredible legends, and I had been warned that the
+natives made it unsafe to be seen talking with him; yet the thought
+of this aged witness to the town's decay, with memories going back to
+the early days of ships and factories, was a _lure_ that no amount
+of reason could make me resist. Curiosity flared up beyond sense and
+caution, and in my youthful egotism I fancied I might be able to sift
+a nucleus of real history from the confused, extravagant outpouring I
+would probably extract with the aid of whiskey.
+
+A quart bottle of such was easily, though not cheaply, obtained in the
+rear of a dingy variety-store just off the Square in Eliot Street.
+
+Re-entering the Square I saw that luck was with me; for--shuffling
+out of Paine Street around the corner of the Gilman House--I glimpsed
+nothing less than the tall, lean, tattered form of old Zadok Allen
+himself. In accordance with my plan, I attracted his attention by
+brandishing my newly-purchased bottle; and soon realized that he had
+begun to shuffle wistfully after me as I turned into Waite Street on my
+way to the most deserted region I could think of. Before I reached Main
+Street I could hear a faint and wheezy "Hey, Mister!" behind me, and I
+presently allowed the old man to catch up and take copious pulls from
+the quart bottle.
+
+I began putting out feelers as we walked along to Water Street and
+turned southward amidst the omnipresent desolation and crazily tilted
+ruins, but found that the aged tongue did not loosen as quickly
+as I had expected. At length I saw a grass-grown opening toward
+the sea between crumbling brick walls, with the weedy length of an
+earth-and-masonry wharf projecting beyond. Piles of moss-covered stones
+near the water promised tolerable seats, and the scene was sheltered
+from all possible view by a ruined warehouse on the north.
+
+About four hours remained for conversation if I were to catch the eight
+o'clock coach for Arkham, and I began to dole out more liquor to the
+ancient tippler; meanwhile eating my own frugal lunch. In my donations
+I was careful not to overshoot the mark, for I did not wish Zadok's
+vinous garrulousness to pass into a stupor. After an hour his furtive
+taciturnity showed signs of disappearing, and something or other had
+caused his wandering gaze to light on the low, distant line of Devil
+Reef, then showing plainly and almost fascinatingly above the waves. He
+bent toward me, took hold of my coat lapel, and hissed out some hints
+that could not be mistaken.
+
+"Thar's whar it all begun--that cursed place of all wickedness whar
+the deep water starts. Gate o' hell--sheer drop daown to a bottom no
+saoundin'-line kin tech. Ol' Cap'n Obed done it--him that faound aout
+more'n was good fer him in the Saouth Sea islands.
+
+"Never was nobody like Cap'n Obed--old limb o' Satan! Heh, heh! I kin
+mind him a-tellin' abaout furren parts, an' callin' all the folks
+stupid fer goin' to Christian meetin' an' bearin' their burdens meek
+an' lowly. Says they'd orter git better gods like some o' the folks
+in the Injies--gods as ud bring 'em good fishin' in return fer their
+sacrifices, an' ud reely answer folks's prayers.
+
+"Matt Eliot, his fust mate, talked a lot, too, only he was agin'
+folks's doin' any heathen things. Told abaout an island east of
+Othaheite whar they was a lot o' stone ruins older'n anybody knew
+anything abaout, kind o' like them on Ponape, in the Carolines, but
+with carvin's of faces that looked like the big statues on Easter
+Island. They was a little volcanic island near thar, too, whar they was
+other ruins with diff'rent carvin's--ruins all wore away like they'd
+ben under the sea onct, an' with picters of awful monsters all over 'em.
+
+"Wal, Sir, Matt he says the natives araound thar had all the fish they
+cud ketch, an' sported bracelets an' armlets an' head rigs made aout
+of a queer kind o' gold an' covered with picters o' monsters jest like
+the ones carved over the ruins on the little island--sorter fishlike
+frogs or froglike fishes that was drawed in all kinds o' positions
+like they was human bein's. Nobody cud git aout o' them whar they got
+all the stuff, an' all the other natives wondered haow they managed to
+find fish in plenty even when the very next islands had lean pickin's.
+Matt he got to wonderin' too, an' so did Cap'n Obed. Obed, he notices,
+besides, that lots of the han'some young folks ud drop aout o' sight
+fer good from year to year, an' that they wan't many old folk araound.
+Also, he thinks some of the folks looks durned queer even fer Kanakys.
+
+"It took Obed to git the truth aout o' them heathens. I dun't know haow
+he done it, but he begun by tradin' fer the gold-like things they wore.
+Ast 'em whar they come from, an' ef they cud git more, an' finally
+wormed the story aout o' the old chief--Walakea, they called him.
+Nobody but Obed ud ever a believed the old yeller devil, but the Cap'n
+cud read folks like they was books. Heh, heh! Nobody never believes me
+naow when I tell 'em, an I dun't s'pose you will, young feller--though
+come to look at ye, ye hev kind o' got them sharp-readin' eyes like
+Obed had."
+
+The old man's whisper grew fainter, and I found myself shuddering at
+the terrible and sincere portentousness of his intonation, even though
+I knew his tale could be nothing but drunken phantasy.
+
+"Wal, Sir, Obed he larnt that they's things on this arth as most folks
+never heard abaout--an' wouldn't believe ef they did hear. It seems
+these Kanakys was sacrificin' heaps o' their young men an' maidens to
+some kind o' god-things that lived under the sea, an' gittin' all kinds
+o' favors in return. They met the things on the little islet with the
+queer ruins, an' it seems them awful picters o' frog-fish monsters was
+supposed to be picters o' these things. Mebbe they was the kind o'
+critters as got all the mermaids stories an' sech started. They had all
+kinds o' cities on the sea-bottom, an' this island was heaved up from
+thar. Seems they was some of the things alive in the stone buildin's
+when the island come up sudden to the surface. That's haow the Kanakys
+got wind they was daown thar. Made sign-talk as soon as they got over
+bein' skeert, an' pieced up a bargain afore long.
+
+"Them things liked human sacrifices. Had had 'em ages afore, but
+lost track o' the upper world arter a time. What they done to the
+victims it ain't fer me to say, an' I guess Obed wa'n't none too
+sharp abaout askin'. But it was all right with the heathens, because
+they'd ben havin' a hard time an' was desp'rate abaout everything.
+They give a sarten number o' young folks to the sea-things twict every
+year--May-Eve an' Hallowe'en--reg'lar as cud be. Also give some o' the
+carved knick-knacks they made. What the things agreed to give in return
+was a plenty o' fish--they druv 'em in from all over the sea--an' a few
+gold-like things naow an' then.
+
+"When it come to matin' with them toad-lookin' fishes, the Kanakys
+kind o' balked, but finally they larnt something as put a new face
+on the matter. Seems that human folks has got a kind o' relation to
+sech water-beasts--that everything alive come aout o' the water onct,
+an' only needs a little change to go back agin. Them things told the
+Kanakys that ef they mixed bloods there'd be children as ud look human
+at fust, but later turn more'n more like the things, till finally
+they'd take to the water an' jine the main lot o' things daown thar.
+An' this is the important part, young feller--them as turned into fish
+things an' went into the water _wouldn't never die_. Them things never
+died excep' they was kilt violent.
+
+"Wal, Sir, it seems by the time Obed knowed them islanders they was all
+full o' fish blood from them deep-water things. When they got old an'
+begun to show it, they was kep' hid until they felt like takin' to the
+water an' quittin' the place. Some was more teched than others, an'
+some never did change quite enough to take to the water; but mostly
+they turned aout jest the way them things said. Them as was born more
+like the things changed arly, but them as was nearly human sometimes
+stayed on the island till they was past seventy, though they'd usually
+go daown under fer trial trips afore that. Folks as had took to the
+water, gen'rally come back a good deal to visit, so's a man ud often be
+a-talkin' to his own five-times-great-grandfather, who'd left the dry
+land a couple o' hundred years or so afore.
+
+"Everybody got aout o' the idee o' dyin'--excep' in canoe wars with
+the other islanders, or as sacrifices to the sea-gods daown below, or
+from snake-bite or plague or sharp gallopin' ailments or somethin'
+afore they cud take to the water--but simply looked forrad to a kind
+o' change that wa'n't a bit horrible arter a while. They thought what
+they'd got was well wuth all they'd had to give up--an' I guess Obed
+kind o' come to think the same hisself when he'd chewed over old
+Walakea's story a bit. Walakea, though, was one of the few as hadn't
+got none of the fish blood--bein' of a royal line that intermarried
+with royal lines on other islands.
+
+"Walakea give him a funny kind o' thingumajig made aout o' lead or
+something, that he said ud bring up the fish things from any place in
+the water whar they might be a nest of 'em. The idee was to drop it
+daown with the right kind o' prayers an' sech. Walakea allaowed as was
+the things was scattered all over the world, so's anybody that looked
+abaout cud find a nest an' bring 'em up ef they was wanted.
+
+"Matt he didn't like this business at all, an' wanted Obed shud keep
+away from the island; but the Cap'n was sharp fer gain, an' faound
+he cud git them gold-like things so cheap it ud pay him to make a
+specialty of 'em.
+
+"Things went on that way fer years, an' Obed got enough o' that
+gold-like stuff to make him start the refinery in Waite's old run-daown
+fullin' mill.
+
+"Wall, come abaout 'thutty-eight--when I was seven year' old--Obed he
+faound the island people all wiped aout between v'yages. Seems the
+other islanders had got wind o' what was goin' on, an' had took matters
+into their own hands. S'pose they must a had, arter all, them old magic
+signs as the sea things says was the only things they was afeard of. No
+tellin' what any o' them Kanakys will chance to git a holt of when the
+sea-bottom throws up some island with ruins older'n the deluge. Pious
+cusses, these was--they didn't leave nothin' standin' on either the
+main island or the little volcanic islet excep' what parts of the ruins
+was too big to knock daown.
+
+"That naturally hit Obed pretty hard, seein' as his normal trade
+was doin' very poor. It hit the whole of Innsmouth, too, because in
+seafarin' days what profited the master of a ship gen'lly profited the
+crew proportionate. Most o' the folks araound the taown took the hard
+times kind o' sheeplike an' resigned, but they was in bad shape because
+the fishin' was peterin' aout an' the mills wa'n't doin' none too well.
+
+"Then's the time Obed he begun a-cursin' at the folks fer bein' dull
+sheep an' prayin' to a Christian heaven as didn't help 'em none. He
+told 'em he'd knowed of folks as prayed to gods that give somethin' ye
+reely need, an' says ef a good bunch o' men ud stand by him, he cud
+mebbe git a holt o' sarten paowers as ud bring plenty o' fish an' quite
+a bit o' gold."
+
+Here the old man faltered, mumbled, and lapsed into a moody and
+apprehensive silence; glancing nervously over his shoulder and then
+turning back to stare fascinatedly at the distant black reef. When
+I spoke to him he did not answer, so I knew I would have to let him
+finish the bottle. He licked its nose and slipped it into his pocket,
+then beginning to nod and whisper softly to himself. I bent close to
+catch any articulate words he might utter, and thought I saw a sardonic
+smile behind the stained, bushy whiskers. Yes--he was really forming
+words, and I could grasp a fair proportion of them.
+
+"Poor Matt--Matt he allus was agin it--tried to line up the folks on
+his side, an' had long talks with the preachers--no use--they run
+the Congregational parson aout o' taown, an' the Methodist feller
+quit--never did see Resolved Babcock, the Baptist parson, agin--Wrath
+o' Jehovy--I was a mighty little critter, but I heerd what I heerd an'
+seen what I seen--Dagon an' Ashtoreth--Belial an' Beëlzebub--Golden
+Caff an' the idols o' Canaan an' the Philistines--Babylonish
+abominations--_Mene, mene, tekel, upharsin_--"
+
+He stopped again, and from the look in his watery blue eyes I feared he
+was close to a stupor after all. But when I gently shook his shoulder
+he turned on me with astonishing alertness and snapped out some more
+obscure phrases.
+
+"Dun't believe me, hey? Heh, heh, heh--then just tell me, young feller,
+why Cap'n Obed an' twenty odd other folks used to row aout to Devil
+Reef in the dead o' night an' chant things so laoud ye cud hear 'em
+all over taown when the wind was right? Tell me that, hey? An' tell
+me why Obed was allus droppin' heavy things daown into the deep water
+t'other side o' the reef whar the bottom shoots daown like a cliff
+lower'n ye kin saound? Tell me what he done with that funny-shaped lead
+thingumajig as Walakea give him? Hey, boy?"
+
+The watery blue eyes were almost savage and maniacal now, and the dirty
+white beard bristled electrically. Old Zadok probably saw me shrink
+back, for he began to cackle evilly.
+
+"Heh, heh, heh, heh! Beginnin' to see, hey? Haow abaout the night I
+took my pa's ship's glass up to a cupalo an' seed the reef a-bristlin'
+thick with shapes that dove off quick soon's the moon riz? Obed an' the
+folks was in a dory, but them shapes dove off the far side into the
+deep water an' never come up.... Haow'd ye like to be a little shaver
+alone up in a cupalo a-watchin' shapes _as wa'n't human shapes_?...
+Hey?... Heh, heh, heh, heh...."
+
+       *       *       *       *       *
+
+The old man was getting hysterical, and I began to shiver with a
+nameless alarm. He laid a gnarled claw on my shoulder, and it seemed to
+me that its shaking was not altogether that of mirth.
+
+"S'pose one night ye seed somethin' heavy heaved offen Obed's dory
+beyond the reef, an' then larned nex' day a young feller was missin'
+from home? Hey? Did anybody ever see hide or hair o' Hiram Gilman agin?
+Did they? An' Nick Pierce, an' Luelly Waite, an' Adoniram Saouthwick,
+an' Henry Garrison? Hey? Heh, heh....
+
+"Wal, Sir, that was the time Obed begun to git on his feet agin. Folks
+see his three darters a-wearin' gold-like things as nobody'd never see
+on 'em afore, an' smoke started comin' aout o' the refin'ry chimbly.
+Other folks was prosp'rin', too--fish began to swarm into the harbor
+fit to kill, an' heaven knows what sized cargoes we begun to ship aout
+to Newb'ryport, Arkham, an' Boston. 'Twas then Obed got the ol' branch
+railrud put through.
+
+"Remember, I ain't sayin' Obed was set on hevin' things jest like
+they was on that Kanaky isle. I dun't think he aimed at fust to do
+no mixin', nor raise no young-uns to take to the water an' turn into
+fishes with etarnal life. He wanted them gold things, an' was willin'
+to pay heavy, an' I guess the _others_ was satisfied fer a while....
+
+"Come in 'forty-six the taown done some lookin' an' thinkin' fer
+itself. Too many folks missin'--too much wild preachin' at meetin' of a
+Sunday--too much talk abaout that reef. I guess I done a bit by tellin'
+Selectman Mowry what I see from the cupalo. They was a party one night
+as follered Obed's craowd aout to the reef, an' I heerd shots betwixt
+the dories. Nex' day Obed an' thutty-two others was in jail, with
+everybody a-wonderin' jest what was afoot an' jest what charge agin
+'em cud be got to holt. God, ef anybody'd looked ahead ... a couple
+o' weeks later, when nothin' had ben throwed into the sea fer that
+long...."
+
+Zadok was showing signs of fright and exhaustion, and I let him keep
+silence for a while, though glancing apprehensively at my watch. The
+tide had turned and was coming in now, and the sound of the waves
+seemed to arouse him.
+
+"That awful night.... I seed 'em.... I was up in the cupalo ... hordes
+of 'em ... swarms of 'em ... all over the reef an' swimmin' up the
+harbor into the Manuxet.... God, what happened in the streets of
+Innsmouth that night ... they rattled our door, but pa wouldn't open
+... then he clumb aout the kitchen winder with his musket to find
+Selectman Mowry an' see what he cud do.... Maounds o' the dead an'
+the dyin' ... shots an' screams ... shaoutin' in Ol' Squar an' Taown
+Squar an' New Church Green ... jail throwed open ... proclamation ...
+treason ... called it the plague when folks come in an' faound haff our
+people missin' ... nobody left but them as ud jine in with Obed an'
+them things or else keep quiet ... never heerd o' my pa no more...."
+
+The old man was panting, and perspiring profusely. His grip on my
+shoulder tightened.
+
+"Everything cleaned up in the mornin'--but they was _traces_.... Obed
+he kinder takes charge an' says things is goin' to be changed ...
+_others'll_ worship with us at meetin'-time, an' sarten haouses hez got
+to entertain _guests_ ... _they_ wanted to mix like they done with the
+Kanakys, an' he fer one didn't feel baound to stop 'em. Far gone, was
+Obed ... jest like a crazy man on the subjeck. He says they brung us
+fish an' treasure, an' shud hev what they hankered arter....
+
+"Nothin' was to be diff'runt on the aoutside, only we was to keep shy
+o' strangers ef we knowed what was good fer us. We all hed to take the
+Oath o' Dagon, an' later on they was secon' an' third Oaths that some
+of us took. Them as ud help special, ud git special rewards--gold an'
+sech. No use balkin', fer they was millions of 'em daown thar. They'd
+ruther not start risin' an' wipin' aout humankind, but ef they was gave
+away an' forced to, they cud do a lot toward jest that.
+
+"Yield up enough sacrifices an' savage knick-knacks an' harborage in
+the taown when they wanted it, an' they'd let well enough alone. All in
+the band of the faithful--Order o' Dagon--an' the children shud never
+die, but go back to the Mother Hydra an' Father Dagon what we all come
+from onct--_Iä! Iä! Cthulhu fhtagn! Ph'nglui mglw'nafh Cthulhu R'lyeh
+wgahnagl fhtagn_--"
+
+Old Zadok began to moan now, and tears were coursing down his
+channelled cheeks into the depths of his beard.
+
+"God, what I seen senct I was fifteen year' old--_Mene, mene,
+tekel, upharsin!_--the folks as was missin', an' them as kilt
+theirselves--them as told things in Arkham or Ipswich or sech places
+was all called crazy, like you're a-callin' me right naow--but God,
+what I seen--they'd a kilt me long ago fer what I know, only I'd
+took the fust an' secon' Oaths o' Dagon offen Obed, so was pertected
+unlessen a jury of 'em proved I told things knowin' an' delib'rit ...
+but I wudn't take the third Oath--I'd a died ruther'n take that--
+
+"It got wuss araound Civil War time, _when children born senct
+'forty-six begun to grow up_--some of 'em, that is. I was
+afeard--never did no pryin' arter that awful night, an' never see one
+o'--_them_--clost to in all my life. That is, never no full-blooded
+one. Barnabas Marsh that runs the refin'ry naow is Obed's grandson by
+his fust wife--son of Onesiphorus, his eldest son, _but his mother was
+another o' them as wa'n't never seed aoutdoors_.
+
+"Right naow Barnabas is abaout changed. Can't shet his eyes no more,
+an' is all aout o' shape. They say he still wears clothes, but he'll
+take to the water soon." ...
+
+The sound of the incoming tide was now very insistent, and little by
+little it seemed to change the old man's mood from maudlin tearfulness
+to watchful fear. He would pause now and then to renew those nervous
+glances over his shoulder or out toward the reef, and despite the wild
+absurdity of his tale, I could not help beginning to share his vague
+apprehensiveness. Zadok now grew shriller, and seemed to be trying to
+whip up his courage with louder speech.
+
+"Hey, yew, why dun't ye say somethin'? Haow'd ye like to be livin' in a
+taown like this, with everything a-rottin' an' a-dyin', an' boarded-up
+monsters crawlin' an' bleatin' an' barkin' an' hoppin' araoun' black
+cellars an' attics every way ye turn? Hey? Wal, Sir, _let me tell ye
+that aint the wust_!"
+
+Zadok was really screaming now, and the mad frenzy of his voice
+disturbed me more than I care to own.
+
+"Curse ye, dun't set thar a-starin' at me with them eyes--I tell Obed
+Marsh he's in hell, an' hez got to stay thar! Heh, heh ... in hell, I
+says! Can't git me--I hain't done nothin' nor told nobody nothin'--
+
+"Oh, you, young feller? Wal, even ef I hain't told nobody nothin' yet,
+I'm a-goin' to naow! Yew jest set still an' listen to me, boy--this is
+what I ain't never told nobody.... I says I didn't get to do no pryin'
+arter that night--_but I found things aout jest the same_!
+
+"Yew want to know what the reel horror is, hey? Wal, it's this--it
+ain't what them fish devils _hez done, but what they're a-goin' to
+do_! They're a-bringin' things up aout o' whar they come from into the
+taown--ben doin' it fer years, an' slackenin' up lately. Them haouses
+north o' the river betwixt Water an' Main Streets is full of 'em--them
+devils _an' what they brung_--an' when they git ready ... I say, _when
+they git ready_ ... ever hear tell of a _shoggoth_?....
+
+"Hey, d'ye hear me? I tell ye I _know what them things be--I seen 'em
+one night when_.... EH-AHHHH--AH! E'YAAHHHH...."
+
+The hideous suddenness and inhuman frightfulness of the old man's
+shriek almost made me faint. His eyes, looking past me toward the
+malodorous sea, were positively starting from his head; while his
+face was a mask of fear worthy of Greek tragedy. His bony claw dug
+monstrously into my shoulder, and he made no motion as I turned my head
+to look at whatever he had glimpsed.
+
+There was nothing that I could see. Only the incoming tide, with
+perhaps one set of ripples more local than the long-flung line of
+breakers. But now Zadok was shaking me, and I turned back to watch the
+melting of that fear-frozen face into a chaos of twitching eyelids and
+mumbling gums. Presently his voice came back--albeit as a trembling
+whisper.
+
+"_Git aout o' here!_ Git aout o' here! _They seen us_--git aout
+fer your life! Dun't wait fer nothin'--_they know naow_--Run fer
+it--quick--_aout o' this taown_--"
+
+Another heavy wave dashed against the loosening masonry of the bygone
+wharf, and changed the mad ancient's whisper to another inhuman and
+blood-curdling scream.
+
+"E-YAAAHHHH!...
+
+"YHAAAAAAAA!..."
+
+Before I could recover my scattered wits he had relaxed his clutch
+on my shoulder and dashed wildly inland toward the street, reeling
+northward around the ruined warehouse wall.
+
+I glanced back at the sea, but there was nothing there. And when I
+reached Water Street and looked along it toward the north there was no
+remaining trace of Zadok Allen.
+
+
+
+
+                                  IV
+
+
+I can hardly describe the mood in which I was left by this harrowing
+episode--an episode at once mad and pitiful, grotesque and terrifying.
+The grocery boy had prepared me for it, yet the reality left me none
+the less bewildered and disturbed. Puerile though the story was, old
+Zadok's insane earnestness and horror had communicated to me a mounting
+unrest which joined with my earlier sense of loathing for the town and
+its blight of intangible shadow.
+
+The hour had grown perilously late--my watch said 7:15, and the Arkham
+bus left Town Square at eight--so I tried to give my thoughts as
+neutral and practical a cast as possible, meanwhile walking rapidly
+through the deserted streets of gaping roofs and leaning houses toward
+the hotel where I had checked my valise and would find my bus.
+
+Studying the grocery youth's map and seeking a route I had not
+traversed before, I chose Marsh Street instead of State for my approach
+to Town Square. Near the corner of Fall Street I began to see scattered
+groups of furtive whisperers, and when I finally reached the Square I
+saw that almost all the loiterers were congregated around the door of
+the Gilman House. It seemed as if many bulging, watery, unwinking eyes
+looked oddly at me as I claimed my valise in the lobby, and I hoped
+that none of these unpleasant creatures would be my fellow-passengers
+on the coach.
+
+The bus, rather early, rattled in with three passengers somewhat
+before eight, and an evil-looking fellow on the sidewalk muttered a
+few indistinguishable words to the driver. I was, it appeared, in very
+bad luck. There had been something wrong with the engine, despite the
+excellent time made from Newburyport, and the bus could not complete
+the journey to Arkham. No, it could not possibly be repaired that
+night, nor was there any other way of getting transportation out of
+Innsmouth, either to Arkham or elsewhere. Sargent was sorry, but I
+would have to stop over at the Gilman. Probably the clerk would make
+the price easy for me, but there was nothing else to do. Almost dazed
+by this sudden obstacle, and violently dreading the fall of night in
+this decaying and half-unlighted town, I left the bus and reentered
+the hotel lobby; where the sullen, queer-looking night clerk told me I
+could have Room 428 on next the top floor--large, but without running
+water--for a dollar.
+
+Despite what I had heard of this hotel in Newburyport, I signed the
+register, paid my dollar, let the clerk take my valise, and followed
+that sour, solitary attendant up three creaking flights of stairs past
+dusty corridors which seemed wholly devoid of life. My room, a dismal
+rear one with two windows and bare, cheap furnishings, over-looked
+a dingy courtyard otherwise hemmed in by low, deserted brick blocks,
+and commanded a view of decrepit westward-stretching roofs with a
+marshy countryside beyond. At the end of the corridor was a bathroom--a
+discouraging relique with ancient marble bowl, tin tub, faint electric
+light, and musty wooden panelling around all the plumbing fixtures.
+
+As twilight deepened I turned on the one feeble electric bulb over the
+cheap, iron-framed bed, and tried as best I could to read. I felt it
+advisable to keep my mind wholesomely occupied, for it would not do
+to brood over the abnormalities of this ancient, blight-shadowed town
+while I was still within its borders. The insane yarn I had heard from
+the aged drunkard did not promise very pleasant dreams, and I felt I
+must keep the image of his wild, watery eyes as far as possible from my
+imagination.
+
+Another thing that disturbed me was the absence of a bolt on the door
+of my room. One had been there, as marks clearly showed, but there
+were signs of recent removal. No doubt it had become out of order,
+like so many other things in this decrepit edifice. In my nervousness
+I looked around and discovered a bolt on the clothespress which seemed
+to be of the same size, judging from the marks, as the one formerly on
+the door. To gain a partial relief from the general tension I busied
+myself by transferring this hardware to the vacant place with the aid
+of a handy three-in-one device including a screw-driver which I kept
+on my keyring. The bolt fitted perfectly, and I was somewhat relieved
+when I knew that I could shoot it firmly upon retiring. There were
+adequate bolts on the two lateral doors to connecting rooms, and these
+I proceeded to fasten.
+
+I did not undress, but decided to read till I was sleepy and then
+lie down with only my coat, collar, and shoes off. Taking a pocket
+flashlight from my valise, I placed it in my trousers, so that I
+could read my watch if I woke up later in the dark. Drowsiness,
+however, did not come; and when I stopped to analyze my thoughts I
+found to my disquiet that I was really unconsciously listening for
+something--listening for something which I dreaded but could not name.
+
+At length, feeling a fatigue which had nothing of drowsiness in it, I
+bolted the newly outfitted hall door, turned off the light, and threw
+myself down on the hard, uneven bed--coat, collar, shoes, and all. In
+the darkness every faint noise of the night seemed magnified, and a
+flood of doubly unpleasant thoughts swept over me. I was sorry I had
+put out the light, yet was too tired to rise and turn it on again.
+Then, after a long, dreary interval, and prefaced by a fresh creaking
+of stairs and corridor, there came that soft, damnably unmistakable
+sound which seemed like a malign fulfilment of all my apprehensions.
+Without the least shadow of a doubt, the lock on my hall door was being
+tried--cautiously, furtively, tentatively--with a key.
+
+The change in the menace from vague premonition to immediate reality
+was a profound shock, and fell upon me with the force of a genuine
+blow. It never once occurred to me that the fumbling might be a mere
+mistake. Malign purpose was all I could think of, and I kept deathly
+quiet, awaiting the would-be intruder's next move.
+
+After a time the cautious rattling ceased, and I heard the room to the
+north entered with a pass key. Then the lock of the connecting door to
+my room was softly tried. The bolt held, of course, and I heard the
+floor creak as the prowler left the room. After a moment there came
+another soft rattling, and I knew that the room to the south of me was
+being entered. Again a furtive trying of a bolted connecting door,
+and again a receding creaking. This time the creaking went along the
+hall and down the stairs, so I knew that the prowler had realized the
+bolted condition of my doors and was giving up his attempt for a time.
+
+_The one thing to do was to get out of that hotel alive as quickly as I
+could, and through some channel other than the front stairs and lobby!_
+
+Rising softly and throwing my flashlight on the switch, I sought
+to light the bulb over my bed in order to choose and pocket some
+belongings for a swift, valiseless flight. Nothing, however, happened;
+and I saw that the power had been cut off. So, filling my pockets
+with the flashlight's aid, I put on my hat and tiptoed to the
+windows to consider chances of descent. Despite the state's safety
+regulations there was no fire escape on this side of the hotel, and
+I saw that my windows commanded only a sheer three-story drop to the
+cobbled courtyard. On the right and left, however, some ancient brick
+business blocks abutted on the hotel; their slant roofs coming up to a
+reasonable jumping distance from my fourth-story level. To reach either
+of these lines of buildings I would have to be in a room two doors
+from my own--in one case on the north and in the other case on the
+south--and my mind instantly set to work calculating what chances I had
+of making the transfer.
+
+First, I reinforced my own outer door by pushing the bureau against
+it--little by little, in order to make a minimum of sound. Then,
+gathering from the grocery boy's map that the best route out of town
+was southward, I glanced first at the connecting door on the south
+side of the room. It was designed to open in my direction, hence I
+saw--after drawing the bolt and finding other fastenings in place--it
+was not a favorable one for forcing. Accordingly abandoning it as a
+route, I cautiously moved the bedstead against it to hamper any attack
+which might be made on it later from the next room. The door on the
+north was hung to open away from me, and this--though a test proved
+it to be locked or bolted from the other side--I knew must be my
+route. If I could gain the roofs of the buildings in Paine Street and
+descend successfully to the ground level, I might perhaps dart through
+the courtyard and the adjacent or opposite buildings to Washington
+or Bates--or else emerge in Paine and edge around southward into
+Washington. In any case, I would aim to strike Washington somehow and
+get quickly out of the Town Square region. My preference would be to
+avoid Paine, since the fire station there might be open all night.
+
+I was irresolutely speculating on when I had better attack the
+northward door, and on how I could least audibly manage it, when I
+noticed that the vague noises underfoot had given place to a fresh and
+heavier creaking of the stairs. A wavering flicker of light showed
+through my transom, and the boards of the corridor began to groan with
+a ponderous load. Muffled sounds of possible vocal origin approached,
+and at length a firm knock came at my outer door.
+
+For a moment I simply held my breath and waited. Eternities
+seemed to elapse, and the nauseous fishy odor of my environment
+seemed to mount suddenly and spectacularly. Then the knocking was
+repeated--continuously, and with growing insistence. I knew that the
+time for action had come, and forthwith drew the bolt of the northward
+connecting door, bracing myself for the task of battering it open. The
+knocking waxed louder, and I hoped that its volume would cover the
+sound of my efforts. At last beginning my attempt, I lunged again and
+again at the thin panelling with my left shoulder, heedless of shock or
+pain.
+
+Finally the connecting door gave, but with such a crash that I knew
+those outside must have heard. Instantly the outside knocking became
+a violent battering, while keys sounded ominously in the hall doors
+of the rooms on both sides of me. Rushing through the newly opened
+connection, I succeeded in bolting the northerly hall door before the
+lock could be turned; but even as I did so I heard the hall door of the
+third room--the one from whose window I had hoped to reach the roof
+below--being tried with a pass key.
+
+For an instant I felt absolute despair, since my trapping in a chamber
+with no window egress seemed complete. Then, with a dazed automatism,
+I made for the next connecting door and performed the blind motion of
+pushing at it in an effort to get through!
+
+Sheer fortunate chance gave me my reprieve--for the connecting door
+before me was not only unlocked but actually ajar. In a second I was
+through, and had my right knee and shoulder against a hall door which
+was visibly opening inward. My pressure took the opener off guard, for
+the thing shut as I pushed, so that I could slip the well-conditioned
+bolt as I had done with the other door. As I gained this respite I
+heard the battering at the two other doors abate, while a confused
+clatter came from the connecting door I had shielded with the bedstead.
+Evidently the bulk of my assailants had entered the southerly room and
+were massing in a lateral attack. But at the same moment a pass key
+sounded in the next door to the north, and I knew that a nearer peril
+was at hand.
+
+The northward connecting door was wide open, but there was no time to
+think about checking the already turning lock in the hall. All I could
+do was to shut and bolt the open connecting door, as well as its mate
+on the opposite side--pushing a bedstead against the one and a bureau
+against the other, and moving a washstand in front of the hall door.
+I must, I saw, trust to such makeshift barriers to shield me till I
+could get out the window and on the roof of the Paine Street block. But
+even in this acute moment my chief horror was something apart from the
+immediate weakness of my defenses. I was shuddering because not one
+of my pursuers, despite some hideous pantings, gruntings, and subdued
+barkings at odd intervals, was uttering an intelligible vocal sound!
+
+As I moved the furniture and rushed toward the windows I heard a
+frightful scurrying along the corridor toward the room north of me, and
+perceived that the southward battering had ceased. Plainly, most of my
+opponents were about to concentrate against the feeble connecting door
+which they knew must open directly on me. Outside, the moon played on
+the ridge-pole of the block below, and I saw that the jump would be
+desperately hazardous because of the steep surface on which I must land.
+
+The clatter at the northerly connecting door was now terrific, and
+I saw that the weak panelling was beginning to splinter. Obviously,
+the besiegers had brought some ponderous object into play as a
+battering-ram. The bedstead, however, still held firm; so that I had at
+least a faint chance of making good my escape. As I opened the window
+I noticed that it was flanked by heavy velour draperies suspended from
+a pole by brass rings, and also that there was a large projecting
+catch for the shutters on the exterior. Seeing a possible means of
+avoiding the dangerous jump, I yanked at the hangings and brought
+them down, pole and all; then quickly hooking two of the rings in the
+shutter catch and flinging the drapery outside. The heavy folds reached
+fully to the abutting roof, and I saw that the rings and catch would
+be likely to bear my weight. So, climbing out of the window and down
+the improvised rope ladder, I left behind me forever the morbid and
+horror-infested fabric of the Gilman House.
+
+I landed safely on the loose slates of the steep roof, and succeeded in
+gaining the gaping black skylight without a slip. The place inside was
+ghoulish-looking, but I was past minding such impressions and made at
+once for the staircase revealed by my flashlight--after a hasty glance
+at my watch, which showed the hour to be 2 A.M. The steps creaked, but
+seemed tolerably sound; and I raced down past a barnlike second story
+to the ground floor. The desolation was complete, and only echoes
+answered my footfalls.
+
+The hallway inside was black, and when I reached the opposite end I saw
+that the street door was wedged immovably shut. Resolved to try another
+building, I groped my way toward the courtyard, but stopped short when
+close to the doorway.
+
+For out of an opened door in the Gilman House a large crowd of doubtful
+shapes was pouring--lanterns bobbing in the darkness, and horrible
+croaking voices exchanging low cries in what was certainly not English.
+Their features were indistinguishable, but their crouching, shambling
+gait was abominably repellent. And worst of all, I perceived that one
+figure was strangely robed, and unmistakably surmounted by a tall tiara
+of a design altogether too familiar. Again groping toward the street,
+I opened a door off the hall and came upon an empty room with closely
+shuttered but sashless windows. Fumbling in the rays of my flashlight,
+I found I could open the shutters; and in another moment had climbed
+outside and was carefully closing the aperture in its original manner.
+
+I walked rapidly, softly, and close to the ruined houses. At Bates
+Street I drew into a yawning vestibule while two shambling figures
+crossed in front of me, but was soon on my way again and approaching
+the open space where Eliot Street obliquely crosses Washington at the
+intersection of South. Though I had never seen this space, it had
+looked dangerous to me on the grocery youth's map; since the moonlight
+would have free play there. There was no use trying to evade it, for
+any alternative course would involve detours of possibly disastrous
+visibility and delaying effect. The only thing to do was to cross it
+boldly and openly; imitating the typical shamble of the Innsmouth folk
+as best I could, and trusting that no one--or at least no pursuer of
+mine--would be there.
+
+Just how fully the pursuit was organized--and indeed, just what its
+purpose might be--I could form no idea. There seemed to be unusual
+activity in the town, but I judged that the news of my escape from
+the Gilman had not yet spread. The open space was, as I had expected,
+strongly moonlit. But my progress was unimpeded, and no fresh sound
+arose to hint that I had been spied. Glancing about me, I involuntarily
+let my pace slacken for a second to take in the sight of the sea,
+gorgeous in the burning moonlight at the street's end. Far out beyond
+the breakwater was the dim, dark line of Devil Reef.
+
+Then, without warning, I saw the intermittent flashes of light on the
+distant reef. My muscles tightened for panic flight, held in only by a
+certain unconscious caution and half-hypnotic fascination. And to make
+matters worse, there now flashed forth from the lofty cupola of the
+Gilman House, which loomed up to the northeast behind me, a series of
+analogous though differently spaced gleams which could be nothing less
+than an answering signal.
+
+I now bent to the left around the ruinous green; still gazing toward
+the ocean as it blazed in the spectral summer moonlight, and watching
+the cryptical flashing of those nameless, unexplainable beacons.
+
+It was then that the most horrible impression of all was borne in upon
+me--the impression which destroyed my last vestige of self-control and
+sent me running frantically southward past the yawning black doorways
+and fishily staring windows of that deserted nightmare street. For at
+a closer glance I saw that the moonlit waters between the reef and
+the shore were far from empty. They were alive with a teeming horde of
+shapes swimming inward toward the town!
+
+My frantic running ceased before I had covered a block, for at my left
+I began to hear something like the hue and cry of organized pursuit.
+There were footsteps and guttural sounds, and a rattling motor wheezed
+south along Federal Street. In a second all my plans were utterly
+changed--for if the southward highway were blocked ahead of me, I must
+clearly find another egress from Innsmouth. I paused and drew into a
+gaping doorway, reflecting how lucky I was to have left the moonlit
+open space before these pursuers came down the parallel street.
+
+Then I thought of the abandoned railway to Rowley, whose solid line of
+ballasted, weed-grown earth still stretched off to the northwest from
+the crumbling station on the edge of the river gorge. There was just a
+chance that the townsfolk would not think of that!
+
+Drawing inside the hall of my deserted shelter, I once more consulted
+the grocery boy's map with the aid of the flashlight. The immediate
+problem was how to reach the ancient railway; and I now saw that the
+safest course was ahead to Babson Street, then west to Lafayette--there
+edging around but not crossing an open space homologous to the one
+I had traversed--and subsequently back northward and westward in
+zigzagging line through Lafayette, Bates, Adams, and Banks Streets--the
+latter skirting the river gorge--to the abandoned and dilapidated
+station I had seen from my window. My reason for going ahead to Babson
+was that I wished neither to re-cross the earlier open space nor to
+begin my westward course along a cross street as broad as South. I
+crossed the street to the right-hand side in order to edge around into
+Babson as inconspicuously as possible.
+
+In Babson Street I clung as closely as possible to the sagging,
+uneven buildings; twice pausing in a doorway as the noises behind me
+momentarily increased. The open space ahead shone wide and desolate
+under the moon, but my route would not force me to cross it. During
+my second pause I began to detect a fresh distribution of the vague
+sounds; and upon looking cautiously out from cover beheld a motor car
+darting across the open space, bound outward along Eliot Street.
+
+As I watched--choked by a sudden rise in the fishy odor after a short
+abatement--I saw a band of uncouth, crouching shapes loping and
+shambling in the same direction; and knew that this must be the party
+guarding the Ipswich road, since that highway forms an extension of
+Eliot Street. Two of the figures I glimpsed were in voluminous robes,
+and one wore a peaked diadem which glistened whitely in the moonlight.
+The gait of this figure was so odd that it sent a chill through me--for
+it seemed to me the creature was almost _hopping_.
+
+When the last of the band was out of sight I resumed my progress;
+darting around the corner into Lafayette Street, and crossing Eliot
+very hurriedly lest stragglers of the party be still advancing along
+that thoroughfare. I did hear some croaking and clattering sounds
+far off toward Town Square, but accomplished the passage without
+disaster. My greatest dread was in re-crossing broad and moonlit South
+Street--with its seaward view--and I had to nerve myself for the
+ordeal. Someone might easily be looking, and possible Eliot Street
+stragglers could not fail to glimpse me from either of two points. At
+the last moment I decided I had better slacken my trot and make the
+crossing as before in the shambling gait of an average Innsmouth native.
+
+I had not quite crossed the street when I heard a muttering band
+advancing along Washington from the north. As they reached the broad
+open space where I had had my first disquieting glimpse of the moonlit
+water I could see them plainly only a block away--and was horrified by
+the bestial abnormality of their faces and the dog-like sub-humanness
+of their crouching gait. One man moved in a positively simian way, with
+long arms frequently touching the ground; while another figure--robed
+and tiaraed--seemed to progress in an almost hopping fashion. I judged
+this party to be the one I had seen in the Gilman's courtyard--the one,
+therefore, most closely on my trail. As some of the figures turned
+to look in my direction I was transfixed with fright, yet managed to
+preserve the casual, shambling gait I had assumed. To this day I do
+not know whether they saw me or not. If they did, my stratagem must
+have deceived them, for they passed on across the moonlit space without
+varying their course--meanwhile croaking and jabbering in some hateful
+guttural patois I could not identify.
+
+Once more in shadow, I resumed my former dog-trot past the leaning and
+decrepit houses that stared blankly into the night. Having crossed to
+the western sidewalk I rounded the nearest corner into Bates Street,
+where I kept close to the buildings on the southern side. At last I saw
+the ancient arcaded station--or what was left of it--and made directly
+for the tracks that started from its farther end.
+
+The rails were rusty but mainly intact, and not more than half the
+ties had rotted away. Walking or running on such a surface was very
+difficult; but I did my best, and on the whole made very fair time. For
+some distance the line kept on along the gorge's brink, but at length I
+reached the long covered bridge where it crossed the chasm at a dizzy
+height. The condition of this bridge would determine my next step. If
+humanly possible, I would use it; if not, I would have to risk more
+street wandering and take the nearest intact highway bridge.
+
+The vast, barnlike length of the old bridge gleamed spectrally in the
+moonlight and I saw that the ties were safe for at least a few feet
+within. Entering, I began to use my flashlight, and was almost knocked
+down by the cloud of bats that flapped past me. About halfway across
+there was a perilous gap in the ties which I feared for a moment would
+halt me; but in the end I risked a desperate jump which fortunately
+succeeded.
+
+I was glad to see the moonlight again when I emerged from that macabre
+tunnel. The old tracks crossed River Street at a grade, and at once
+veered off into a region increasingly rural and with less and less of
+Innsmouth's abhorrent fishy odor. Here the dense growth of weeds and
+briers hindered me and cruelly tore my clothes, but I was none the less
+glad that they were there to give me concealment in case of peril. I
+knew that much of my route must be visible from the Rowley road.
+
+The marshy region began very shortly, with the single track on a low,
+grassy embankment. Then came a sort of island of higher ground, where
+the line passed through a shallow open cut choked with bushes and
+brambles. I was very glad of this partial shelter, since at this point
+the Rowley road was uncomfortably near according to my window view.
+
+Just before entering the cut I glanced behind me, but saw no pursuer.
+The ancient spires and roofs of decaying Innsmouth gleamed lovely and
+ethereal in the magic yellow moonlight, and I thought of how they must
+have looked in the old days before the shadow fell. Then, as my gaze
+circled inland from the town, something less tranquil arrested my
+notice and held me immobile for a second.
+
+What I saw--or fancied I saw--was a disturbing suggestion of undulant
+motion far to the south; a suggestion which made me conclude that
+a very large horde must be pouring out of the city along the level
+Ipswich road. The distance was great, and I could distinguish nothing
+in detail; but I did not at all like the look of that moving column.
+
+All sorts of unpleasant conjectures crossed my mind. I thought of those
+very extreme Innsmouth types said to be hidden in crumbling, centuried
+warrens near the waterfront. I thought, too, of those nameless swimmers
+I had seen. Counting the parties so far glimpsed, as well as those
+presumably covering other roads, the number of my pursuers must be
+strangely large for a town as depopulated as Innsmouth.
+
+Who were they? Why were they here? And if such a column of them was
+scouring the Ipswich road, would the patrols on the other roads be
+likewise augmented?
+
+I had entered the brush-grown cut and was struggling along at a very
+slow pace when that damnable fishy odor again waxed dominant. There
+were sounds, too--a kind of wholesale, colossal flopping or pattering
+which somehow called up images of the most detestable sort.
+
+And then both stench and sounds grew stronger, so that I paused
+shivering and grateful for the cut's protection. It was here, I
+recalled, that the Rowley road drew so close to the old railway before
+crossing westward and diverging. Something was coming along that road,
+and I must lie low till its passage and vanishment in the distance.
+Crouched in the bushes of that sandy cleft I felt reasonably safe, even
+though I knew the searchers would have to cross the track in front of
+me not much more than a hundred yards away. I would be able to see
+them, but they could not, except by a malign miracle, see me.
+
+All at once I began dreading to look at them as they passed. I saw the
+close moonlit space where they would surge by, and had curious thoughts
+about the irredeemable pollution of that space. They would perhaps
+be the worst of all Innsmouth types--something one would not care to
+remember.
+
+The stench waxed overpowering, and the noises swelled to a bestial
+babel of croaking, baying, and barking, without the least suggestion
+of human speech. Were these indeed the voices of my pursuers? That
+flopping or pattering was monstrous--I could not look upon the
+degenerate creatures responsible for it. I would keep my eyes shut till
+the sounds receded toward the west. The horde was very close now--the
+air foul with their hoarse snarlings, and the ground almost shaking
+with their alien-rhythmed footfalls. My breath nearly ceased to come,
+and I put every ounce of will-power into the task of holding my eyelids
+down.
+
+I am not even yet willing to say whether what followed was a hideous
+actuality or only a nightmare hallucination. The later action of the
+government, after my frantic appeals, would tend to confirm it as a
+monstrous truth; but could not an hallucination have been repeated
+under the quasi-hypnotic spell of that ancient, haunted, and shadowed
+town?
+
+But I must try to tell what I thought I saw that night under the
+mocking yellow moon--saw surging and hopping down the Rowley road in
+plain sight in front of me as I crouched among the wild brambles of
+that desolate railway cut. Of course my resolution to keep my eyes shut
+had failed. It was foredoomed to failure--for who could crouch blindly
+while a legion of croaking, baying entities of unknown source flopped
+noisomely past, scarcely more than a hundred yards away?
+
+For I knew that a long section of them must be plainly in sight where
+the sides of the cut flattened out and the road crossed the track--and
+I could no longer keep myself from sampling whatever horror that
+leering yellow moon might have to show.
+
+It was the end, for whatever remains to me of life on the surface of
+this earth, of every vestige of mental peace and confidence in the
+integrity of nature and of the human mind. Can it be possible that this
+planet has actually spawned such things; that human eyes have truly
+seen, as objective flesh, what man has hitherto known only in febrile
+phantasy and tenuous legend?
+
+And yet I saw them in a limitless stream--flopping, hopping, croaking,
+bleating--surging inhumanly through the spectral moonlight in a
+grotesque, malignant saraband of fantastic nightmare. And some of them
+had tall tiaras of that nameless whitish-gold metal ... and some were
+strangely robed ... and one, who led the way, was clad in a ghoulishly
+humped black coat and striped trousers, and had a man's felt hat
+perched on the shapeless thing that answered for a head....
+
+I think their predominant color was a grayish-green, though they had
+white bellies. They were mostly shiny and slippery, but the ridges of
+their backs were scaly. Their forms vaguely suggested the anthropoid,
+while their heads were the heads of fish, with prodigious bulging eyes
+that never closed. At the sides of their necks were palpitating gills,
+and their long paws were webbed. They hopped irregularly, sometimes on
+two legs and sometimes on four. I was somehow glad that they had no
+more than four limbs. Their croaking, baying voices, clearly used for
+articulate speech, held all the dark shades of expression which their
+staring faces lacked.
+
+But for all of their monstrousness they were not unfamiliar to me. I
+knew too well what they must be--for was not the memory of that evil
+tiara at Newburyport still fresh? They were the blasphemous fish-frogs
+of the nameless design--living and horrible--and as I saw them I knew
+also of what that humped, tiaraed priest in the black church basement
+had so fearsomely reminded me. Their number was past guessing. It
+seemed to me that there were limitless swarms of them--and certainly my
+momentary glimpse could have shown only the least fraction. In another
+instant everything was blotted out by a merciful fit of fainting; the
+first I had ever had.
+
+
+
+
+                                   V
+
+
+It was a gentle daylight rain that awaked me from my stupor in the
+brush-grown railway cut, and when I staggered out to the roadway ahead
+I saw no trace of any prints in the fresh mud. Innsmouth's ruined roofs
+and toppling steeples loomed up grayly toward the southeast, but not a
+living creature did I spy in all the desolate salt marshes around. My
+watch was still going, and told me that the hour was past noon.
+
+The reality of what I had been through was highly uncertain in my mind,
+but I felt that something hideous lay in the background. I must get
+away from evil-shadowed Innsmouth--and accordingly I began to test
+my cramped, wearied powers of locomotion. Despite weakness, hunger,
+horror, and bewilderment I found myself after a time able to walk; so
+started slowly along the muddy road to Rowley. Before evening I was
+in the village, getting a meal and providing myself with presentable
+clothes. I caught the night train to Arkham, and the next day talked
+long and earnestly with government officials there; a process I later
+repeated in Boston. With the main result of these colloquies the public
+is now familiar--and I wish, for normality's sake, there were nothing
+more to tell. Perhaps it is madness that is overtaking me--yet perhaps
+a greater horror--or a greater marvel--is reaching out.
+
+I dared not look for that piece of strange jewelry said to be in the
+Miskatonic University Museum. I did, however, improve my stay in Arkham
+by collecting some genealogical notes I had long wished to possess;
+very rough and hasty data, it is true, but capable of good use later
+on when I might have time to collate and codify them. The curator of
+the historical society there--Mr. E. Lapham Peabody--was very courteous
+about assisting me, and expressed unusual interest when I told him I
+was a grandson of Eliza Orne of Arkham, who was born in 1867 and had
+married James Williamson of Ohio at the age of seventeen.
+
+It seemed that a maternal uncle of mine had been there many years
+before on a quest much like my own; and that my grandmother's family
+was a topic of some local curiosity. There had, Mr. Peabody said, been
+considerable discussion about the marriage of her father, Benjamin
+Orne, just after the Civil War; since the ancestry of the bride was
+peculiarly puzzling. That bride was understood to have been an orphaned
+Marsh of New Hampshire--a cousin of the Essex County Marshes--but her
+education had been in France and she knew very little of her family. A
+guardian had deposited funds in a Boston bank to maintain her and her
+French governess; but that guardian's name was unfamiliar to Arkham
+people, and in time he dropped out of sight, so that the governess
+assumed his role by court appointment. The French-woman--now long
+dead--was very taciturn, and there were those who said she could have
+told more than she did.
+
+But the most baffling thing was the inability of anyone to place
+the recorded parents of the young woman--Enoch and Lydia (Meserve)
+Marsh--among the known families of New Hampshire. Possibly,
+many suggested, she was the natural daughter of some Marsh of
+prominence--she certainly had the true Marsh eyes. Most of the
+puzzling was done after her early death, which took place at the birth
+of my grandmother--her only child. Having formed some disagreeable
+impressions connected with the name of Marsh, I did not welcome the
+news that it belonged on my own ancestral tree; nor was I pleased
+by Mr. Peabody's suggestion that I had the true Marsh eyes myself.
+However, I was grateful for data which I knew would prove valuable;
+and took copious notes and lists of book references regarding the
+well-documented Orne family.
+
+I went directly home to Toledo from Boston, and later spent a month
+at Maumee recuperating from my ordeal. In September I entered Oberlin
+for my final year, and from then till the next June was busy with
+studies and other wholesome activities--reminded of the bygone terror
+only by occasional official visits from government men in connection
+with the campaign which my pleas and evidence had started. Around the
+middle of July--just a year after the Innsmouth experience--I spent a
+week with my late mother's family in Cleveland; checking some of my
+new genealogical data with the various notes, traditions, and bits
+of heirloom material in existence there, and seeing what kind of a
+connected chart I could construct.
+
+I did not exactly relish this task, for the atmosphere of the
+Williamson home had always depressed me. There was a strain of
+morbidity there, and my mother had never encouraged my visiting her
+parents as a child, although she always welcomed her father when
+he came to Toledo. My Arkham-born grandmother had seemed strange
+and almost terrifying to me, and I do not think I grieved when she
+disappeared. I was eight years old then, and it was said that she had
+wandered off in grief after the suicide of my uncle Douglas, her eldest
+son. He had shot himself after a trip to New England--the same trip,
+no doubt, which had caused him to be recalled at the Arkham Historical
+Society.
+
+This uncle had resembled her, and I had never liked him either.
+Something about the staring, unwinking expression of both of them
+had given me a vague, unaccountable uneasiness. My mother and uncle
+Walter had not looked like that. They were like their father, though
+poor little cousin Lawrence--Walter's son--had been an almost perfect
+duplicate of his grandmother before his condition took him to the
+permanent seclusion of a sanitarium at Canton. I had not seen him in
+four years, but my uncle once implied that his state, both mental and
+physical, was very bad. This worry had probably been a major cause of
+his mother's death two years before.
+
+My grandfather and his widowered son Walter now comprised the Cleveland
+household, but the memory of older times hung thickly over it. I still
+disliked the place, and tried to get my researches done as quickly as
+possible. Williamson records and traditions were supplied in abundance
+by my grandfather; though for Orne material I had to depend on my uncle
+Walter, who put at my disposal the contents of all his files, including
+notes, letters, cuttings, heirlooms, photographs, and miniatures.
+
+It was in going over the letters and pictures on the Orne side that I
+began to acquire a kind of terror of my own ancestry. As I have said,
+my grandmother and uncle Douglas had always disturbed me. Now, years
+after their passing, I gazed at their pictured faces with a measurably
+heightened feeling of repulsion and alienation. I could not at first
+understand the change, but gradually a horrible sort of _comparison_
+began to obtrude itself on my unconscious mind despite the steady
+refusal of my consciousness to admit even the least suspicion of it.
+It was clear that the typical expression of these faces now suggested
+something it had not suggested before--something which would bring
+stark panic if too openly thought of.
+
+But the worst shock came when my uncle showed me the Orne jewelry in
+a downtown safe-deposit vault. Some of the items were delicate and
+inspiring enough, but there was one box of strange old pieces descended
+from my mysterious great-grandmother which my uncle was almost
+reluctant to produce. They were, he said, of very grotesque and almost
+repulsive design.
+
+As my uncle began slowly and grudgingly to unwrap the things, he urged
+me not to be shocked by the strangeness and frequent hideousness of
+the designs. There were two armlets, a tiara, and a kind of pectoral;
+the latter having in high relief certain figures of almost unbearable
+extravagance.
+
+He seemed to expect some demonstration when the first piece--the
+tiara--became visible, but I doubt if he expected quite what actually
+happened. I did not expect it, either, for I thought I was thoroughly
+forewarned regarding what the jewelry would turn out to be. What I did
+was to faint silently away just as I had done in that brier-choked
+railway cut a year before.
+
+From that day on my life has been a nightmare of brooding and
+apprehension, nor do I know how much is hideous truth and how much
+madness. My great-grandmother had been a Marsh of unknown source whose
+husband lived in Arkham--and did not old Zadok say that the daughter of
+Obed Marsh by a monstrous mother was married to an Arkham man through
+a trick? What was it the ancient toper had muttered about the likeness
+of my eyes to Captain Obed's? In Arkham, too, the curator had told me I
+had the true Marsh eyes. Was Obed Marsh my own great-great-grandfather?
+Who--or _what_--then, was my great-great-grandmother? But perhaps
+this was all madness. Those whitish-gold ornaments might easily
+have been bought from some Innsmouth sailor by the father of my
+great-grandmother, whoever he was. And that look in the staring-eyed
+faces of my grandmother and self-slain uncle might be sheer fancy,
+bolstered up by the Innsmouth shadow which had so darkly colored my
+imagination. But why had my uncle killed himself after an ancestral
+quest in New England?
+
+For more than two years I fought off these reflections with partial
+success. My father secured me a place in an insurance office, and
+I buried myself in routine as deeply as possible. In the winter of
+1930-31, however, the dreams began. They were very sparse and insidious
+at first, but increased in frequency and vividness as the weeks went
+by. Great watery spaces opened out before me, and I seemed to wander
+through titanic sunken porticos and labyrinths of weedy cyclopean walls
+and grotesque fishes as my companions. Then the _other shapes_ began to
+appear, filling me with nameless horror the moment I awoke. But during
+the dreams they did not horrify me at all--I was one with them; wearing
+their unhuman trappings, treading their aqueous ways, and praying
+monstrously at their evil sea-bottom temples.
+
+There was much more than I could remember, but even what I did remember
+each morning would be enough to stamp me as a madman or a genius if
+ever I dared write it down. Some frightful influence, I felt, was
+seeking gradually to drag me out of the sane world of wholesome life
+into unnameable abysses of blackness and alienage; and the process
+told heavily on me. My health and appearance grew steadily worse, till
+finally I was forced to give up my position and adopt the static,
+secluded life of an invalid. Some odd nervous affliction had me in its
+grip, and I found myself at times almost unable to shut my eyes.
+
+It was then that I began to study the mirror with mounting alarm. The
+slow ravages of disease are not pleasant to watch, but in my case there
+was something subtler and more puzzling in the background. My father
+seemed to notice it, too, for he began looking at me curiously and
+almost affrightedly. What was taking place in me? Could it be that I
+was coming to resemble my grandmother and uncle Douglas?
+
+One night I had a frightful dream in which I met my grandmother
+under the sea. She lived in a phosphorescent palace of many
+terraces, with gardens of strange leprous corals and grotesque
+brachiate efflorescences, and welcomed me with a warmth that may
+have been sardonic. She had changed--as those who take to the water
+change--and told me she had never died. Instead, she had gone to a
+spot her dead son had learned about, and had leaped to a realm whose
+wonders--destined for him as well--he had spurned with a smoking
+pistol. This was to be my realm, too--I could not escape it. I would
+never die, but would live with those who had lived since before man
+ever walked the earth.
+
+[Illustration: "One night, in a frightful dream, I met two Ancient Ones
+under the sea in a phosphorescent, many terraced palace surrounded by
+gardens of strange, leprous corals."]
+
+I met also that which had been her grandmother. For eighty thousand
+years Pth'thya-l'yi had lived in Y'ha-nthlei, and thither she had gone
+back after Obed Marsh was dead. Y'ha-nthlei was not destroyed when
+the upper-earth men shot death into the sea. It was hurt, but not
+destroyed. The Deep Ones could never be destroyed, even though the
+palaeogean magic of the forgotten Old Ones might sometimes check them.
+For the present they would rest; but some day, if they remembered, they
+would rise again for the tribute Great Cthulhu craved. It would be a
+city greater than Innsmouth next time. They had planned to spread, and
+had brought up that which would help them, but now they must wait once
+more. For bringing the upper-earth men's death I must do a penance,
+but that would not be heavy. This was the dream in which I saw a
+_shoggoth_ for the first time, and the sight set me awake in a frenzy
+of screaming. That morning the mirror definitely told me I had acquired
+_the Innsmouth look_.
+
+So far I have not shot myself as my uncle Douglas did. I bought an
+automatic and almost took the step, but certain dreams deterred me. The
+tense extremes of horror are lessening, and I feel queerly drawn toward
+the unknown sea-deeps instead of fearing them. I hear and do strange
+things in sleep, and awake with a kind of exaltation instead of terror.
+I do not believe I need to wait for the full change as most have
+waited. If I did, my father would probably shut me up in a sanitarium
+as my poor little cousin is shut up. Stupendous and unheard-of
+splendors await me below, and I shall seek them soon. _Iā-R'lyeh!
+Cthulhu fhtagn! Iā! Iā!_ No, I shall not shoot myself--I cannot
+be made to shoot myself!
+
+I shall plan my cousin's escape from that Canton madhouse, and together
+we shall go to marvel-shadowed Innsmouth. We shall swim out to that
+brooding reef in the sea and dive down through black abysses to
+cyclopean and many-columned Y'ha-nthlei, and in that lair of the Deep
+Ones we shall dwell amidst wonder and glory forever.
+
+                      At the MOUNTAINS of MADNESS
+
+                          By H. P. LOVECRAFT
+
+           [Transcriber's Note: This etext was produced from
+            Astounding Stories February, March, April 1936.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+
+I am forced into speech because men of science have refused to follow
+my advice without knowing why. It is altogether against my will that
+I tell my reasons for opposing this contemplated invasion of the
+antarctic--with its vast fossil hunt and its wholesale boring and
+melting of the ancient ice caps. And I am the more reluctant because my
+warning may be in vain.
+
+Doubt of the real facts, as I must reveal them, is inevitable; yet,
+if I suppressed what will seem extravagant and incredible there would
+be nothing left. The hitherto withheld photographs, both ordinary
+and aërial, will count in my favor, for they are damnably vivid and
+graphic. Still, they will be doubted because of the great lengths to
+which clever fakery can be carried. The ink drawings, of course, will
+be jeered at as obvious impostures; notwithstanding a strangeness and
+technique which art experts ought to remark and puzzle over.
+
+In the end I must rely on the judgment and standing of the few
+scientific leaders who have, on the one hand, sufficient independence
+of thought to weigh my data on its own hideously convincing merits or
+in the light of certain primordial and highly baffling myth cycles;
+and on the other hand, sufficient influence to deter the exploring
+world in general from any rash and over-ambitious program in the region
+of those mountains of madness.
+
+It is an unfortunate fact that relatively obscure men like myself and
+my associates, connected only with a small university, have little
+chance of making an impression where matters of a wildly bizarre or
+highly controversial natures are concerned.
+
+It is further against us that we are not, in the strictest sense,
+specialists in the fields which came primarily to be concerned. As a
+geologist, my object in leading the Miskatonic University Expedition
+was wholly that of securing deep-level specimens of rock and soil from
+various parts of the antarctic continent, aided by the remarkable drill
+devised by Professor Frank H. Pabodie of our engineering department.
+
+I had no wish to be a pioneer in any other field than this, but I did
+hope that the use of this new mechanical appliance at different points
+along previously explored paths would bring to light materials of a
+sort hitherto unreached by the ordinary methods of collection.
+
+Pabodie's drilling apparatus, as the public already knows from our
+reports, was unique and radical in its lightness, portability, and
+capacity to combine the ordinary Artesian drill principle with the
+principle of the small circular rock drill in such a way as to cope
+quickly with strata of varying hardness.
+
+Steel head, jointed rods, gasoline motor, collapsible wooden derrick,
+dynamiting paraphernalia, cording, rubbish-removal auger, and sectional
+piping for bores five inches wide and up to one thousand feet deep all
+formed, with needed accessories, no greater load than three seven-dog
+sledges could carry. This was made possible by the clever aluminum
+alloy of which most of the metal objects were fashioned.
+
+Four large Dornier aëroplanes, designed especially for the tremendous
+altitude flying necessary on the antarctic plateau and with added
+fuel-warming and quick-starting devices worked out by Pabodie, could
+transport our entire expedition from a base at the edge of the great
+ice barrier to various suitable inland points, and from these points a
+sufficient quota of dogs would serve us.
+
+We planned to cover as great an area as one antarctic season--or
+longer, if absolutely necessary--would permit, operating mostly in the
+mountain ranges and on the plateau south of Ross Sea; regions explored
+in varying degree by Shackleton, Amundsen, Scott, and Byrd. With
+frequent changes of camp, made by aëroplane and involving distances
+great enough to be of geological significance, we expected to unearth a
+quite unprecedented amount of material--especially in the pre-Cambrian
+strata of which so narrow a range of antarctic specimens had previously
+been secured.
+
+We wished also to obtain as great as possible a variety of the upper
+fossiliferous rocks, since the primal life history of this bleak realm
+of ice and death is of the highest importance to our knowledge of the
+earth's past. That the antarctic continent was once temperate and
+even tropical, with a teeming vegetable and animal life of which the
+lichens, marine fauna, arachnida, and penguins of the northern edge are
+the only survivors, is a matter of common information; and we hoped to
+expand that information in variety, accuracy, and detail. When a simple
+boring revealed fossiliferous signs, we would enlarge the aperture by
+blasting, in order to get specimens of suitable size and condition.
+
+Our borings, of varying depth according to the promise held out by the
+upper soil or rock, were to be confined to exposed, or nearly exposed,
+land surfaces--these inevitably being slopes and ridges because of the
+mile or two-mile thickness of solid ice overlying the lower levels.
+
+We could not afford to waste drilling depth on any considerable amount
+of more glaciation, though Pabodie had worked out a plan for sinking
+copper electrodes in thick clusters of borings and melting off limited
+areas of ice with current from a gasoline-driven dynamo.
+
+It is this plan--which we could not put into effect except
+experimentally on an expedition such as ours--that the coming
+Starkweather-Moore Expedition proposes to follow, despite the warnings
+I have issued since our return from the antarctic.
+
+       *       *       *       *       *
+
+The public knows of the Miskatonic Expedition through our frequent
+wireless reports to the _Arkham Advertiser_ and Associated Press, and
+through the later articles by Pabodie and myself. We consisted of four
+men from the University--Pabodie, Lake of the biology department,
+Atwood of the physics department--also a meteorologist--and myself,
+representing geology and having nominal command, also sixteen
+assistants: seven graduate students from Miskatonic and nine skilled
+mechanics.
+
+Of these sixteen, twelve were qualified aëroplane pilots, all but two
+of whom were competent wireless operators. Eight of them understood
+navigation with compass and sextant, as did Pabodie, Atwood and I. In
+addition, of course, our two ships--wooden exwhalers, reinforced for
+ice conditions and having auxiliary steam--were fully manned.
+
+The Nathaniel Derby Pickman Foundation, aided by a few special
+contributions, financed the expedition; hence our preparations were
+extremely thorough, despite the absence of great publicity.
+
+The dogs, sledges, machines, camp materials, and unassembled parts of
+our five planes were delivered in Boston, and there our ships were
+loaded.
+
+We were marvelously well-equipped for our specific purposes, and in
+all matters pertaining to supplies, regimen, transportation, and camp
+construction we profited by the excellent example of our many recent
+and exceptionally brilliant predecessors. It was the unusual number and
+fame of these predecessors which made our own expedition--ample though
+it was--so little noticed by the world at large.
+
+As the newspapers told, we sailed from Boston Harbor on September 2nd,
+1930, taking a leisurely course down the coast and through the Panama
+Canal, and stopping at Samoa and Hobart, Tasmania, at which latter
+place we took on final supplies.
+
+None of our exploring party had ever been in the polar regions before,
+hence we all relied greatly on our ship captains--J. B. Douglas,
+commanding the brig _Arkham_, and serving as commander of the sea
+party, and Georg Thorfinnssen, commanding the barque _Miskatonic_--both
+veteran whalers in antarctic waters.
+
+As we left the inhabited world behind the sun sank lower and lower in
+the north, and stayed longer and longer above the horizon each day.
+At about 62° South Latitude we sighted our first icebergs--tablelike
+objects with vertical sides--and just before reaching the antarctic
+circle, which we crossed on October 20th with appropriately quaint
+ceremonies, we were considerably troubled with field ice.
+
+The falling temperature bothered me considerably after our long voyage
+through the tropics, but I tried to brace up for the worse rigors to
+come. On many occasions the curious atmospheric effects enchanted me
+vastly; these included a strikingly vivid mirage--the first I had ever
+seen--in which distant bergs became the battlements of unimaginable
+cosmic castles.
+
+Pushing through the ice, which was fortunately neither extensive
+nor thickly packed, we regained open water at South Latitude 67°,
+East Longitude 175°. On the morning of October 26th a strong land
+blink appeared on the south, and before noon we all felt a thrill of
+excitement at beholding a vast, lofty, and snow-clad mountain chain
+which opened out and covered the whole vista ahead. At last we had
+encountered an outpost of the great unknown continent and its cryptic
+world of frozen death.
+
+These peaks were obviously the Admiralty Range discovered by Ross, and
+it would now be our task to round Cape Adare and sail down the east
+coast of Victoria Land to our contemplated base on the shore of McMurdo
+Sound, at the foot of the volcano Erebus in South Latitude 77° 9´.
+
+       *       *       *       *       *
+
+The last lap of the voyage was vivid and fancy-stirring. Great barren
+peaks of mystery loomed up constantly against the west as the low
+northern sun of noon or the still lower horizon-grazing southern sun of
+midnight poured its hazy reddish rays over the white snow, bluish ice
+and water lanes, and black bits of exposed granite slope.
+
+Through the desolate summits swept raging, intermittent gusts of
+the terrible antarctic wind, whose cadences sometimes held vague
+suggestions of a wild and half-sentient musical piping, with notes
+extending over a wide range, and which for some subconscious mnemonic
+reason seemed to me disquieting and even dimly terrible.
+
+Something about the scene reminded me of the strange and disturbing
+Asian paintings of Nicholas Roerich, and of the still stranger and more
+disturbing descriptions of the evilly fabled plateau of Leng which
+occur in the dreaded _Necronomicon_ of the mad Arab Abdul Alhazred. I
+was rather sorry, later on, that I had ever looked into that monstrous
+book at the college library.
+
+On the 7th of November, sight of the westward range having been
+temporarily lost, we passed Franklin Island; and the next day descried
+the cones of Mts. Erebus and Terror on Ross Island ahead, with the long
+line of the Parry Mountains beyond. There now stretched off to the east
+the low, white line of the great ice barrier, rising perpendicularly
+to a height of two hundred feet like the rocky cliffs of Quebec, and
+marking the end of southward navigation.
+
+In the afternoon we entered McMurdo Sound and stood off the coast in
+the lee of smoking Mt. Erebus. The scoriaceous peak towered up some
+twelve thousand seven hundred feet against the eastern sky, like a
+Japanese print of the sacred Fujiyama, while beyond it rose the white,
+ghostlike height of Mt. Terror, ten thousand nine hundred feet in
+altitude, and now extinct as a volcano.
+
+Puffs of smoke from Erebus came intermittently, and one of the graduate
+assistants--a brilliant young fellow named Danforth--pointed out what
+looked like lava on the snowy slope, remarking that this mountain,
+discovered in 1840, had undoubtedly been the source of Poe's image
+when he wrote seven years later:
+
+      "--the lavas that restlessly roll
+    Their sulphurous currents down Yaanek
+      In the ultimate climes of the pole--
+    That groan as they roll down Mount Yaanek
+      In the realms of the boreal pole."
+
+Danforth was a great reader of bizarre material, and had talked a
+good deal of Poe. I was interested myself because of the antarctic
+scene of Poe's only long story--the disturbing and enigmatical _Arthur
+Gordon Pym_. On the barren shore, and on the lofty ice barrier in the
+background, myriad of grotesque penguins squawked and flapped their
+fins, while many fat seals were visible on the water, swimming or
+sprawling across large cakes of slowly drifting ice.
+
+Using small boats, we effected a difficult landing on Ross Island
+shortly after midnight, on the morning of the 9th, carrying a line of
+cable from each of the ships and preparing to unload supplies by means
+of a breeches-buoy arrangement.
+
+Our sensations on first treading antarctic soil were poignant and
+complex, even though at this particular point the Scott and Shackleton
+expeditions had preceded us.
+
+Our camp on the frozen shore below the volcano's slope was only a
+provisional one, headquarters being kept aboard the _Arkham_. We landed
+all our drilling apparatus, dogs, sledges, tents, provisions, gasoline
+tanks, experimental ice-melting outfit, cameras, both ordinary and
+aërial, aëroplane parts, and other accessories, including three small
+portable wireless outfits--besides those in the planes--capable of
+communicating with the _Arkham's_ large outfit from any part of the
+antarctic continent that we would be likely to visit.
+
+The ship's outfit, communicating with the outside world, was to convey
+press reports to the _Arkham Advertiser's_ powerful wireless station
+on Kingsport Head, Mass. We hoped to complete our work during a single
+antarctic summer; but if this proved impossible we would winter on the
+_Arkham_, sending the _Miskatonic_ north before the freezing of the ice
+for another summer's supplies.
+
+       *       *       *       *       *
+
+I need not repeat what the newspapers have already published about our
+early work: of our ascent of Mt. Erebus; our successful mineral borings
+at several points on Ross Island and the singular speed with which
+Pabodie's apparatus accomplished them, even through solid rock layers;
+our provisional test of the small ice-melting equipment; our perilous
+ascent of the great barrier with sledges and supplies; and our final
+assembling of five huge aëroplanes at the camp atop the barrier.
+
+The health of our land party--twenty men and fifty-five Alaskan sledge
+dogs--was remarkable, though of course we had so far encountered no
+really destructive temperatures or windstorms.
+
+For the most part, the thermometer varied between zero and 20° or 25°
+above, and our experience with New England winters had accustomed us to
+rigors of this sort. The barrier camp was semipermanent, and destined
+to be a storage cache for gasoline, provisions, dynamite, and other
+supplies.
+
+Only four of our planes were needed to carry the actual exploring
+material, the fifth being left with a pilot and two men, from the
+ships, at the storage cache to form a means of reaching us from the
+_Arkham_ in case all our exploring planes were lost.
+
+Later, when not using all the other planes for moving apparatus, we
+would employ one or two in a shuttle transportation service between
+this cache and another permanent base on the great plateau from six
+hundred to seven hundred miles southward, beyond Beardmore Glacier.
+
+Despite the almost unanimous accounts of appalling winds and tempests
+that pour down from the plateau, we determined to dispense with
+intermediate bases, taking our chances in the interest of economy and
+probable efficiency.
+
+Wireless reports have spoken of the breathtaking, four-hour, nonstop
+flight of our squadron on November 21st over the lofty shelf ice, with
+vast peaks rising on the west, and the unfathomed silences echoing to
+the sound of our engines.
+
+Wind troubled us only moderately, and our radio compasses helped us
+through the one opaque fog we encountered. When the vast rise loomed
+ahead, between Latitudes 83° and 84°, we knew we had reached Beardmore
+Glacier, the largest valley glacier in the world, and that the frozen
+sea was now giving place to a frowning and mountainous coast line.
+
+At last we were truly entering the white, æon-dead world of the
+ultimate south. Even as we realized it we saw the peak of Mt. Nansen
+in the eastern distance, towering up to its height of almost fifteen
+thousand feet.
+
+The successful establishment of the southern base above the glacier in
+Latitude 86° 7´, East Longitude 174° 23´, and the phenomenally rapid
+and effective borings and blastings made at various points reached by
+our sledge trips and short aëroplane flights, are matters of history;
+as is the arduous and triumphant ascent of Mt. Nansen by Pabodie and
+two of the graduate students--Gedney and Carroll--on December 13th to
+15th.
+
+We were some eight thousand five hundred feet above sea-level. When
+experimental drillings revealed solid ground only twelve feet down
+through the snow and ice at certain points, we made considerable use of
+the small melting apparatus and sunk bores and performed dynamiting at
+many places, where no previous explorer had ever thought of securing
+mineral specimens.
+
+The pre-Cambrian granites and beacon sandstones thus obtained confirmed
+our belief that this plateau was homogeneous, with the great bulk of
+the continent to the west, but somewhat different from the parts lying
+eastward below South America--which we then thought to form a separate
+and smaller continent divided from the larger one by a frozen junction
+of Ross and Weddell Seas, though Byrd has since disproved the report.
+
+In certain of the sandstones, dynamited and chiseled after boring
+revealed their nature, we found some highly interesting fossil markings
+and fragments; notably ferns, seaweeds, trilobites, crinoids, and such
+mollusks as linguellæ and gastropods--all of which seemed of real
+significance in connection with the region's primordial history. There
+was also a queer triangular, striated marking, about a foot in greatest
+diameter, which Lake pieced together from three fragments of slate
+brought up from a deep-blasted aperture.
+
+These fragments came from a point to the westward, near the Queen
+Alexandra Range; and Lake, as a biologist, seemed to find their curious
+marking unusually puzzling and provocative, though to my geological eye
+it looked not unlike some of the ripple effects reasonably common in
+the sedimentary rocks.
+
+Since slate is no more than a metamorphic formation into which a
+sedimentary stratum is pressed, and since the pressure itself produces
+odd distorting effects on any markings which may exist, I saw no reason
+for extreme wonder over the striated depression.
+
+       *       *       *       *       *
+
+On January 6, 1931, Lake, Pabodie, Daniels, all six of the students,
+four mechanics, and myself flew directly over the south pole in two
+of the great planes, being forced down once by a sudden high wind,
+which, fortunately, did not develop into a typical storm. This was,
+as the papers have stated, one of several observation flights, during
+others of which we tried to discern new topographical features in areas
+unreached by previous explorers.
+
+Our early flights were disappointing in this latter respect, though
+they afforded us some magnificent examples of the richly fantastic and
+deceptive mirages of the polar regions, of which our sea voyage had
+given us some brief foretastes.
+
+Distant mountains floated in the sky as enchanted cities, and often the
+whole white world would dissolve into a gold, silver, and scarlet land
+of Dunsanian dreams and adventurous expectancy under the magic of the
+low midnight sun.
+
+On cloudy days we had considerable trouble in flying, owing to the
+tendency of snowy earth and sky to merge into one mystical opalescent
+void with no visible horizon to mark the junction of the two.
+
+At length we resolved to carry out our original plan of flying five
+hundred miles eastward with all four exploring planes and establishing
+a fresh sub-base at a point which would probably be on the smaller
+continental division, as we mistakenly conceived it. Geological
+specimens obtained there would be desirable for purposes of comparison.
+
+Our health so far had remained excellent--lime juice well offsetting
+the steady diet of tinned and salted food, and temperatures generally
+above zero enabling us to do without our thickest furs.
+
+It was now midsummer, and with haste and care we might be able to
+conclude work by March and avoid a tedious wintering through the long
+antarctic night. Several savage windstorms had burst upon us from the
+west, but we had escaped damage through the skill of Atwood in devising
+rudimentary aëroplane shelters and windbreaks of heavy snow blocks, and
+in reinforcing the principal camp buildings with snow. Our good luck
+and efficiency had indeed been almost uncanny.
+
+The outside world knew, of course, of our program, and was told also
+of Lake's strange and dogged insistence on a westward--or rather,
+northwestward--prospecting trip before our radical shift to the new
+base.
+
+It seems that he had pondered a great deal and with alarmingly radical
+daring over that triangular striated marking in the slate; reading into
+it certain contradictions in nature and geological period which whetted
+his curiosity to the utmost, and made him avid to sink more borings
+and blastings in the west-stretching formation to which the exhumed
+fragments evidently belonged.
+
+He was strangely convinced that the marking was the print of some
+bulky, unknown, and radically unclassifiable organism of considerably
+advanced evolution, notwithstanding that the rock which bore it was of
+so vastly ancient a date--Cambrian if not actually pre-Cambrian--as to
+preclude the probable existence not only of all highly evolved life,
+but of any life at all above the unicellular or at most the trilobite
+stage. These fragments, with their odd marking, must have been five
+hundred million to a thousand million years old.
+
+
+
+
+                                  II.
+
+
+Popular imagination, I judge, responded actively to our wireless
+bulletins of Lake's start northwestward into regions never trodden
+by human foot or penetrated by human imagination, though we did not
+mention his wild hopes of revolutionizing the entire sciences of
+biology and geology.
+
+His preliminary sledging and boring journey of January 11th to 18th
+with Pabodie and five others--marred by the loss of two dogs in an
+upset when crossing one of the great pressure ridges in the ice--had
+brought up more and more of the Archæan slate; and even I was
+interested by the singular profusion of evident fossil markings in that
+unbelievably ancient stratum.
+
+These markings, however, were of very primitive life forms involving
+no great paradox except that any life forms should occur in rock as
+definitely pre-Cambrian as this seemed to be; hence I still failed to
+see the good sense of Lake's demand for an interlude in our time-saving
+program--an interlude requiring the use of all four planes, many men,
+and the whole of the expedition's mechanical apparatus.
+
+I did not, in the end, veto the plan, though I decided not to accompany
+the northwestward party despite Lake's plea for my geological advice.
+While they were gone, I would remain at the base with Pabodie and five
+men and work out final plans for the eastward shift. In preparation for
+this transfer, one of the planes had begun to move up a good gasoline
+supply from McMurdo Sound; but this could wait temporarily. I kept
+with me one sledge and nine dogs, since it is unwise to be at any time
+without possible transportation in an utterly tenantless world of
+æon-long death.
+
+Lake's subexpedition into the unknown, as every one will recall, sent
+out its own reports from the short-wave transmitters on the planes;
+these being simultaneously picked up by our apparatus at the southern
+base and by the _Arkham_ at McMurdo Sound, whence they were relayed to
+the outside world on wave lengths up to fifty meters.
+
+The start was made January 22nd at 4 a.m.; and the first wireless
+message we received came only two hours later, when Lake spoke of
+descending and starting a small-scale ice-melting and bore at a point
+some three hundred miles away from us. Six hours after that a second
+and very excited message told of the frantic, beaverlike work whereby a
+shallow shaft had been sunk and blasted, culminating in the discovery
+of slate fragments with several markings approximately like the one
+which had caused the original puzzlement.
+
+Three hours later a brief bulletin announced the resumption of the
+flight in the teeth of a raw and piercing gale; and when I dispatched
+a message of protest against further hazards, Lake replied curtly that
+his new specimens made any hazard worth taking.
+
+I saw that his excitement had reached the point of mutiny, and that I
+could do nothing to check this headlong risk of the whole expedition's
+success; but it was appalling to think of his plunging deeper and
+deeper into that treacherous and sinister white immensity of tempests
+and unfathomed mysteries which stretched off for some fifteen hundred
+miles to the half-known, half-suspected coast line of Queen Mary and
+Knox Lands.
+
+       *       *       *       *       *
+
+Then, in about an hour and a half more, came that doubly excited
+message from Lake's moving plane, which almost reversed my sentiments
+and made me wish I had accompanied the party:
+
+    "10:05 p.m. On the wing. After snowstorm, have spied mountain range
+    ahead higher than any hitherto seen. May equal Himalayas, allowing
+    for height of plateau. Probable Latitude 76° 15´, Longitude 113° 10´
+    E. Reaches far as can see to right and left. Suspicion of two
+    smoking cones. All peaks black and bare of snow. Gale blowing off
+    them impedes navigation."
+
+After that Pabodie, the men, and I hung breathlessly over the receiver.
+Thought of this titanic mountain rampart seven hundred miles away
+inflamed our deepest sense of adventure; and we rejoiced that our
+expedition, if not ourselves personally, had been its discoverers. In
+half an hour Lake called us again:
+
+    "Moulton's plane forced down on plateau in foothills, but nobody
+    hurt and perhaps can repair. Shall transfer essentials to other
+    three for return or further moves if necessary, but no more heavy
+    plane travel needed just now. Mountains surpass anything in
+    imagination. Am going up scouting in Carroll's plane, with all
+    weight out.
+
+    "You can't imagine anything like this. Highest peaks must go over
+    thirty-five thousand feet. Everest out of the running, Atwood to
+    work out height with theodolite while Carroll and I go up. Probably
+    wrong about cones, for formations look stratified. Possibly
+    pre-Cambrian slate with other strata mixed in. Queer sky line
+    effects--regular sections of cubes clinging to highest peaks. Whole
+    thing marvelous in red-gold light of low sun. Like land of mystery
+    in a dream or gateway to forbidden world of untrodden wonder. Wish
+    you were here to study."
+
+Though it was technically sleeping time, not one of us listeners
+thought for a moment of retiring. It must have been a good deal
+the same at McMurdo Sound, where the supply cache and the _Arkham_
+were also getting the messages; for Captain Douglas gave out a call
+congratulating everybody on the important find, and Sherman, the cache
+operator, seconded his sentiments. We were sorry, of course, about the
+damaged aëroplane, but hoped it could be easily mended. Then, at eleven
+p.m., came another call from Lake:
+
+    "Up with Carroll over highest foothills. Don't dare try really tall
+    peaks in present weather, but shall later. Frightful work climbing,
+    and hard going at this altitude, but worth it. Great range fairly
+    solid, hence can't get any glimpses beyond. Main summits exceed
+    Himalayas, and very queer. Range looks like pre-Cambrian slate,
+    with plain signs of many other upheaved strata. Was wrong about
+    volcanism. Goes farther in either direction than we can see. Swept
+    clear of snow above about twenty-one thousand feet.
+
+    "Odd formations on slopes of highest mountains. Great low square
+    blocks with exactly vertical sides, and rectangular lines of low,
+    vertical ramparts, like the old Asian castles clinging to steep
+    mountains in Roerich's paintings. Impressive from distance. Flew
+    close to some, and Carroll thought they were formed of smaller
+    separate pieces, but that is probably weathering. Most edges
+    crumbled and rounded off as if exposed to storms and climate
+    changes for millions of years.
+
+    "Parts, especially upper parts, seem to be of lighter-colored
+    rock than any visible strata on slopes proper, hence an evidently
+    crystalline origin. Close flying shows many cave mouths, some
+    unusually regular in outline, square or semicircular. You must come
+    and investigate. Think I saw rampart squarely on top of one peak.
+    Height seems about thirty thousand to thirty-five thousand feet. Am
+    up twenty-one thousand five hundred myself, in devilish, gnawing
+    cold. Wind whistles and pipes through passes and in and out of
+    caves, but no flying danger so far."
+
+From then on for another half hour Lake kept up a running fire of
+comment, and expressed his intention of climbing some of the peaks on
+foot. I replied that I would join him as soon as he could send a plane,
+and that Pabodie and I would work out the best gasoline plan--just
+where and how to concentrate our supply in view of the expedition's
+altered character.
+
+Obviously, Lake's boring operations, as well as his aëroplane
+activities, would need a great deal delivered at the new base which
+he was to establish at the foot of the mountains; and it was possible
+that the eastward flight might not be made, after all, this season. In
+connection with this business I called Captain Douglas and asked him to
+get as much as possible out of the ships and up the barrier with the
+single dog team we had left there. A direct route across the unknown
+region between Lake and McMurdo Sound was what we really ought to
+establish.
+
+Lake called me later to say that he had decided to let the camp stay
+where Moulton's plane had been forced down, and where repairs had
+already progressed somewhat. The ice sheet was very thin, with dark
+ground here and there visible, and he would sink some borings and
+blasts at that very point before making any sledge trips or climbing
+expeditions.
+
+He spoke of the ineffable majesty of the whole scene, and the queer
+state of his sensations at being in the lee of vast, silent pinnacles,
+whose ranks shot up like a wall reaching the sky at the world's rim.
+
+[Illustration: _It was a queer state of sensations--being in the lee of
+vast, silent pinnacles, where ranks shot up like a wall reaching the
+sky at the world's rim._]
+
+Atwood's theodolite observations had placed the height of the five
+tallest peaks at from thirty thousand to thirty-four thousand feet.
+
+The windswept nature of the terrain clearly disturbed Lake, for it
+argued the occasional existence of prodigious gales, violent beyond
+anything we had so far encountered. His camp lay a little more than
+five miles from where the higher foothills rose abruptly.
+
+I could almost trace a note of subconscious alarm in his words--flashed
+across a glacial void of seven hundred miles--as he urged that we all
+hasten with the matter and get the strange, new region disposed of as
+soon as possible. He was about to rest now, after a continuous day's
+work of almost unparalleled speed, strenuousness, and results.
+
+       *       *       *       *       *
+
+In the morning I had a three-cornered wireless talk with Lake and
+Captain Douglas at their widely separated bases. It was agreed that one
+of Lake's planes would come to my base for Pabodie, the five men, and
+myself, as well as for all the fuel it could carry. The rest of the
+fuel question, depending on our decision about an easterly trip, could
+wait for a few days, since Lake had enough for immediate camp heat and
+borings.
+
+Eventually the old southern base ought to be restocked, but if we
+postponed the easterly trip we would not use it till the next summer,
+and, meanwhile, Lake must send a plane to explore a direct route
+between his new mountains and McMurdo Sound.
+
+Pabodie and I prepared to close our base for a short or long period, as
+the case might be. If we wintered in the antarctic we would probably
+fly straight from Lake's base to the _Arkham_ without returning to
+this spot. Some of our conical tents had already been reinforced by
+blocks of hard snow, and now we decided to complete the job of making a
+permanent village. Owing to a very liberal tent supply, Lake had with
+him all that his base would need, even after our arrival. I wirelessed
+that Pabodie and I would be ready for the northwestward move after one
+day's work and one night's rest.
+
+Our labors, however, were not very steady after four p.m., for about
+that time Lake began sending in the most extraordinary and excited
+messages. His working day had started unpropitiously, since an
+aëroplane survey of the nearly exposed rock surfaces showed an entire
+absence of those Archæan and primordial strata for which he was
+looking, and which formed so great a part of the colossal peaks that
+loomed up at a tantalizing distance from the camp.
+
+Most of the rocks glimpsed were apparently Jurassic and Comanchean
+sandstones and Permian and Triassic schists, with now and then a glossy
+black outcropping suggesting a hard and slaty coal.
+
+This rather discouraged Lake, whose plans all hinged on unearthing
+specimens more than five hundred million years older. It was clear
+to him that in order to recover the Archæan slate vein in which he
+had found the odd markings, he would have to make a long sledge trip
+from these foothills to the steep slopes of the gigantic mountains
+themselves.
+
+He had resolved, nevertheless, to do some local boring as part of the
+expedition's general program; hence, he set up the drill and put five
+men to work with it while the rest finished settling the camp and
+repairing the damaged aëroplane. The softest visible rock--a sandstone
+about a quarter of a mile from the camp--had been chosen for the
+first sampling; and the drill made excellent progress without much
+supplementary blasting.
+
+It was about three hours afterward, following the first really heavy
+blast of the operation, that the shouting of the drill crew was heard;
+and that young Gedney--the acting foreman--rushed into the camp with
+the startling news.
+
+       *       *       *       *       *
+
+They had struck a cave. Early in the boring the sandstone had given
+place to a vein of Comanchean limestone, full of minute fossil
+cephalopods, corals, echini, and spirifera, and with occasional
+suggestions of siliceous sponges and marine vertebrate bones--the
+latter probably of teliosts, sharks, and ganoids.
+
+This, in itself, was important enough, as affording the first
+vertebrate fossils the expedition had yet secured; but when shortly
+afterward the drill head dropped through the stratum into apparent
+vacancy, a wholly new and doubly intense wave of excitement spread
+among the excavators.
+
+A good-sized blast had laid open the subterrane secret; and now,
+through a jagged aperture perhaps five feet across and three feet
+thick, there yawned before the avid searchers a section of shallow
+limestone hollowing worn more than fifty million years ago by the
+trickling ground waters of a bygone tropic world.
+
+The hollowed layer was not more than seven or eight feet deep, but
+extended off indefinitely in all directions and had a fresh, slightly
+moving air which suggested its membership in an extensive subterranean
+system. Its roof and floor were abundantly equipped with large
+stalactites and stalagmites, some of which met in columnar form.
+
+But important above all else was the vast deposit of shells and bones,
+which in places nearly choked the passage. Washed down from unknown
+jungles of Mesozoic tree ferns and fungi, and forests of Tertiary
+cycads, fan palms, and primitive angiosperms, this osseous medley
+contained representatives of more Cretaceous, Eocene, and other
+animal species than the greatest palæontologist could have counted or
+classified in a year. Mollusks, crustacean armor, fishes, amphibians,
+reptiles, birds, and early mammals--great and small, known and unknown.
+
+No wonder Gedney ran back to the camp shouting, and no wonder every one
+else dropped work and rushed headlong through the biting cold to where
+the tall derrick marked a new-found gateway to secrets of inner earth
+and vanished æons.
+
+When Lake had satisfied the first keen edge of his curiosity he
+scribbled a message in his notebook and had young Moulton run back to
+the camp to dispatch it by wireless.
+
+This was my first word of the discovery, and it told of the
+identification of early shells, bones of ganoids and placoderms,
+remnants of labyrinthodonta and thecoiidea, great mosasaur skull
+fragments, dinosaur vertebræ and armor plates, pterodactyl teeth and
+wing bones, Archaeopteryx débris, Miocene sharks' teeth, primitive
+bird skulls, and other bones of archaic mammals such as Palæotheres,
+Xiphodons, Eohippi, Oreodons, and Titanotheriidæ.
+
+There was nothing as recent as a mastodon, elephant, true camel, deer,
+or bovine animal; hence Lake concluded that the last deposits had
+occurred during the Oligocene Age, and that the hollowed stratum had
+lain in its present dried, dead, and inaccessible state for at least
+thirty million years.
+
+On the other hand, the prevalence of very early life forms was singular
+in the highest degree. Though the limestone formation was, on the
+evidence of such typical imbedded fossils as ventriculites, positively
+and unmistakably Comanchean and not a particle earlier; the free
+fragments in the hollow space included a surprising proportion from
+organisms hitherto considered as peculiar to far older periods--even
+rudimentary fishes, mollusks, and corals as remote as the Silurian or
+Ordovician.
+
+The inevitable inference was that in this part of the world there had
+been a remarkable and unique degree of continuity between the life of
+over three hundred million years ago and that of only thirty million
+years ago. How far this continuity had extended beyond the Oligocene
+Age when the cavern was closed was of course past all speculation.
+
+In any event, the coming of the frightful ice in the Pleistocene some
+five hundred thousand years ago--a mere yesterday as compared with the
+age of this cavity--must have put an end to any of the primal forms
+which had locally managed to outlive their common terms.
+
+       *       *       *       *       *
+
+Lake was not content to let his first message stand, but had another
+bulletin written and dispatched across the snow to the camp before
+Moulton could get back. After that Moulton stayed at the wireless in
+one of the planes, transmitting to me--and to the _Arkham_ for relaying
+to the outside world--the frequent postscripts which Lake sent him by a
+succession of messengers.
+
+Those who followed the newspapers will remember the excitement created
+among men of science by that afternoon's reports--reports which have
+finally led, after all these years, to the organization of that very
+Starkweather-Moore Expedition which I am so anxious to dissuade from
+its purposes. I had better give the messages literally as Lake sent
+them, and as our base operator McTighe translated them from his pencil
+shorthand:
+
+    Fowler makes discovery of highest importance in sandstone and
+    limestone fragments from blasts. Several distinct triangular
+    striated prints like those in archæan slate, proving that source
+    survived from over six hundred million years ago to Comanchean
+    times without more than moderate morphological changes and decrease
+    in average size. Comanchean prints apparently more primitive or
+    decadent, if anything, than older ones. Emphasize importance of
+    discovery in press. Will mean to biology what Einstein has meant
+    to mathematics and physics. Joins up with my previous work and
+    amplifies conclusions.
+
+    Appears to indicate, as I suspected, that earth has seen whole cycle
+    or cycles of organic life before known one that begins with
+    Archæozoic cells. Was evolved and specialized not later than a
+    thousand million years ago, when planet was young and recently
+    uninhabitable for any life forms of normal protoplasmic structure.
+    Question arises when, where, and how development took place.
+
+        *       *       *       *       *
+
+    Later. Examining certain skeletal fragments of large land and marine
+    saurians and primitive mammals, find singular local wounds or
+    injuries to bony structure not attributable to any known predatory
+    or carnivorous animal of any period. Of two sorts--straight,
+    penetrant bores, and apparently hacking incisions. One or two
+    cases of cleanly severed bones. Not many specimens affected. Am
+    sending to camp for electric torches. Will extend search area
+    underground by hacking away stalactites.
+
+        *       *       *       *       *
+
+    Still later. Have found peculiar soapstone fragment about six inches
+    across and an inch and a half thick, wholly unlike any visible local
+    formation--greenish, but no evidences to place its period. Has
+    curious smoothness and regularity. Shaped like five-pointed star
+    with tips broken off, and signs of other cleavage at inward angles
+    and in center of surface. Small, smooth depression in center of
+    unbroken surface. Arouses much curiosity as to source and
+    weathering. Probably some freak of water action. Carroll, with
+    magnifier, thinks he can make out additional markings of geologic
+    significance. Groups of tiny dots in regular patterns. Dogs growing
+    uneasy as we work, and seem to hate this soapstone. Must see if it
+    has any peculiar odor. Will report again when Mills gets back with
+    light and we start on underground area.
+
+        *       *       *       *       *
+
+    10:15 p.m. Important discovery. Orrendorf and Watkins, working
+    underground at 9:45 with light, found monstrous barrel-shaped fossil
+    of wholly unknown nature; probably vegetable unless overgrown
+    specimen of unknown marine radiata. Tissue evidently preserved by
+    mineral salts. Tough as leather, but astonishing flexibility
+    retained in places. Marks of broken-off parts at ends and around
+    sides. Six feet end to end, three and five tenths feet central
+    diameter, tapering to one foot at each end. Like a barrel with five
+    bulging ridges in place of staves. Lateral breakages, as of
+    thinnish stalks, are at equator in middle of these ridges. In
+    furrows between ridges are curious growths--combs or wings that
+    fold up and spread out like fans. All greatly damaged but one,
+    which gives almost seven-foot wing spread. Arrangement reminds one
+    of certain monsters of primal myth, especially fabled Elder Things
+    in _Necronomicon_.
+
+    These wings seem to be membranous, stretched on framework of
+    glandular tubing. Apparent minute orifices in frame tubing at wing
+    tips. Ends of body shriveled, giving no clue to interior or to what
+    has been broken off there. Must dissect when we get back to camp.
+    Can't decide whether vegetable or animal. Many features obviously
+    of almost incredible primitiveness. Have set all hands cutting
+    stalactites and looking for further specimens. Additional scarred
+    bones found, but these must wait. Having trouble with dogs. They
+    can't endure the new specimen, and would probably tear it to pieces
+    if we didn't keep it at a distance from them.
+
+        *       *       *       *       *
+
+    11:30 p.m. Attention, Dyer, Pabodie, Douglas. Matter of highest--I
+    might say transcendent--importance. _Arkham_ must relay to Kingsport
+    Head Station at once. Strange barrel growth is the archæan thing
+    that left prints in rocks. Mills, Boudreau, and Fowler discover
+    cluster of thirteen more at underground point forty feet from
+    aperture. Mixed with curiously rounded and configured soapstone
+    fragments smaller than one previously found--star-shaped, but no
+    marks of breakage except at some of the points.
+
+    Of organic specimens, eight apparently perfect, with all appendages.
+    Have brought all to surface, leading off dogs to distance. They
+    cannot stand the things. Give close attention to description and
+    repeat back for accuracy. Papers must get this right.
+
+    Objects are eight feet long all over. Six-foot, five-ridged barrel
+    torso three and five tenths feet central diameter, one foot end
+    diameters. Dark gray, flexible, and infinitely tough. Seven-foot
+    membranous wings of same color, found folded, spread out of furrows
+    between ridges. Wing framework tubular or glandular, or lighter
+    gray, with orifices at wing tips. Spread wings have serrated edge.
+    Around equator, one at central apex of each of the five vertical,
+    stavelike ridges, are five systems of light-gray flexible arms or
+    tentacles found tightly folded to torso but expansible to maximum
+    length of over three feet. Like arms of primitive crinoid. Single
+    stalks three inches diameter branch after six inches into five
+    substalks, each of which branches after eight inches into five
+    small, tapering tentacles or tendrils, giving each stalk a total
+    of twenty-five tentacles.
+
+    At top of torso blunt, bulbous neck of lighter gray, with gill-like
+    suggestions, holds yellowish five-pointed starfish-shaped apparent
+    head covered with three-inch wiry cilia of various prismatic colors.
+
+    Head thick and puffy, about two feet point to point, with three-inch
+    flexible yellowish tubes projecting from each point. Slit in exact
+    center of top probably breathing aperture. At end of each tube is
+    spherical expansion where yellowish membrane rolls back on handling
+    to reveal glassy, red-irised globe, evidently an eye.
+
+    Five slightly longer reddish tubes start from inner angles of
+    starfish-shaped head and end in saclike swellings of same color
+    which, upon pressure, open to bell-shaped orifices two inches
+    maximum  diameter and lined with sharp, white tooth-like
+    projections--probable mouths. All these tubes, cilia, and points
+    of starfish head, found folded tightly down; tubes and points
+    clinging to bulbous neck and  torso. Flexibility surprising despite
+    vast toughness.
+
+    At bottom of torso, rough but dissimilarly functioning counterparts
+    of head arrangements exist. Bulbous light-gray pseudoneck, without
+    gill suggestions, holds greenish five-pointed starfish arrangement.
+
+    Tough, muscular arms four feet long and tapering from seven inches
+    diameter at base to about two and five tenths at point. To each
+    point is attached small end of a greenish five-veined membranous
+    triangle eight inches long and six wide at farther end. This is the
+    paddle, fin, or pseudofoot which had made prints in rocks from a
+    thousand million to fifty or sixty million years old.
+
+    From inner angles of starfish arrangement project two-foot reddish
+    tubes tapering from three inches diameter at base to one at tip.
+    Orifices at tips. All these parts infinitely tough and leathery,
+    but extremely flexible. Four-foot arms with paddles undoubtedly
+    used for locomotion of some sort, marine or otherwise. When moved,
+    display suggestions of exaggerated muscularity. As found, all
+    these projections tightly folded over pseudoneck and end of torso,
+    corresponding to projections at other end.
+
+    Cannot yet assign positively to animal or vegetable kingdom, but
+    odds now favor animal. Probably represents incredibly advanced
+    evolution of radiata without loss of certain primitive features.
+    Echinoderm resemblances unmistakable despite local contradictory
+    evidences.
+
+    Wing structure puzzles in view of probable marine habitat, but may
+    have use in water navigation. Symmetry is curiously vegetablelike,
+    suggesting vegetable's essential up-and-down structure rather than
+    animal's fore-and-aft structure. Fabulously early date of evolution,
+    preceding even simplest archæan Protozoa hitherto known, baffles all
+    conjecture as to origin.
+
+    Complete specimens have such uncanny resemblance to certain
+    creatures of primal myth that suggestion of ancient existence
+    outside antarctic becomes inevitable. Dyer and Pabodie have read
+    _Necronomicon_ and seen Clark Ashton Smith's nightmare paintings
+    based on text, and will understand when I speak of Elder Things
+    supposed to have created all earth life as jest or mistake. Students
+    have always thought conception formed from morbid imaginative
+    treatment of very ancient tropical radiata. Also like prehistoric
+    folklore things Wilmarth has spoken of--Cthulhu cult appendages,
+    etc.
+
+    Vast field of study opened. Deposits probably of late Cretaceous
+    or early Eocene period, judging from associated specimens. Massive
+    stalagmites deposited above them. Hard work hewing out, but
+    toughness prevented damage. State of preservation miraculous,
+    evidently owing to limestone action. No more found so far, but
+    will resume search later. Job now to get fourteen huge specimens
+    to camp without dogs, which bark furiously and can't be trusted
+    near them.
+
+    With nine men--three left to guard the dogs--we ought to manage the
+    three sledges fairly well, though wind is bad. Must establish plane
+    communication with McMurdo Sound and begin shipping material. But
+    I've got to dissect one of these things before we take any rest.
+    Wish I had a real laboratory here. Dyer better kick himself for
+    having tried to stop my westward trip. First the world's greatest
+    mountains, and then this. If this last isn't the high spot of the
+    expedition, I don't know what is. We're made scientifically.
+    Congrats, Pabodie, on the drill that opened up the cave. Now will
+    _Arkham_ please repeat description?
+
+[Illustration: "_I've got to dissect one of these things before_----"
+
+"_First the world's greatest mountains--then this!_"]
+
+The sensations of Pabodie and myself at receipt of this report were
+almost beyond description, nor were our companions much behind us in
+enthusiasm. McTighe, who had hastily translated a few high spots as
+they came from the droning receiving set, wrote out the entire message
+from his shorthand version, as soon as Lake's operator signed off.
+
+All appreciated the epoch-making significance of the discovery, and
+I sent Lake congratulations as soon as the _Arkham's_ operator had
+repeated back the descriptive parts as requested; and my example was
+followed by Sherman from his station at the McMurdo Sound supply cache,
+as well as by Captain Douglas of the _Arkham_.
+
+Later, as head of the expedition, I added some remarks to be relayed
+through the _Arkham_ to the outside world. Of course, rest was an
+absurd thought amidst this excitement; and my only wish was to get to
+Lake's camp as quickly as I could. It disappointed me when he sent word
+that a rising mountain gale made early aërial travel impossible.
+
+But within an hour and a half interest again rose to banish
+disappointment. Lake, sending more messages, told of the completely
+successful transportation of the fourteen great specimens to the camp.
+It had been a hard pull, for the things were surprisingly heavy; but
+nine men had accomplished it very neatly. Now some of the party were
+hurriedly building a snow corral at a safe distance from the camp, to
+which the dogs could be brought for greater convenience in feeding. The
+specimens were laid out on the hard snow near the camp, save for one on
+which Lake was making crude attempts at dissection.
+
+This dissection seemed to be a greater task than had been expected,
+for, despite the heat of a gasoline stove in the newly raised
+laboratory tent, the deceptively flexible tissues of the chosen
+specimen--a powerful and intact one--lost nothing of their more than
+leathery toughness. Lake was puzzled as to how he might make the
+requisite incisions without violence destructive enough to upset all
+the structural niceties he was looking for.
+
+He had, it is true, seven more perfect specimens; but these were too
+few to use up recklessly unless the cave might later yield an unlimited
+supply. Accordingly, he removed the specimen and dragged in one which,
+though having remnants of the starfish arrangements at both ends, was
+badly crushed and partly disrupted along one of the great torso furrows.
+
+Results, quickly reported over the wireless, were baffling and
+provocative indeed. Nothing like delicacy or accuracy was possible with
+instruments hardly able to cut the anomalous tissue, but the little
+that was achieved left us all awed and bewildered.
+
+Existing biology would have to be wholly revised, for this thing was no
+product of any cell growth science knows about. There had been scarcely
+any mineral replacement, and despite an age of perhaps forty million
+years the internal organs were wholly intact.
+
+The leathery, undeteriorative, and almost indestructible quality was an
+inherent attribute of the thing's form of organization, and pertained
+to some paleocene cycle of invertebrate evolution utterly beyond our
+powers of speculation.
+
+At first all that Lake found was dry, but as the heated tent produced
+its thawing effect, organic moisture of pungent and offensive odor
+was encountered toward the thing's uninjured side. It was not blood,
+but a thick, dark-green fluid apparently answering the same purpose.
+By the time Lake reached this stage all thirty-seven dogs had been
+brought to the still uncompleted corral near the camp, and even at that
+distance set up a savage barking and show of restlessness at the acrid,
+diffusive smell.
+
+       *       *       *       *       *
+
+Far from helping to place the strange entity, this provisional
+dissection merely deepened its mystery. All guesses about its external
+members had been correct, and on the evidence of these one could hardly
+hesitate to call the thing animal, but internal inspection brought up
+so many vegetable evidences that Lake was left hopelessly at sea. It
+had digestion and circulation, and eliminated waste matter through the
+reddish tubes of its starfish-shaped base.
+
+Cursorily, one would say that its respiratory apparatus handled oxygen
+rather than carbon dioxide; and there were odd evidences of air-storage
+chambers and methods of shifting respiration from the external orifice
+to at least two other fully developed breathing systems--gills and
+pores.
+
+Clearly, it was amphibian and probably adapted to long airless
+hibernation periods as well. Vocal organs seemed present in connection
+with the main respiratory system, but they presented anomalies beyond
+immediate solution. Articulate speech, in the sense of syllable
+utterance, seemed barely conceivable, but musical piping notes covering
+a wide range were highly probable. The muscular system was almost
+pre-naturally developed.
+
+The nervous system was so complex and highly developed as to leave Lake
+aghast. Though excessively primitive and archaic in some respects, the
+thing had a set of gangliar centers and connectives arguing the very
+extremes of specialized development.
+
+Its five-lobed brain was surprisingly advanced, and there were signs of
+a sensory equipment, served in part through the wiry cilia of the head,
+involving factors alien to any other terrestrial organism. Probably it
+had more than five senses, so that its habits could not be predicted
+from any existing analogy.
+
+It must, Lake thought, have been a creature of keen sensitiveness and
+delicately differentiated functions in its primal world--much like the
+ants and bees of to-day. It reproduced like the vegetable cryptogams,
+especially the pteridophyta; having spore cases at the tips of the
+wings and evidently developing from a thallus or prothallus.
+
+But to give it a name at this stage was mere folly. It looked like a
+radiate, but was clearly something more. It was partly vegetable, but
+had three fourths of the essentials of animal structure. That it was
+marine in origin, its symmetrical contour and certain other attributes
+clearly indicated; yet one could not be exact as to the limit of its
+later adaptations.
+
+The wings, after all, held a persistent suggestion of the aërial.
+How it could have undergone its tremendously complex evolution on a
+new-born earth in time to leave prints in archæan rocks was so far
+beyond conception as to make Lake whimsically recall the primal myths
+about Great Old Ones who filtered down from the stars and concocted
+earth life as a joke or mistake; and the wild tales of cosmic hill
+things from outside told by a folklorist colleague in Miskatonic's
+English department.
+
+       *       *       *       *       *
+
+Naturally, he considered the possibility of the pre-Cambrian prints
+having been made by a less evolved ancestor of the present specimens,
+but quickly rejected this too-facile theory upon considering the
+advanced structural qualities of the older fossils. If anything, the
+later contours showed decadence rather than higher evolution.
+
+The size of the pseudofeet had decreased, and the whole morphology
+seemed coarsened and simplified. Moreover, the nerves and organs,
+just examined, held singular suggestions of retrogression from forms
+still more complex. Atrophied and vestigial parts were surprisingly
+prevalent. Altogether, little could be said to have been solved; and
+Lake fell back on mythology for a provisional name--jocosely dubbing
+his finds "The Elder Ones."
+
+At about two-thirty a.m., having decided to postpone further work and
+get a little rest, he covered the dissected organism with a tarpaulin,
+emerged from the laboratory tent, and studied the intact specimens with
+renewed interest.
+
+The ceaseless antarctic sun had begun to limber up their tissues a
+trifle, so that the head points and tubes of two or three showed
+signs of unfolding; but Lake did not believe there was any danger of
+immediate decomposition in the almost subzero air. He did, however,
+move all the undissected specimens closer together and throw a spare
+tent over them in order to keep off the direct solar rays. That
+would also help to keep their possible scent away from the dogs,
+whose hostile unrest was really becoming a problem, even at their
+substantial distance and behind the higher and higher snow walls, which
+an increased quota of the men were hastening to raise around their
+quarters.
+
+He had to weight down the corners of the tent cloth with heavy blocks
+of snow to hold it in place amidst the rising gale, for the titan
+mountains seemed about to deliver some gravely severe blasts. Early
+apprehensions about sudden antarctic winds were revived, and under
+Atwood's supervision precautions were taken to bank the tents, new dog
+corral, and crude aëroplane shelters with snow, on the mountainward
+side. These latter shelters, begun with hard snow blocks during odd
+moments, were by no means as high as they should have been; and Lake
+finally detached all hands from other tasks to work on them.
+
+It was after four when Lake at last prepared to sign off and advised
+us all to share the rest period his outfit would take when the shelter
+walls were a little higher. He held some friendly chat with Pabodie
+over the ether, and repeated his praise of the really marvelous drills
+that had helped him make his discovery. Atwood also sent greetings and
+praises.
+
+I gave Lake a warm word of congratulation, owning up that he was right
+about the western trip, and we all agreed to get in touch by wireless
+at ten in the morning. If the gale was then over, Lake would send a
+plane for the party at my base. Just before retiring I dispatched a
+final message to the _Arkham_, with instructions about toning down the
+day's news for the outside world, since the full details seemed radical
+enough to rouse a wave of incredulity until further substantiated.
+
+
+
+
+                                 III.
+
+
+None of us, I imagine, slept very heavily or continuously that morning.
+Both the excitement of Lake's discovery and the mounting fury of the
+wind were against such a thing. So savage was the blast even where we
+were, that we could not help wondering how much worse it was at Lake's
+camp, directly under the vast unknown peaks that bred and delivered it.
+
+McTighe was awake at ten o'clock and tried to get Lake on the wireless,
+as agreed, but some electrical condition in the disturbed air to the
+westward seemed to prevent communication. We did, however, get the
+_Arkham_, and Douglas told me that he had likewise been vainly trying
+to reach Lake. He had not known about the wind, for very little was
+blowing at McMurdo Sound, despite its persistent rage where we were.
+
+Throughout the day we all listened anxiously and tried to get Lake at
+intervals, but invariably without results. About noon a positive frenzy
+of wind stampeded out of the west, causing us to fear for the safety of
+our camp; but it eventually died down, with only a moderate relapse at
+two p.m.
+
+After three o'clock it was very quiet, and we redoubled our efforts to
+get Lake. Reflecting that he had four planes, each provided with an
+excellent short-wave outfit, we could not imagine any ordinary accident
+capable of crippling all his wireless equipment at once. Nevertheless,
+the stony silence continued, and when we thought of the delirious force
+the wind must have had in his locality we could not help making the
+most direful conjectures.
+
+By six o'clock our fears had become intense and definite, and after a
+wireless consultation with Douglas and Thorfinnssen I resolved to take
+steps toward investigation. The fifth aëroplane, which we had left
+at the McMurdo Sound supply cache with Sherman and two sailors, was
+in good shape and ready for instant use, and it seemed that the very
+emergency for which it had been saved was now upon us.
+
+I got Sherman by wireless and ordered him to join me with the plane
+and the two sailors at the southern base as quickly as possible, the
+air conditions being apparently highly favorable. We then talked over
+the personnel of the coming investigation party, and decided that we
+would include all hands, together with the sledge and dogs which I
+had kept with me. Even so great a load would not be too much for one
+of the huge planes built to our special orders for heavy machinery
+transportation. At intervals I still tried to reach Lake with the
+wireless, but all to no purpose.
+
+Sherman, with the sailors Gunnarsson and Larsen, took off at seven
+thirty; and reported a quiet flight from several points on the wing.
+They arrived at our base at midnight, and all hands at once discussed
+the next move. It was risky business sailing over the antarctic in a
+single aëroplane without any line of bases, but no one drew back from
+what seemed like the plainest necessity. We turned in at two o'clock
+for a brief rest after some preliminary loading of the plane, but were
+up again in four hours to finish the loading and packing.
+
+At seven fifteen a.m., January 25th, we started northwestward under
+McTighe's pilotage with ten men, seven dogs, a sledge, a fuel and food
+supply, and other items including the plane's wireless outfit. The
+atmosphere was clear, fairly quiet, and relatively mild in temperature,
+and we anticipated very little trouble in reaching the latitude and
+longitude designated by Lake as the site of his camp. Our apprehensions
+were over what we might find, or fail to find, at the end of our
+journey, for silence continued to answer all calls dispatched to the
+camp.
+
+       *       *       *       *       *
+
+Every incident of that four-and-a-half-hour flight is burned into my
+recollection because of its crucial position in my life. It marked my
+loss, at the age of fifty-four, of all that peace and balance which the
+normal mind possesses through its accustomed conception of external
+nature and nature's laws.
+
+Thenceforward the ten of us--but the student Danforth and myself
+above all others--were to face a hideously amplified world of lurking
+horrors which nothing can erase from our emotions, and which we
+would refrain from sharing with mankind in general if we could. The
+newspapers have printed the bulletins we sent from the moving plane,
+telling of our nonstop course, our two battles with treacherous
+upper-air gales, our glimpse of the broken surface where Lake had sunk
+his mid-journey shaft three days before, and our sight of a group of
+those strange fluffy snow cylinders noted by Amundsen and Byrd as
+rolling in the wind across the endless leagues of frozen plateau.
+
+There came a point, though, when our sensations could not be conveyed
+in any words the press would understand, and a later point when we had
+to adopt an actual rule of strict censorship.
+
+The sailor Larsen was first to spy the jagged line of witchlike cones
+and pinnacles ahead, and his shouts sent every one to the windows of
+the great cabined plane. Despite our speed, they were very slow in
+gaining prominence; hence we knew that they must be infinitely far off,
+and visible only because of their abnormal height.
+
+Little by little, however, they rose grimly into the western sky,
+allowing us to distinguish various bare, bleak, blackish summits, and
+to catch the curious sense of phantasy which they inspired as seen
+in the reddish antarctic light against the provocative background of
+iridescent ice-dust clouds.
+
+In the whole spectacle there was a persistent, pervasive hint of
+stupendous secrecy and potential revelation. It was as if these
+stark, nightmare spires marked the pylons of a frightful gateway into
+forbidden spheres of dream, and complex gulfs of remote time, space,
+and ultradimensionality. I could not help feeling that they were evil
+things--mountains of madness whose farther slopes looked out over some
+accursed ultimate abyss.
+
+That seething, half-luminous cloud background held ineffable
+suggestions of a vague, ethereal beyondness far more than terrestrially
+spatial, and gave appalling reminders of the utter remoteness,
+separateness, desolation, and æon-long death of this untrodden and
+unfathomed austral world.
+
+       *       *       *       *       *
+
+It was young Danforth who drew our notice to the curious regularities
+of the higher mountain sky line--regularities like clinging fragments
+of perfect cubes, which Lake had mentioned in his messages, and which
+indeed justified his comparison with the dreamlike suggestions of
+primordial temple ruins, on cloudy Asian mountaintops so subtly and
+strangely painted by Roerich.
+
+There was indeed something hauntingly Roerichlike about this whole
+unearthly continent of mountainous mystery. I had felt it in October
+when we first caught sight of Victoria Land, and I felt it afresh now.
+I felt, too, another wave of uneasy consciousness of archæan mythical
+resemblances, of how disturbingly this lethal realm corresponded to the
+evilly famed plateau of Leng in the primal writings.
+
+Mythologists have placed Leng in Central Asia, but the racial memory of
+man--or of his predecessors--is long, and it may well be that certain
+tales have come down from lands and mountains and temples of horror
+earlier than Asia and earlier than any human world we know.
+
+A few daring mystics have hinted at a pre-Pleistocene origin for the
+fragmentary Pnakotic Manuscripts, and have suggested that the devotees
+of Tsathoggua were as alien to mankind as Tsathoggua itself.
+
+Leng, wherever in space or time it might brood, was not a region I
+would care to be in or near, nor did I relish the proximity of a
+world that had ever bred such ambiguous and archæan monstrosities as
+those Lake had just mentioned. At the moment I felt sorry that I had
+ever read the abhorred _Necronomicon_, or talked so much with that
+unpleasantly erudite folklorist Wilmarth at the university.
+
+       *       *       *       *       *
+
+This mood undoubtedly served to aggravate my reaction to the bizarre
+mirage which burst upon us from the increasingly opalescent zenith
+as we drew near the mountains and began to make out the cumulative
+undulations of the foothills. I had seen dozens of polar mirages during
+the preceding weeks, some of them quite as uncanny and fantastically
+vivid as the present sample, but this one had a wholly novel and
+obscure quality of menacing symbolism, and I shuddered as the seething
+labyrinth of fabulous walls and towers and minarets loomed out of the
+troubled ice vapors above our heads.
+
+The effect was that of a Cyclopean city of no architecture known to
+man or to human imagination, with vast aggregations of night-black
+masonry embodying monstrous perversions of geometrical laws. There
+were truncated cones, sometimes terraced or fluted, surmounted by
+tall cylindrical shafts here and there bulbously enlarged and often
+capped with tiers of thinnish scalloped disks, and strange, beetling,
+tablelike constructions suggesting piles of multitudinous rectangular
+slabs or circular plates or five-pointed stars with each one
+overlapping the one beneath.
+
+There were composite cones and pyramids either alone or surmounting
+cylinders or cubes or flatter truncated cones and pyramids, and
+occasional needlelike spires in curious clusters of five.
+
+All of these febrile structures seemed knit together by tubular bridges
+crossing from one to the other at various dizzy heights, and the
+implied scale of the whole was terrifying and oppressive in its sheer
+giganticism.
+
+The general type of mirage was not unlike some of the wilder forms
+observed and drawn by the arctic whaler Scoresby in 1820, but at
+this time and place, with those dark, unknown mountain peaks soaring
+stupendously ahead, that anomalous elder-world discovery in our minds,
+and the pall of probable disaster enveloping the greater part of our
+expedition, we all seemed to find in it a taint of latent malignity and
+infinitely evil portent.
+
+I was glad when the mirage began to break up, though in the process
+the various nightmare turrets and cones assumed distorted, temporary
+forms of even vaster hideousness. As the whole illusion dissolved to
+churning opalescence, we began to look earthward again, and saw that
+our journey's end was not far off.
+
+The unknown mountains ahead rose dizzily up like a fearsome rampart of
+giants, their curious regularities showing with startling clearness
+even without a field glass. We were over the lowest foothills now, and
+could see amidst the snow, ice, and bare patches of their main plateau
+a couple of darkish spots which we took to be Lake's camp and boring.
+
+The higher foothills shot up between five and six miles away, forming a
+range almost distinct from the terrifying line of more than Himalayan
+peaks beyond them. At length Ropes--the student who had relieved
+McTighe at the controls--began to head downward toward the left-hand
+dark spot whose size marked it as the camp. As he did so, McTighe sent
+out the last uncensored wireless message the world was to receive from
+our expedition.
+
+Every one, of course, has read the brief and unsatisfying bulletins of
+the rest of our antarctic sojourn.
+
+Some hours after our landing we sent a guarded report of the tragedy we
+found, and reluctantly announced the wiping out of the whole Lake party
+by the frightful wind of the preceding day, or of the night before
+that. There were eleven known dead, young Gedney was missing.
+
+People pardoned our hazy lack of details through realization of the
+shock the sad event must have caused us, and believed us when we
+explained that the mangling action of the wind had rendered all eleven
+bodies unsuitable for transportation outside.
+
+Indeed, I flatter myself that even in the midst of our distress, utter
+bewilderment, and soul-clutching horror, we scarcely went beyond the
+truth in any specific instance. The tremendous significance lies in
+what we dared not tell; what I would not tell now but for the need of
+warning others off from nameless terrors.
+
+       *       *       *       *       *
+
+It is a fact that the wind had wrought dreadful havoc. Whether all
+could have lived through it, even without the other thing, is gravely
+open to doubt. The storm, with its fury of madly driven ice particles,
+must have been beyond anything our expedition had encountered before.
+
+One aëroplane shelter--all, it seems, had been left in a far too flimsy
+and inadequate state--was nearly pulverized; and the derrick at the
+distant boring was entirely shaken to pieces.
+
+The exposed metal of the grounded planes and drilling machinery was
+bruised into a high polish, and two of the small tents were flattened
+despite their snow banking. Wooden surfaces left out in the blast were
+pitted and denuded of paint, and all signs of tracks in the snow were
+completely obliterated.
+
+It is also true that we found none of the archæan biological objects in
+a condition to take outside as a whole. We did gather some minerals
+from a vast, tumbled pile, including several of the greenish soapstone
+fragments whose odd five-pointed rounding and faint patterns of grouped
+dots caused so many doubtful comparisons, and some fossil bones, among
+which were the most typical of the curiously injured specimens.
+
+None of the dogs survived, their hurriedly built snow inclosure near
+the camp being almost wholly destroyed. The wind may have done that,
+though the greater breakage, on the side next to the camp, which was
+not the windward one, suggests an outward leap or break of the frantic
+beasts themselves.
+
+All three sledges were gone, and we have tried to explain that the wind
+may have blown them off into the unknown. The drill and ice-melting
+machinery at the boring were too badly damaged to warrant salvage, so
+we used them to choke up that subtly disturbing gateway to the past
+which Lake had blasted.
+
+We likewise left at the camp the two most shaken up of the planes;
+since our surviving party had only four real pilots--Sherman, Danforth,
+McTighe, and Ropes--in all, with Danforth in a poor nervous shape to
+navigate. We brought back all the books, scientific equipment, and
+other incidentals we could find, though much was rather unaccountably
+blown away. Spare tents and furs were either missing or badly out of
+condition.
+
+It was approximately four p.m., after wide plane cruising had forced
+us to give Gedney up for lost, that we sent our guarded message to the
+_Arkham_ for relaying; and I think we did well to keep it as calm and
+noncommittal as we succeeded in doing.
+
+The most we said about agitation concerned our dogs, whose frantic
+uneasiness near the biological specimens was to be expected from poor
+Lake's accounts. We did not mention, I think, their display of the
+same uneasiness when sniffing around the queer greenish soapstones
+and certain other objects in the disordered region--objects including
+scientific instruments, aëroplanes, and machinery, both at the camp
+and at the boring, whose parts had been loosened, moved, or otherwise
+tampered with by winds that must have harbored singular curiosity and
+investigativeness.
+
+About the fourteen biological specimens we were pardonably indefinite.
+We said that the only ones we discovered were damaged, but that enough
+was left of them to prove Lake's description wholly and impressively
+accurate. It was hard work keeping our personal emotions out of this
+matter--and we did not mention numbers or say exactly how we had found
+those which we did find. We had by that time agreed not to transmit
+anything suggesting madness on the part of Lake's men, and it surely
+looked like madness to find six imperfect monstrosities carefully
+buried upright in nine-foot snow graves under five-pointed mounds
+punched over with groups of dots in patterns exactly like those on
+the queer greenish soapstones dug up from Mesozoic or Tertiary times.
+The eight perfect specimens mentioned by Lake seemed to have been
+completely blown away.
+
+       *       *       *       *       *
+
+We were careful, too, about the public's general peace of mind; hence
+Danforth and I said little about that frightful trip over the mountains
+the next day. It was the fact that only a radically lightened plane
+could possibly cross a range of such height which mercifully limited
+that scouting tour to the two of us.
+
+On our return at one a.m., Danforth was close to hysterics, but kept an
+admirably stiff upper lip. It took no persuasion to make him promise
+not to show our sketches and the other things we brought away in our
+pockets, not to say anything more to the others than what we had agreed
+to relay outside, and to hide our camera films for private development
+later on; so that part of my present story will be as new to Pabodie,
+McTighe, Ropes, Sherman, and the rest as it will be to that world in
+general. Indeed--Danforth is closer mouthed than I: for he saw, or
+thinks he saw, one thing he will not tell even me.
+
+As all know, our report included a tale of a hard ascent--a
+confirmation of Lake's opinion that the great peaks are of archæan
+slate and other very primal crumpled strata unchanged since at least
+middle Comanchean time, a conventional comment on the regularity of the
+clinging cube and rampart formations, a decision that the cave mouths
+indicate dissolved calcareous veins, a conjecture that certain slopes
+and passes would permit of the scaling and crossing of the entire range
+by seasoned mountaineers, and a remark that the mysterious other side
+holds a lofty and immense superplateau as ancient and unchanging as the
+mountains themselves--twenty thousand feet in elevation, with grotesque
+rock formations protruding through a thin glacial layer and with low
+gradual foothills between the general plateau surface and the sheer
+precipices of the highest peaks.
+
+This body of data is in every respect true so far as it goes, and
+it completely satisfied the men at the camp. We laid our absence of
+sixteen hours--a longer time than our announced flying, landing,
+reconnoitering, and rock-collecting program called for--to a long
+mythical spell of adverse wind conditions, and told truly of our
+landing on the farther foothills.
+
+Fortunately our tale sounded realistic and prosaic enough not to tempt
+any of the others into emulating our flight. Had any tried to do that,
+I would have used every ounce of my persuasion to stop them--and I do
+not know what Danforth would have done.
+
+While we were gone, Pabodie, Sherman, Ropes, McTighe, and Williamson
+had worked like beavers over Lake's two best planes, fitting them
+again for use, despite the altogether unaccountable juggling of their
+operative mechanism.
+
+We decided to load all the planes the next morning and start back for
+our old base as soon as possible. Even though indirect, that was the
+safest way to work toward McMurdo Sound; for a straight-line flight
+across the most utterly unknown stretches of the æon-dead continent
+would involve many additional hazards.
+
+Further exploration was hardly feasible in view of our tragic
+decimation and the ruin of our drilling machinery. The doubts and
+horrors around us--which we did not reveal--made us wish only to escape
+from this austral world of desolation and brooding madness as swiftly
+as we could.
+
+       *       *       *       *       *
+
+As the public knows, our return to the world was accomplished without
+further disasters. All planes reached the old base on the evening of
+the next day--January 27th--after a swift nonstop flight; and on the
+28th we made McMurdo Sound in two laps, the one pause being very brief,
+and occasioned by a faulty rudder, in the furious wind over the ice
+shelf after we had cleared the great plateau.
+
+In five days more, the _Arkham_ and _Miskatonic_, with all hands and
+equipment on board, were shaking clear of the thickening field ice
+and working up Ross Sea, with the mocking mountains of Victoria Land
+looming westward against a troubled antarctic sky and twisting the
+wind's wails into a wide-ranged musical piping which chilled my soul to
+the quick.
+
+Less than a fortnight later we left the last hint of polar land behind
+us and thanked heaven that we were clear of a haunted, accursed realm
+where life and death, space and time, have made black and blasphemous
+alliances in the unknown epochs since matter first writhed and swam on
+the planet's scarce-cooled crust.
+
+Since our return we have all constantly worked to discourage antarctic
+exploration, and have kept certain doubts and guesses to ourselves with
+splendid unity and faithfulness. Even young Danforth, with his nervous
+breakdown, has not flinched or babbled to his doctors.
+
+Indeed, as I have said, there is one thing he thinks he alone saw
+which he will not tell even me, though I think it would help his
+psychological state if he would consent to do so. It might explain and
+relieve much, though perhaps the thing was no more than the delusive
+aftermath of an earlier shock. That is the impression I gather after
+those rare, irresponsible moments when he whispers disjointed things to
+me--things which he repudiates vehemently as soon as he gets a grip on
+himself again.
+
+It will be hard work deterring others from the great white south, and
+some of our efforts may directly harm our cause by drawing inquiring
+notice. We might have known from the first that human curiosity is
+undying, and that the results we announced would be enough to spur
+others ahead on the same age-long pursuit of the unknown.
+
+Lake's reports of those biological monstrosities had aroused
+naturalists and palæontologists to the highest pitch, though we were
+sensible enough not to show the detached parts we had taken from the
+actual buried specimens, or our photographs of those specimens as
+they were found. We also refrained from showing the more puzzling of
+the scarred bones and greenish soapstones; while Danforth and I have
+closely guarded the pictures we took or drew on the superplateau across
+the range, and the crumpled things we smoothed, studied in terror, and
+brought away in our pockets.
+
+But now that Starkweather-Moore party is organizing, and with a
+thoroughness far beyond anything our outfit attempted--if not
+dissuaded, they will get to the innermost nucleus of the antarctic
+and melt and bore till they bring up that which we know may end the
+world. So I must break through all reticences at last--even about that
+ultimate, nameless thing beyond the mountains of madness.
+
+
+
+
+                                  IV.
+
+
+It is only with vast hesitancy and repugnance that I let my mind go
+back to Lake's camp and what we really found there--and to that other
+thing beyond the awful mountain wall.
+
+I have told of the wind-ravaged terrain, the damaged shelters, the
+disarranged machinery, the varied uneasiness of our dogs, the missing
+sledges and other items, the deaths of men and dogs, the absence of
+Gedney, and the six insanely buried biological specimens, strangely
+sound in texture for all their structural injuries, from a world forty
+million years dead. I do not recall whether I mentioned that upon
+checking up the canine bodies we found one dog missing. We did not
+think much about that till later--indeed, only Danforth and I have
+thought of it at all.
+
+The principal things I have been keeping back relate to the bodies,
+and to certain subtle points which may or may not lend a hideous and
+incredible kind of rationale to the apparent chaos.
+
+At the time, I tried to keep the men's minds off those points; for
+it was so much simpler--so much more normal--to lay everything to an
+outbreak of madness on the part of some of Lake's party. From the look
+of things, that demon mountain wind must have been enough to drive
+any man mad in the midst of this center of all earthly mystery and
+desolation.
+
+The crowning abnormality, of course, was the condition of the
+bodies--men and dogs alike. They had all been in some terrible kind
+of conflict, and were torn and mangled in fiendish and altogether
+inexplicable ways. Death, so far as we could judge, had in each case
+come from strangulation or laceration.
+
+The dogs had evidently started the trouble, for the state of their
+ill-built corral bore witness to its forcible breakage from within.
+It had been set some distance from the camp because of the hatred of
+the animals for those hellish archæan organisms, but the precaution
+seemed to have been taken in vain. When left alone in that monstrous
+wind, behind flimsy walls of insufficient height, they must have
+stampeded--whether from the wind itself, or from some subtle,
+increasing odor emitted by the nightmare specimens, one could not say.
+
+       *       *       *       *       *
+
+But whatever had happened, it was hideous and revolting enough.
+Perhaps I had better put squeamishness aside and tell the worst at
+last--though with a categorical statement of opinion, based on the
+first-hand observations and most rigid deductions of both Danforth and
+myself, that the then missing Gedney was in no way responsible for the
+loathsome horrors we found.
+
+I have said that the bodies were frightfully mangled. Now I must
+add that some were incised and subtracted from in the most curious,
+cold-blooded, and inhuman fashion. It was the same with dogs and men.
+All the healthier, fatter bodies, quadrupedal or bipedal, had had
+their most solid masses of tissue cut out and removed, as by a careful
+butcher; and around them was a strange sprinkling of salt--taken from
+the ravaged provision chests on the planes--which conjured up the most
+horrible associations.
+
+The thing had occurred in one of the crude aëroplane shelters from
+which the plane had been dragged out, and subsequent winds had effaced
+all tracks which could have supplied any plausible theory. Scattered
+bits of clothing, roughly slashed from the human incision subjects,
+hinted no clues.
+
+It is useless to bring up the half impression of certain faint snow
+prints in one shielded corner of the ruined inclosure--because that
+impression did not concern human prints at all, but was clearly
+mixed up with all the talk of fossil prints which poor Lake had been
+giving throughout the preceding weeks. One had to be careful of one's
+imagination in the lee of those overshadowing mountains of madness.
+
+As I have indicated, Gedney and one dog turned out to be missing in
+the end. When we came on that terrible shelter we had missed two dogs
+and two men; but the fairly unharmed dissecting tent, which we entered
+after investigating the monstrous graves, had something to reveal.
+
+It was not as Lake had left it, for the covered parts of the primal
+monstrosity had been removed from the improvised table. Indeed, we had
+already realized that one of the six imperfect and insanely buried
+things we had found--the one with the trace of a peculiarly hateful
+odor--must represent the collected sections of the entity which Lake
+had tried to analyze.
+
+On and around that laboratory table were strewn other things, and it
+did not take long for us to guess that those things were the carefully,
+though oddly and inexpertly dissected parts of one man and one dog. I
+shall spare the feelings of survivors by omitting mention of the man's
+identity.
+
+Lake's anatomical instruments were missing, but there were evidences
+of their careful cleansing. The gasoline stove was also gone, though
+around it we found a curious litter of matches. We buried the human
+parts beside the other ten men, and the canine parts with the other
+thirty-five dogs. Concerning the bizarre smudges on the laboratory
+table, and on the jumble of roughly handled illustrated books scattered
+near it, we were much too bewildered to speculate.
+
+This formed the worst of the camp horror, but other things were
+equally perplexing. The disappearance of Gedney, the one dog, the
+eight uninjured biological specimens, the three sledges, and certain
+instruments, illustrated technical and scientific books, writing
+materials, electric torches and batteries, food and fuel, heating
+apparatus, spare tents, fur suits, and the like, was utterly beyond
+sane conjecture; as were likewise the spatter-fringed ink blots on
+certain pieces of paper, and the evidences of curious alien fumbling
+and experimentation around the planes and all other mechanical devices
+both at the camp and at the boring. The dogs seemed to abhor this oddly
+disordered machinery.
+
+Then, too, there was the upsetting of the larder, the disappearance
+of certain staples, and the jarringly comical heap of tin cans pried
+open in the most unlikely ways and at the most unlikely places. The
+profusion of scattered matches, intact, broken, or spent, formed
+another minor enigma--as did the two or three tent cloths and fur suits
+which we found lying about with peculiar and unorthodox slashings
+conceivably due to clumsy efforts at unimaginable adaptations.
+
+The maltreatment of the human and canine bodies, and the crazy burial
+of the damaged archæan specimens, were all of a piece with this
+apparent disintegrative madness. In view of just such an eventuality
+as the present one, we carefully photographed all the main evidences
+of insane disorder at the camp; and shall use the prints to buttress
+our pleas against the departure of the proposed Starkweather-Moore
+Expedition.
+
+       *       *       *       *       *
+
+Our first act after finding the bodies in the shelter was to photograph
+and open the row of insane graves with the five-pointed snow mounds.
+We could not help noticing the resemblance of these monstrous mounds,
+with their clusters of grouped dots, to poor Lake's descriptions of the
+strange greenish soapstones; and when we came on some of the soapstones
+themselves in the great mineral pile we found the likeness very close
+indeed.
+
+The whole general formation, it must be made clear, seemed abominably
+suggestive of the starfish head of the archæan entities; and we agreed
+that the suggestion must have worked potently upon the sensitized minds
+of Lake's overwrought party.
+
+For madness--centering in Gedney as the only possible surviving
+agent--was the explanation spontaneously adopted by everybody so far
+as spoken utterance was concerned; though I will not be so naïve as
+to deny that each of us may have harbored wild guesses which sanity
+forbade him to formulate completely.
+
+Sherman, Pabodie, and McTighe made an exhaustive aëroplane cruise over
+all the surrounding territory in the afternoon, sweeping the horizon
+with field glasses in quest of Gedney and of the various missing
+things; but nothing came to light.
+
+The party reported that the titan-barrier range extended endlessly to
+right and left alike, without any diminution in height or essential
+structure. On some of the peaks, though, the regular cube and rampart
+formations were bolder and plainer, having doubly fantastic similitudes
+to Roerich-painted Asian hill ruins. The distribution of cryptical cave
+mouths on the black snow-denuded summits seemed roughly even as far as
+the range could be traced.
+
+In spite of all the prevailing horrors we were left with enough sheer
+scientific zeal and adventurousness to wonder about the unknown realm
+beyond those mysterious mountains.
+
+As our guarded messages stated, we rested at midnight after our day of
+terror and bafflement--but not without a tentative plan for one or more
+range-crossing altitude flights in a lightened plane with aërial camera
+and geologist's outfit, beginning the following morning.
+
+It was decided that Danforth and I try it first, and we awaked at seven
+a.m. intending an early trip; though heavy winds--mentioned in our
+brief bulletin to the outside world--delayed our start till nearly nine
+o'clock.
+
+I have already repeated the noncommittal story we told the men at
+camp--and relayed outside--after our return sixteen hours later.
+It is now my terrible duty to amplify this account by filling in
+the merciful blanks with hints of what we really saw in that hidden
+transmontane world--hints of the revelations which have finally driven
+Danforth to a nervous collapse.
+
+I wish he would add a really frank word about the thing which he thinks
+he alone saw--even though it was probably a nervous delusion--and which
+was perhaps the last straw that put him where he is; but he is firm
+against that. All I can do is to repeat his later disjointed whispers
+about what set him shrieking as the plane soared back through the
+wind-tortured mountain pass after that real and tangible shock which I
+shared.
+
+This will form my last word. If the plain signs of surviving elder
+horrors in what I disclose be not enough to keep others from meddling
+with the inner antarctic--or at least from prying too deeply beneath
+the surface of that ultimate waste of forbidden secrets and unhuman,
+æon-cursed desolation--the responsibility for unnamable and perhaps
+immeasurable evils will not be mine.
+
+       *       *       *       *       *
+
+Danforth and I, studying the notes made by Pabodie in his afternoon
+flight and checking up with a sextant, had calculated that the lowest
+available pass in the range lay somewhat to the right of us, within
+sight of camp, and about twenty-three thousand or twenty-four thousand
+feet above sea-level. For this point, then, we first headed in the
+lightened plane as we embarked on our flight of discovery.
+
+The camp itself, on foothills which sprang from a high continental
+plateau, was some twelve thousand feet in altitude; hence the
+actual height increase necessary was not so vast as it might seem.
+Nevertheless we were acutely conscious of the rarefied air and intense
+cold as we rose; for, on account of visibility conditions, we had
+to leave the cabin windows open. We were dressed, of course, in our
+heaviest furs.
+
+As we drew near the forbidding peaks, dark and sinister above the
+line of crevasse-riven snow and interstitial glaciers, we noticed more
+and more the curiously regular formations clinging to the slopes; and
+thought again of the strange Asian paintings of Nicholas Roerich.
+
+The ancient and wind-weathered rock strata fully verified all of
+Lake's bulletins, and proved that these pinnacles had been towering
+up in exactly the same way since a surprisingly early time in earth's
+history--perhaps over fifty million years. How much higher they had
+once been, it was futile to guess; but everything about this strange
+region pointed to obscure atmospheric influences unfavorable to
+change, and calculated to retard the usual climatic processes of rock
+disintegration.
+
+But it was the mountainside tangle of regular cubes, ramparts, and cave
+mouths which fascinated and disturbed us most. I studied them with a
+field glass and took aërial photographs while Danforth drove; and at
+times I relieved him at the controls--though my aviation knowledge was
+purely an amateur's--in order to let him use the binoculars.
+
+We could easily see that much of the material of the things was a
+lightish archæan quartzite, unlike any formation visible over broad
+areas of the general surface; and that their regularity was extreme and
+uncanny to an extent which poor Lake had scarcely hinted.
+
+As he had said, their edges were crumbled and rounded from untold
+æons of savage weathering; but their preternatural solidity and tough
+material had saved them from obliteration. Many parts, especially
+those closest to the slopes, seemed identical in substance with the
+surrounding rock surface.
+
+The whole arrangement looked like the ruins of Macchu Picchu in
+the Andes, or the primal foundation walls of Kish as dug up by the
+Oxford-Field Museum Expedition in 1929; and both Danforth and I
+obtained that occasional impression of separate Cyclopean blocks which
+Lake had attributed to his flight-companion Carroll.
+
+How to account for such things in this place was frankly beyond me, and
+I felt queerly humbled as a geologist. Igneous formations often have
+strange regularities--like the famous Giants' Causeway in Ireland--but
+this stupendous range, despite Lake's original suspicion of smoking
+cones, was above all else nonvolcanic in evident structure.
+
+The curious cave mouths, near which the odd formation seemed most
+abundant, presented another, albeit a lesser puzzle because of their
+regularity of outline. They were, as Lake's bulletin had said, often
+approximately square or semicircular; as if the natural orifices had
+been shaped to greater symmetry by some magic hand. Their numerousness
+and wide distribution were remarkable, and suggested that the whole
+region was honeycombed with tunnels dissolved out of limestone strata.
+
+Such glimpses as we secured did not extend far within the caverns, but
+we saw that they were apparently clear of stalactites and stalagmites.
+Outside, those parts of the mountain slopes adjoining the apertures
+seemed invariably smooth and regular; and Danforth thought that the
+slight cracks and pittings of the weathering tended toward unusual
+patterns.
+
+Filled as he was with the horrors and strangenesses discovered at the
+camp, he hinted that the pittings vaguely resembled those baffling
+groups of dots sprinkled over the primeval greenish soapstones, so
+hideously duplicated on the madly conceived snow mounds above those six
+buried monstrosities.
+
+       *       *       *       *       *
+
+We had risen gradually in flying over the higher foothills and along
+toward the relatively low pass we had selected. As we advanced we
+occasionally looked down at the snow and ice of the land route,
+wondering whether we could have attempted the trip with the simpler
+equipment of earlier days.
+
+Somewhat to our surprise we saw that the terrain was far from difficult
+as such things go; and that despite the crevasses and other bad spots
+it would not have been likely to deter the sledges of a Scott, a
+Shackleton, or an Amundsen. Some of the glaciers appeared to lead up to
+wind-bared passes with unusual continuity, and upon reaching our chosen
+pass we found that its case formed no exception.
+
+Our sensations of tense expectancy as we prepared to round the crest
+and peer out over an untrodden world can hardly be described on paper;
+even though we had no cause to think the regions beyond the range
+essentially different from those already seen and traversed. The touch
+of evil mystery in these barrier mountains, and in the beckoning sea of
+opalescent sky glimpsed betwixt their summits, was a highly subtle and
+attenuated matter not to be explained in literal words. Rather was it
+an affair of vague psychological symbolism and æsthetic association--a
+thing mixed up with exotic poetry and paintings, and with archaic myths
+lurking in shunned and forbidden volumes.
+
+Even the wind's burden held a peculiar strain of conscious malignity;
+and for a second it seemed that the composite sound included a bizarre
+musical whistling, or piping over a wide range as the blast swept in
+and out of the omnipresent and resonant cave mouths. There was a cloudy
+note of reminiscent repulsion in this sound, as complex and unplaceable
+as any of the other dark impressions.
+
+We were now, after a slow ascent, at a height of twenty-three thousand
+five hundred and seventy feet according to the aneroid; and had left
+the region of clinging snow definitely below us. Up here were only
+dark, bare rock slopes and the start of rough-ribbed glaciers--but with
+those provocative cubes, ramparts, and echoing cave mouths to add a
+portent of the unnatural, the fantastic, and the dreamlike.
+
+Looking along the line of high peaks, I thought I could see the one
+mentioned by poor Lake, with a rampart exactly on top. It seemed to be
+half lost in a queer antarctic haze--such a haze, perhaps, as had been
+responsible for Lake's early notion of volcanism.
+
+The pass loomed directly before us, smooth and windswept between its
+jagged and malignly frowning pylons. Beyond it was a sky fretted with
+swirling vapors and lighted by the low polar sun--the sky of that
+mysterious farther realm upon which we felt no human eye had ever gazed.
+
+A few more feet of altitude and we would behold that realm. Danforth
+and I, unable to speak except in shouts amidst the howling, piping wind
+that raced through the pass and added to the noise of the unmuffled
+engines, exchanged eloquent glances. And then, having gained those last
+few feet, we did indeed stare across the momentous divide and over the
+unsampled secrets of an elder and utterly alien earth.
+
+
+
+
+                                  V.
+
+
+I think that both of us simultaneously cried out in mixed awe, wonder,
+terror, and disbelief in our own senses as we finally cleared the pass
+and saw what lay beyond. Of course, we must have had some natural
+theory in the back of our heads to steady our faculties for the moment.
+Probably we thought of such things as the grotesquely weathered stones
+of the Garden of the Gods in Colorado, or the fantastically symmetrical
+wind-carved rocks of the Arizona desert. Perhaps we even half thought
+the sight a mirage like that we had seen the morning before on first
+approaching those mountains of madness.
+
+We must have had some such normal notions to fall back upon as our
+eyes swept that limitless, tempest-scarred plateau and grasped the
+almost endless labyrinth of colossal, regular, and geometrically
+eurythmic stone masses which reared their crumbled and pitted crests
+above a glacial sheet not more than forty or fifty feet deep at its
+thickest, and in places obviously thinner.
+
+The effect of the monstrous sight was indescribable, for some fiendish
+violation of known natural law seemed certain at the outset. Here,
+on a hellishly ancient table-land fully twenty thousand feet high,
+and in a climate deadly to habitation since a prehuman age not less
+than five hundred thousand years ago, there stretched nearly to the
+vision's limit a tangle of orderly stone which only the desperation of
+mental self-defense could possibly attribute to any but a conscious and
+artificial cause.
+
+[Illustration: _The effect of the monstrous sight was indescribable!
+Some fiendish violation of natural law!_]
+
+We had previously dismissed, so far as serious thought was concerned,
+any theory that the cubes and ramparts of the mountainsides were other
+than natural in origin. How could they be otherwise, when man himself
+could scarcely have been differentiated from the great apes at the time
+when this region succumbed to the present unbroken reign of glacial
+death?
+
+Yet now the sway of reason seemed irrefutably shaken, for this
+Cyclopean maze of squared, curved, and angled blocks had features which
+cut off all comfortable refuge. It was, very clearly, the blasphemous
+city of the mirage in stark, objective, and ineluctable reality. That
+damnable portent had had a material basis after all--there had been
+some horizontal stratum of ice dust in the upper air, and this shocking
+stone survival had projected its image across the mountains according
+to the simple laws of reflection. Of course, the phantom had been
+twisted and exaggerated, and had contained things which the real source
+did not contain; yet now, as we saw that real source, we thought it
+even more hideous and menacing than its distant image.
+
+[Illustration: _It was, very clearly, the blasphemous city of the
+mirage--in stark, objective reality!_]
+
+Only the incredible, unhuman massiveness of these vast stone towers
+and ramparts had saved the frightful thing from utter annihilation in
+the hundreds of thousands--perhaps millions--of years it had brooded
+there amidst the blasts of a bleak upland. "Corona Mundi--Roof of the
+World----" All sorts of fantastic phrases sprang to our lips as we
+looked dizzily down at the unbelievable spectacle.
+
+I thought again of the eldritch primal myths that had so persistently
+haunted me since my first sight of this dead antarctic world--of
+the demonic plateau of Leng, of the Mi-Go, or Abominable Snow Men
+of the Himalayas, of the Pnakotic Manuscripts with their prehuman
+implications, of the Cthulhu cult, of the _Necronomicon_, and of the
+Hyperborean legends of formless Tsathoggua and the worse than formless
+star spawn associated with that semientity.
+
+       *       *       *       *       *
+
+For boundless miles in every direction the thing stretched off with
+very little thinning; indeed, as our eyes followed it to the right and
+left along the base of the low, gradual foothills which separated it
+from the actual mountain rim, we decided that we could see no thinning
+at all except for an interruption at the left of the pass through
+which we had come. We had merely struck, at random, a limited part of
+something of incalculable extent.
+
+The foothills were more sparsely sprinkled with grotesque stone
+structures, linking the terrible city to the already familiar cubes and
+ramparts which evidently formed its mountain outposts. These latter,
+as well as the queer cave mouths, were as thick on the inner as on the
+outer sides of the mountains.
+
+The nameless stone labyrinth consisted, for the most part, of
+walls from ten to one hundred and fifty feet in ice-clear height,
+and of a thickness varying from five to ten feet. It was composed
+mostly of prodigious blocks of dark primordial slate, schist, and
+sandstone--blocks in many cases as large as 4 × 6 × 8 feet--though in
+several places it seemed to be carved out of a solid, uneven bed rock
+of pre-Cambrian slate.
+
+The buildings were far from equal in size, there being innumerable
+honeycomb arrangements of enormous extent as well as smaller separate
+structures.
+
+The general shape of these things tended to be conical, pyramidal, or
+terraced; though there were many perfect cylinders, perfect cubes,
+clusters of cubes, and other rectangular forms, and a peculiar
+sprinkling of angled edifices whose five-pointed ground plan roughly
+suggested modern fortifications. The builders had made constant and
+expert use of the principle of the arch, and domes had probably existed
+in the city's heyday.
+
+The whole tangle was monstrously weathered, and the glacial surface
+from where the towers projected was strewn with fallen blocks and
+immemorial débris. Where the glaciation was transparent we could see
+the lower parts of the gigantic piles, and we noticed the ice-preserved
+stone bridges which connected the different towers at varying distances
+above the ground. On the exposed walls we could detect the scarred
+places where other and higher bridges of the same sort had existed.
+
+Closer inspection revealed countless largish windows; some of which
+were closed with shutters of a petrified material originally wood,
+though most gaped open in a sinister and menacing fashion.
+
+Many of the ruins, of course, were roofless, and with uneven though
+wind-rounded upper edges; whilst others, of a more sharply conical or
+pyramidal model or else protected by higher surrounding structures,
+preserved intact outlines despite the omnipresent crumbling and
+pitting. With the field glass we could barely make out what seemed to
+be sculptural decorations in horizontal bands--decorations including
+those curious groups of dots whose presence on the ancient soapstones
+now assumed a vastly larger significance.
+
+In many places the buildings were totally ruined and the ice sheet
+deeply riven from various geologic causes. In other places the
+stonework was worn down to the very level of the glaciation. One
+broad swath, extending from the plateau's interior to a cleft in the
+foothills about a mile to the left of the pass we had traversed, was
+wholly free from buildings. It probably represented, we concluded,
+the course of some great river which in Tertiary times--millions
+of years ago--had poured through the city and into some prodigious
+subterranean abyss of the great barrier range. Certainly, this was
+above all a region of caves, gulfs, and underground secrets beyond
+human penetration.
+
+       *       *       *       *       *
+
+Looking back to our sensations, and recalling our dazedness at viewing
+this monstrous survival from æons we had thought prehuman, I can only
+wonder that we preserved the semblance of equilibrium which we did.
+Of course, we knew that something--chronology, scientific theory, or
+our own consciousness--was woefully awry; yet we kept enough poise to
+guide the plane, observe many things quite minutely, and take a careful
+series of photographs which may yet serve both us and the world in good
+stead.
+
+In my case, ingrained scientific habit may have helped; for above all
+my bewilderment and sense of menace there burned a dominant curiosity
+to fathom more of this age-old secret--to know what sort of beings
+had built and lived in this incalculably gigantic place, and what
+relation to the general world of its time or of other times so unique a
+concentration of life could have had.
+
+For this place could be no ordinary city. It must have formed the
+primary nucleus and center of some archaic and unbelievable chapter of
+earth's history whose outward ramifications, recalled only dimly in the
+most obscure and distorted myths, had vanished utterly amidst the chaos
+of terrene convulsions long before any human race we know had shambled
+out of apedom.
+
+Here sprawled a Palæogæan megalopolis compared with which the fabled
+Atlantis and Lemuria, Commoriom and Uzuldaroum, and Olathoë in the
+land of Lomar are recent things of to-day--not even of yesterday;
+a megalopolis ranking with such whispered prehuman blasphemies as
+Valusia, R'lyeh, Ib in the land of Mnar, and the Nameless City of
+Arabia Deserta.
+
+As we flew above that tangle of stark Titan towers my imagination
+sometimes escaped all bounds and roved aimlessly in realms of fantastic
+associations--even weaving links betwixt this lost world and some of my
+own wildest dreams concerning the mad horror at the camp.
+
+The plane's fuel tank, in the interest of greater lightness, had
+been only partly filled; hence we now had to exert caution in our
+explorations. Even so, however, we covered an enormous extent of
+ground--or rather, air--after swooping down to a level where the wind
+became virtually negligible.
+
+There seemed to be no limit to the mountain range, or to the length
+of the frightful stone city which bordered its inner foothills. Fifty
+miles of flight in each direction showed no major change in the
+labyrinth of rock and masonry that clawed up corpselike through the
+eternal ice.
+
+There were, though, some highly absorbing diversifications; such as
+the carvings on the canyon where that broad river had once pierced the
+foothills and approached its sinking place in the great range.
+
+The headlands at the stream's entrance had been boldly carved into
+Cyclopean pylons; and something about the ridgy, barrel-shaped designs
+stirred up oddly vague, hateful, and confusing semiremembrances in both
+Danforth and me.
+
+We also came upon several star-shaped open spaces, evidently public
+squares, and noted various undulations in the terrain. Where a sharp
+hill rose, it was generally hollowed out into some sort of rambling
+stone edifice; but there were at least two exceptions. Of these latter,
+one was too badly weathered to disclose what had been on the jutting
+eminence, while the other still bore a fantastic conical monument
+carved out of the solid rock and roughly resembling such things as the
+well-known Snake Tomb in the ancient valley of Petra.
+
+Flying inland from the mountains, we discovered that the city was
+not of infinite width, even though its length along the foothills
+seemed endless. After about thirty miles the grotesque stone buildings
+began to thin out, and in ten more miles we came to an unbroken waste
+virtually without signs of sentient artifice. The course of the river
+beyond the city seemed marked by a broad, depressed line, while the
+land assumed a somewhat greater ruggedness, seeming to slope slightly
+upward as it receded in the mist-hazed west.
+
+So far we had made no landing, yet to leave the plateau without an
+attempt at entering some of the monstrous structures would have been
+inconceivable. Accordingly, we decided to find a smooth place on the
+foothills near our navigable pass, there grounding the plane and
+preparing to do some exploration on foot.
+
+Though these gradual slopes were partly covered with a scattering of
+ruins, low flying soon disclosed an ample number of possible landing
+places. Selecting that nearest to the pass, since our next flight would
+be across the great range and back to camp, we succeeded about twelve
+thirty p.m. in coming down on a smooth, hard snow field wholly devoid
+of obstacles and well adapted to a swift and favorable take-off later
+on.
+
+       *       *       *       *       *
+
+It did not seem necessary to protect the plane with a snow banking for
+so brief a time and in so comfortable an absence of high winds at this
+level; hence we merely saw that the landing skis were safely lodged,
+and that the vital parts of the mechanism were guarded against the cold.
+
+For our foot journey we discarded the heaviest of our flying furs, and
+took with us a small outfit consisting of pocket compass, hand camera,
+light provisions, voluminous notebooks and paper, geologist's hammer
+and chisel, specimen bags, coil of climbing rope, and powerful electric
+torches with extra batteries; this equipment having been carried in the
+plane on the chance that we might be able to effect a landing, take
+ground pictures, make drawings and topographical sketches, and obtain
+rock specimens from some bare slope, outcropping, or mountain cave.
+
+Fortunately, we had a supply of extra paper to tear up, place in a
+spare specimen bag, and use on the ancient principle of hare and hounds
+for marking our course in any interior mazes we might be able to
+penetrate. This had been brought in case we found some cave system with
+air quiet enough to allow such a rapid and easy method in place of the
+usual rock-chipping method of trail blazing.
+
+Walking cautiously downhill over the crusted snow, toward the
+stupendous stone labyrinth that loomed against the opalescent west,
+we felt almost as keen a sense of imminent marvels as we had felt on
+approaching the unfathomed mountain pass four hours previously.
+
+True, we had become visually familiar with the incredible secret
+concealed by the barrier peaks; yet the prospect of actually entering
+primordial walls reared by conscious beings perhaps millions of years
+ago--before any known race of men could have existed--was none the
+less awesome and potentially terrible in its implications of cosmic
+abnormality.
+
+Though the thinness of the air at this prodigious altitude made
+exertion somewhat more difficult than usual, both Danforth and I found
+ourselves bearing up very well, and felt equal to almost any task which
+might fall to our lot.
+
+It took only a few steps to bring us to a shapeless ruin worn level
+with the snow, while ten or fifteen rods farther on there was a huge,
+roofless rampart still complete in its gigantic five-pointed outline,
+and rising to an irregular height of ten or eleven feet. For this
+latter we headed; and when at last we were actually able to touch
+its weathered Cyclopean blocks, we felt that we had established an
+unprecedented and almost blasphemous link with forgotten æons normally
+closed to our species.
+
+This rampart, shaped like a star and perhaps three hundred feet from
+point to point, was built of Jurassic sandstone blocks of irregular
+size, averaging 6 x 8 feet in surface. There was a row of arched
+loopholes or windows about four feet wide and five feet high, spaced
+quite symmetrically along the points of the star and at its inner
+angles, and with the bottoms about four feet from the glaciated surface.
+
+Looking through these, we could see that the masonry was fully five
+feet thick, that there were no partitions remaining within, and that
+there were traces of banded carvings or bas-reliefs on the interior
+walls--facts we had indeed guessed before, when flying low over this
+rampart and others like it. Though lower parts must have originally
+existed, all traces of such things were now wholly obscured by the deep
+layer of ice and snow at this point.
+
+We crawled through one of the windows and vainly tried to decipher
+the nearly effaced mural designs, but did not attempt to disturb
+the glaciated floor. Our orientation flights had indicated that many
+buildings in the city proper were less ice-choked, and that we might
+perhaps find wholly clear interiors leading down to the true ground
+level if we entered those structures still roofed at the top.
+
+Before we left the rampart we photographed it carefully, and studied
+its mortarless Cyclopean masonry with complete bewilderment. We wished
+that Pabodie were present, for his engineering knowledge might have
+helped us guess how such titanic blocks could have been handled in that
+unbelievably remote age when the city and its outskirts were built up.
+
+       *       *       *       *       *
+
+The half-mile walk downhill to the actual city, with the upper wind
+shrieking vainly and savagely through the skyward peaks in the
+background, was something of which the smallest details will always
+remain engraved on my mind. Only in fantastic nightmares could any
+human beings but Danforth and me conceive such optical effects.
+
+Between us and the churning vapors of the west lay that monstrous
+tangle of dark stone towers, its outré and incredible forms impressing
+us afresh at every new angle of vision. It was a mirage in solid stone,
+and were it not for the photographs I would still doubt that such a
+thing could be. The general type of masonry was identical with that
+of the rampart we had examined; but the extravagant shapes which this
+masonry took in its urban manifestations were past all description.
+
+Even the pictures illustrate only one or two phases of its endless
+variety, preternatural massiveness, and utterly alien exoticism. There
+were geometrical forms for which an Euclid could scarcely find a
+name--cones of all degrees of irregularity and truncation, terraces
+of every sort of provocative disproportion, shafts with odd bulbous
+enlargements, broken columns in curious groups, and five-pointed or
+five-ridged arrangements of mad grotesqueness.
+
+As we drew nearer we could see beneath certain transparent parts of the
+ice sheet, and detect some of the tubular stone bridges that connected
+the crazily sprinkled structures at various heights. Of orderly streets
+there seemed to be none, the only broad open swath being a mile to the
+left, where the ancient river had doubtless flowed through the town
+into the mountains.
+
+Our field glasses showed the external, horizontal bands of nearly
+effaced sculptures and dot groups to be very prevalent, and we could
+half imagine what the city must once have looked like--even though most
+of the roofs and tower tops had necessarily perished.
+
+As a whole, it had been a complex tangle of twisted lanes and alleys,
+all of them deep canyons, and some little better than tunnels because
+of the overhanging masonry or overarching bridges.
+
+Now, outspread below us, it loomed like a dream phantasy against a
+westward mist through whose northern end the low, reddish antarctic sun
+of early afternoon was struggling to shine; and when, for a moment,
+that sun encountered a denser obstruction and plunged the scene into
+temporary shadow, the effect was subtly menacing in a way I can never
+hope to depict. Even the faint howling and piping of the unfelt wind in
+the great mountain passes behind us took on a wilder note of purposeful
+malignity.
+
+The last stage of our descent to the town was unusually steep and
+abrupt, and a rock outcropping at the edge where the grade changed led
+us to think that an artificial terrace had once existed there. Under
+the glaciation, we believed, there must be a flight of steps or its
+equivalent.
+
+When at last we plunged into the town itself, clambering over fallen
+masonry and shrinking from the oppressive nearness and dwarfing height
+of omnipresent crumbling and pitted walls, our sensations again became
+such that I marvel at the amount of self-control we retained.
+
+Danforth was frankly jumpy, and began making some offensively
+irrelevant speculations about the horror at the camp--which I resented
+all the more because I could not help sharing certain conclusions
+forced upon us by many features of this morbid survival from nightmare
+antiquity.
+
+The speculations worked on his imagination, too; for in one
+place--where a débris-littered alley turned a sharp corner--he insisted
+that he saw faint traces of ground markings which he did not like;
+whilst elsewhere he stopped to listen to a subtle, imaginary sound
+from some undefined point--a muffled musical piping, he said, not
+unlike that of the wind in the mountain caves, yet somehow disturbingly
+different.
+
+The ceaseless five-pointedness of the surrounding architecture and
+of the few distinguishable mural arabesques had a dimly sinister
+suggestiveness we could not escape, and gave us a touch of terrible
+subconscious certainty concerning the primal entities which had reared
+and dwelt in this unhallowed place.
+
+Nevertheless, our scientific and adventurous souls were not wholly
+dead, and we mechanically carried out our program of chipping specimens
+from all the different rock types represented in the masonry. We wished
+a rather full set in order to draw better conclusions regarding the age
+of the place.
+
+Nothing in the great outer walls seemed to date from later than the
+Jurassic and Comanchean periods, nor was any piece of stone in the
+entire place of a greater recency than the Pliocene age. In stark
+certainty, we were wandering amidst a death which had reigned at least
+five hundred thousand years, and in all probability even longer.
+
+       *       *       *       *       *
+
+As we proceeded through this maze of stone-shadowed twilight we stopped
+at all available apertures to study interiors and investigate entrance
+possibilities. Some were above our reach, whilst others led only into
+ice-choked ruins as unroofed and barren as the rampart on the hill.
+
+One, though spacious and inviting, opened on a seemingly bottomless
+abyss without visible means of descent. Now and then we had a chance to
+study the petrified wood of a surviving shutter, and were impressed by
+the fabulous antiquity implied in the still discernible grain. These
+things had come from Mesozoic gymnosperms and conifers--especially
+Cretaceous cycads--and from fan palms and early angiosperms of plainly
+Tertiary date. Nothing definitely later than the Pliocene could be
+discovered.
+
+In the placing of these shutters--whose edges showed the former
+presence of queer and long-vanished hinges--usage seemed to be
+varied--some being on the outer and some on the inner side of the
+deep embrasures. They seemed to have become wedged in place, thus
+surviving the rusting of their former and probably metallic fixtures
+and fastenings.
+
+After a time we came across a row of windows--in the bulges of a
+colossal five-edged cone of undamaged apex--which led into a vast,
+well-preserved room with stone flooring; but these were too high in
+the room to permit descent without a rope. We had a rope with us,
+but did not wish to bother with this twenty-foot drop unless obliged
+to--especially in this thin plateau air where great demands were made
+upon the heart action.
+
+This enormous room was probably a hall or concourse of some sort, and
+our electric torches showed bold, distinct, and potentially startling
+sculptures arranged round the walls in broad, horizontal bands
+separated by equally broad strips of conventional arabesques. We took
+careful note of this spot, planning to enter here unless a more easily
+gained interior was encountered.
+
+Finally, though, we did encounter exactly the opening we wished; an
+archway about six feet wide and ten feet high, marking the former end
+of an aërial bridge which had spanned an alley about five feet above
+the present level of glaciation. These archways, of course, were flush
+with upper-story floors, and in this case one of the floors still
+existed.
+
+The building thus accessible was a series of rectangular terraces
+on our left facing westward. That across the alley, where the other
+archway yawned, was a decrepit cylinder with no windows and with
+a curious bulge about ten feet above the aperture. It was totally
+dark inside, and the archway seemed to open on a well of illimitable
+emptiness.
+
+Heaped débris made the entrance to the vast left-hand building doubly
+easy, yet for a moment we hesitated before taking advantage of the
+long-wished chance. For though we had penetrated into this tangle of
+archaic mystery, it required fresh resolution to carry us actually
+inside a complete and surviving building of a fabulous elder world
+whose nature was becoming more and more hideously plain to us.
+
+In the end, however, we made the plunge, and scrambled up over the
+rubble into the gaping embrasure. The floor beyond was of great slate
+slabs, and seemed to form the outlet of a long, high corridor with
+sculptured walls.
+
+Observing the many inner archways which led off from it, and realizing
+the probable complexity of the nest of apartments within, we decided
+that we must begin our system of hare-and-hound trail blazing. Hitherto
+our compasses, together with frequent glimpses of the vast mountain
+range between the towers in our rear, had been enough to prevent our
+losing our way; but from now on, the artificial substitute would be
+necessary.
+
+Accordingly we reduced our extra paper to shreds of suitable size,
+placed these in a bag to be carried by Danforth, and prepared to use
+them as economically as safety would allow. This method would probably
+gain us immunity from straying, since there did not appear to be any
+strong air currents inside the primordial masonry. If such should
+develop, or if our paper supply should give out, we could of course
+fall back on the more secure though more tedious and retarding method
+of rock chipping.
+
+Just how extensive a territory we had opened up, it was impossible
+to guess without a trial. The close and frequent connection of the
+different buildings made it likely that we might cross from one to
+another on bridges underneath the ice, except where impeded by local
+collapses and geologic rifts, for very little glaciation seemed to have
+entered the massive constructions.
+
+Almost all the areas of transparent ice had revealed the submerged
+windows as tightly shuttered, as if the town had been left in that
+uniform state until the glacial sheet came to crystallize the lower
+part for all succeeding time. Indeed, one gained a curious impression
+that this place had been deliberately closed and deserted in some dim,
+bygone æon, rather than overwhelmed by any sudden calamity or even
+gradual decay. Had the coming of the ice been foreseen, and had a
+nameless population left _en masse_ to seek a less doomed abode?
+
+The precise physiographic conditions attending the formation of the
+ice sheet at this point would have to wait for later solution. It had
+not, very plainly, been a grinding drive. Perhaps the pressure of
+accumulated snows had been responsible, and perhaps some flood from
+the river, or from the bursting of some ancient glacial dam in the
+great range, had helped to create the special state now observable.
+Imagination could conceive almost anything in connection with this
+place.
+
+
+
+
+                                  VI.
+
+
+It would be cumbrous to give a detailed, consecutive account of
+our wanderings inside that cavernous, æon-dead honeycomb of primal
+masonry--that monstrous lair of elder secrets which now echoed for the
+first time, after uncounted epochs, to the tread of human feet.
+
+This is especially true because so much of the horrible drama and
+revelation came from a mere study of the omnipresent mural carvings.
+Our flash-light photographs of those carvings will do much toward
+proving the truth of what we are now disclosing, and it is lamentable
+that we had not a larger film supply with us. As it was, we made crude
+notebook sketches of certain salient features after all our films were
+used up.
+
+The building which we had entered was one of great size and
+elaborateness, and gave us an impressive notion of the architecture of
+that nameless geologic past. The inner partitions were less massive
+than the outer walls, but on the lower levels were excellently
+preserved. Labyrinthine complexity, involving curiously irregular
+differences in floor levels, characterized the entire arrangement; and
+we should certainly have been lost at the very outset but for the trail
+of torn paper left behind us.
+
+We decided to explore the more decrepit upper parts first of all, hence
+climbed aloft in the maze for a distance of some one hundred feet, to
+where the topmost tier of chambers yawned snowily and ruinously open to
+the polar sky. Ascent was effected over the steep, transversely ribbed
+stone ramps or inclined planes which everywhere served in lieu of
+stairs.
+
+The rooms we encountered were of all imaginable shapes and proportions,
+ranging from five-pointed stars to triangles and perfect cubes. It
+might be safe to say that their general average was about 30 x 30 feet
+in floor area, and twenty feet in height, though many larger apartments
+existed.
+
+After thoroughly examining the upper regions and the glacial level
+we descended, story by story, into the submerged part, where indeed
+we soon saw we were in a continuous maze of connected chambers and
+passages probably leading over unlimited areas outside this particular
+building.
+
+The Cyclopean massiveness and giganticism of everything about us became
+curiously oppressive; and there was something vaguely but deeply
+unhuman in all the contours, dimensions, proportions, decorations, and
+constructional nuances of the blasphemously archaic stonework. We soon
+realized, from what the carvings revealed, that this monstrous city was
+many million years old.
+
+We cannot yet explain the engineering principles used in the anomalous
+balancing and adjustment of the vast rock masses, though the function
+of the arch was clearly much relied on. The rooms we visited were
+wholly bare of all portable contents, a circumstance which sustained
+our belief in the city's deliberate desertion. The prime decorative
+feature was the almost universal system of mural sculpture, which
+tended to run in continuous horizontal bands three feet wide and
+arranged from floor to ceiling in alternation with bands of equal width
+given over to geometrical arabesques.
+
+There were exceptions to this rule of arrangement, but its
+preponderance was overwhelming. Often, however, a series of smooth
+cartouches containing oddly patterned groups of dots would be sunk
+along one of the arabesque bands.
+
+       *       *       *       *       *
+
+The technique, we soon saw, was mature, accomplished, and æsthetically
+evolved to the highest degree of civilized mastery, though utterly
+alien in every detail to any known art tradition of the human race.
+In delicacy of execution no sculpture I have ever seen could approach
+it. The minutest details of elaborate vegetation, or of animal life,
+were rendered with astonishing vividness despite the bold scale of the
+carvings; whilst the conventional designs were marvels of skillful
+intricacy.
+
+The arabesques displayed a profound use of mathematical principles, and
+were made up of obscurely symmetrical curves and angles based on the
+quantity of five.
+
+The pictorial bands followed a highly formalized tradition, and
+involved a peculiar treatment of perspective, but had an artistic force
+that moved us profoundly notwithstanding the intervening gulf of vast
+geologic periods.
+
+Their method of design hinged on a singular juxtaposition of the cross
+section with the two-dimensional silhouette, and embodied an analytical
+psychology beyond that of any known race of antiquity. It is useless to
+try to compare this art with any represented in our museums. Those who
+see our photographs will probably find its closest analogue in certain
+grotesque conceptions of the most daring futurists.
+
+The arabesque tracery consisted altogether of depressed lines, whose
+depth on unweathered walls varied from one to two inches. When
+cartouches with dot groups appeared--evidently as inscriptions in some
+unknown and primordial language and alphabet--the depression of the
+smooth surface was perhaps an inch and a half, and of the dots perhaps
+a half inch more. The pictorial bands were in countersunk low relief,
+their background being depressed about two inches from the original
+wall surface.
+
+In some specimens marks of a former coloration could be detected,
+though for the most part the untold æons had disintegrated and banished
+any pigments which may have been applied. The more one studied the
+marvelous technique the more one admired the things. Beneath their
+strict conventionalization one could grasp the minute and accurate
+observation and graphic skill of the artists; and indeed, the very
+conventions themselves served to symbolize and accentuate the real
+essence or vital differentiation of every object delineated.
+
+We felt, too, that besides these recognizable excellences there
+were others lurking beyond the reach of our perceptions. Certain
+touches here and there gave vague hints of latent symbols and stimuli
+which another mental and emotional background, and a fuller or
+different sensory equipment, might have made of profound and poignant
+significance to us.
+
+The subject matter of the sculptures obviously came from the life of
+the vanished epoch of their creation, and contained a large proportion
+of evident history. It is this abnormal historic-mindedness of the
+primal race--a chance circumstance operating, through coincidence,
+miraculously in our favor--which made the carvings so awesomely
+informative to us, and which caused us to place their photography and
+transcription above all other considerations.
+
+In certain rooms the dominant arrangement was varied by the presence of
+maps, astronomical charts, and other scientific designs on an enlarged
+scale--these things giving a naïve and terrible corroboration to what
+we gathered from the pictorial friezes and dados.
+
+In hinting at what the whole revealed, I can only hope that my account
+will not arouse a curiosity greater than sane caution on the part of
+those who believe me at all. It would be tragic if any were to be
+allured to that realm of death and horror by the very warning meant to
+discourage them.
+
+       *       *       *       *       *
+
+Interrupting these sculptured walls were high windows and massive
+twelve-foot doorways; both now and then retaining the petrified wooden
+planks--elaborately carved and polished--of the actual shutters and
+doors. All metal fixtures had long ago vanished, but some of the doors
+remained in place and had to be forced aside as we progressed from room
+to room.
+
+Window frames with odd transparent panes--mostly elliptical--survived
+here and there, though in no considerable quantity. There were also
+frequent niches of great magnitude, generally empty, but once in a
+while containing some bizarre object carved from green soapstone which
+was either broken or perhaps held too inferior to warrant removal.
+
+Other apertures were undoubtedly connected with bygone mechanical
+facilities--heating, lighting, and the like--of a sort suggested in
+many of the carvings. Ceilings tended to be plain, but had sometimes
+been inlaid with green soapstone or other tiles, mostly fallen now.
+Floors were also paved with such tiles, though plain stonework
+predominated.
+
+As I have said, all furniture and other movables were absent; but the
+sculptures gave a clear idea of the strange devices which had once
+filled these tomblike, echoing rooms. Above the glacial sheet the
+floors were generally thick with detritus, litter, and débris, but
+farther down this condition decreased.
+
+In some of the lower chambers and corridors there was little more than
+gritty dust or ancient incrustations, while occasional areas had an
+uncanny air of newly swept immaculateness. Of course, where rifts or
+collapses had occurred, the lower levels were as littered as the
+upper ones.
+
+A central court--as we had seen in other structures, from the
+air--saved the inner regions from total darkness; so that we seldom had
+to use our electric torches in the upper rooms except when studying
+sculptured details. Below the ice cap, however, the twilight deepened;
+and in many parts of the tangled ground level there was an approach to
+absolute blackness.
+
+To form even a rudimentary idea of our thoughts and feelings as we
+penetrated this æon-silent maze of unhuman masonry one must correlate
+a hopelessly bewildering chaos of fugitive moods, memories, and
+impressions. The sheer appalling antiquity and lethal desolation of the
+place were enough to overwhelm almost any sensitive person, but added
+to these elements were the recent unexplained horror at the camp, and
+the revelations all too soon effected by the terrible mural sculptures
+around us.
+
+The moment we came upon a perfect section of carving, where no
+ambiguity of interpretation could exist, it took only a brief study
+to give us the hideous truth--a truth which it would be naïve to claim
+Danforth and I had not independently suspected before, though we had
+carefully refrained from even hinting it to each other. There could
+now be no further merciful doubt about the nature of the beings which
+had built and inhabited this monstrous dead city millions of years
+ago, when man's ancestors were primitive archaic mammals, and vast
+Dinosauria roamed the tropical steppes of Europe and Asia.
+
+We had previously clung to a desperate alternative and insisted--each
+to himself--that the omnipresence of the five-pointed motif meant only
+some cultural or religious exaltation of the archæan natural object
+which had so patently embodied the quality of five-pointedness; as the
+decorative motifs of Minoan Crete exalted the sacred bull, those of
+Egypt the scarabæus, those of Rome the wolf and the eagle, and those of
+various savage tribes some chosen totem animal.
+
+But this lone refuge was now stripped from us, and we were forced to
+face definitely the reason-shaking realization which the reader of
+these pages has doubtless long ago anticipated. I can scarcely bear to
+write it down in black and white even now, but perhaps that will not be
+necessary.
+
+       *       *       *       *       *
+
+The things once rearing and dwelling in this frightful masonry in the
+age of Dinosauria were not indeed Dinosauria, but far worse. Mere
+Dinosauria were new and almost brainless objects--but the builders of
+the city were wise and old, and had left certain traces in rocks even
+then laid down well nigh a thousand million years--rocks laid down
+before the true life of earth had advanced beyond plastic groups of
+cells--rocks laid down before the true life of earth had existed at all.
+
+They were the makers and enslavers of that life, and above all doubt
+the originals of the fiendish elder myths which things like the
+Pnakotic Manuscripts and the _Necronomicon_ affrightedly hint about.
+They were the great "Old Ones" that had filtered down from the stars
+when earth was young--the beings whose substance an alien evolution had
+shaped, and whose powers were such as this planet had never bred. And
+to think that only the day before Danforth and I had actually looked
+upon fragments of their millennially fossilized substance--and that
+poor Lake and his party had seen their complete outlines----
+
+It is, of course, impossible for me to relate in proper order the
+stages by which we picked up what we know of that monstrous chapter of
+prehuman life. After the first shock of the certain revelation, we had
+to pause a while to recuperate, and it was fully three o'clock before
+we got started on our actual tour of systematic research.
+
+The sculptures in the building we entered were of relatively late
+date--perhaps two million years ago--as checked up by geological,
+biological, and astronomical features--and embodied an art which would
+be called decadent in comparison with that of specimens we found in
+older buildings, after crossing bridges under the glacial sheet.
+
+One edifice hewn from the solid rock seemed to go back forty or
+possibly even fifty million years--to the lower Eocene or upper
+Cretaceous--and contained bas-reliefs of an artistry surpassing
+anything else, with one tremendous exception, that we encountered. That
+was, we have since agreed, the oldest domestic structure we traversed.
+
+Were it not for the support of those flashlights soon to be made
+public, I would refrain from telling what I found and inferred, lest I
+be confined as a madman. Of course, the infinitely early parts of the
+patchwork tale--representing the preterrestrial life of the star-headed
+beings on other planets, in other galaxies, and in other universes--can
+readily be interpreted as the fantastic mythology of those beings
+themselves; yet such parts sometimes involved designs and diagrams so
+uncannily close to the latest findings of mathematics and astrophysics
+that I scarcely know what to think. Let others judge when they see the
+photographs I shall publish.
+
+Naturally, no one set of carvings which we encountered told more than a
+fraction of any connected story, nor did we even begin to come upon the
+various stages of that story in their proper order. Some of the vast
+rooms were independent units so far as their designs were concerned,
+whilst in other cases a continuous chronicle would be carried through a
+series of rooms and corridors.
+
+The best of the maps and diagrams were on the walls of a frightful
+abyss below even the ancient ground level--a cavern perhaps two hundred
+feet square and sixty feet high, which had almost undoubtedly been an
+educational center of some sort.
+
+There were many provoking repetitions of the same material in different
+rooms and buildings, since certain chapters of experience, and certain
+summaries or phases of racial history, had evidently been favorites
+with different decorators or dwellers. Sometimes, though, variant
+versions of the same theme proved useful in settling debatable points
+and filling up gaps.
+
+I still wonder that we deduced so much in the short time at our
+disposal. Of course, we even now have only the barest outline--and
+much of that was obtained later on from a study of the photographs and
+sketches we made.
+
+It may be the effect of this later study--the revived memories and
+vague impressions acting in conjunction with his general sensitiveness
+and with that final supposed horror-glimpse whose essence he will not
+reveal even to me--which has been the immediate source of Danforth's
+present breakdown.
+
+But it had to be; for we could not issue our warning intelligently
+without the fullest possible information, and the issuance of that
+warning is a prime necessity. Certain lingering influences in that
+unknown antarctic world of disordered time and alien natural law make
+it imperative that further exploration be discouraged.
+
+
+
+
+                                 VII.
+
+
+The full story, so far as deciphered, will eventually appear in an
+official bulletin of Miskatonic University. Here I shall sketch only
+the salient highlights in a formless, rambling way. Myth or otherwise,
+the sculptures told of the coming of those star-headed things to the
+nascent, lifeless earth out of cosmic space--their coming, and the
+coming of many other alien entities such as at certain times embark
+upon spatial pioneering.
+
+They seemed able to traverse the interstellar ether on their vast
+membranous wings--thus oddly confirming some curious hill folklore long
+ago told me by an antiquarian colleague. They had lived under the sea a
+good deal, building fantastic cities and fighting terrific battles with
+nameless adversaries by means of intricate devices employing unknown
+principles of energy.
+
+Evidently their scientific and mechanical knowledge far surpassed
+man's to-day, though they made use of its more widespread and elaborate
+forms only when obliged to.
+
+Some of the sculptures suggested that they had passed through a stage
+of mechanized life on other planets, but had receded upon finding
+its effects emotionally unsatisfying. Their preternatural toughness
+of organization and simplicity of natural wants made them peculiarly
+able to live on a high plane without the more specialized fruits
+of artificial manufacture, and even without garments, except for
+occasional protection against the elements.
+
+It was under the sea, at first for food and later for other purposes,
+that they first created earth life--using available substances
+according to long-known methods.
+
+The more elaborate experiments came after the annihilation of various
+cosmic enemies. They had done the same thing on other planets, having
+manufactured not only necessary foods, but certain multicellular
+protoplasmic masses capable of molding their tissues into all sorts of
+temporary organs under hypnotic influence and thereby forming ideal
+slaves to perform the heavy work of the community.
+
+These viscous masses were without doubt what Abdul Alhazred whispered
+about as the "Shoggoths" in his frightful _Necronomicon_, though even
+that mad Arab had not hinted that any existed on earth except in the
+dreams of those who had chewed a certain alkaloidal herb.
+
+When the star-headed Old Ones on this planet had synthesized their
+simple food forms and bred a good supply of Shoggoths, they allowed
+other cell groups to develop into other forms of animal and vegetable
+life for sundry purposes, extirpating any whose presence became
+troublesome.
+
+With the aid of the Shoggoths, whose expansions could be made to lift
+prodigious weights, the small, low cities under the sea grew to vast
+and imposing labyrinths of stone not unlike those which later rose on
+land. Indeed, the highly adaptable Old Ones had lived much on land in
+other parts of the universe, and probably retained many traditions of
+land construction.
+
+As we studied the architecture of all these sculptured Palæogæan
+cities, including that whose æon-dead corridors we were even then
+traversing, we were impressed by a curious coincidence which we have
+not yet tried to explain, even to ourselves. The tops of the buildings,
+which in the actual city around us had, of course, been weathered into
+shapeless ruins ages ago, were clearly displayed in the bas-reliefs,
+and showed vast clusters of needlelike spires, delicate finials
+on certain cone and pyramid apexes, and tiers of thin, horizontal
+scalloped disks capping cylindrical shafts.
+
+This was exactly what we had seen in that monstrous and portentous
+mirage, cast by a dead city whence such sky-line features had been
+absent for thousands and ten of thousands of years, which loomed on our
+ignorant eyes across the unfathomed mountains of madness as we first
+approached poor Lake's ill-fated camp.
+
+       *       *       *       *       *
+
+Of the life of the Old Ones, both under the sea and after part of them
+migrated to land, volumes could be written. Those in shallow water had
+continued the fullest use of the eyes at the ends of their five main
+head tentacles, and had practiced the arts of sculpture and of writing
+in quite the usual way--the writing accomplished with a stylus on
+waterproof waxen surfaces.
+
+Those lower down in the ocean depths, though they used a curious
+phosphorescent organism to furnish light, pieced out their vision with
+obscure special senses operating through the prismatic cilia on their
+heads--senses which rendered all the Old Ones partly independent of
+light in emergencies. Their forms of sculpture and writing had changed
+curiously during the descent, embodying certain apparently chemical
+coating processes--probably to secure phosphorescence--which the
+bas-reliefs could not make clear to us.
+
+The beings moved in the sea partly by swimming--using the lateral
+crinoid arms--and partly by wriggling with the lower tier of tentacles
+containing the pseudofeet. Occasionally they accomplished long swoops
+with the auxiliary use of two or more sets of their fan-like folding
+wings.
+
+On land they locally used the pseudofeet, but now and then flew to
+great heights or over long distances with their wings. The many
+slender tentacles into which the crinoid arms branched were infinitely
+delicate, flexible, strong, and accurate in muscular-nervous
+coördination--ensuring the utmost skill and dexterity in all artistic
+and other manual operations.
+
+The toughness of the things was almost incredible. Even the terrific
+pressure of the deepest sea bottoms appeared powerless to harm them.
+Very few seemed to die at all except by violence, and their burial
+places were very limited. The facts that they covered their vertically
+inhumed dead with five-pointed inscribed mounds set up thoughts in
+Danforth and me which made a fresh pause and recuperation necessary
+after the sculptures revealed it.
+
+[Illustration: _The toughness of the things was almost incredible. Even
+terrific pressures were powerless to harm them!_]
+
+The beings multiplied by means of spores--like vegetable pteridophyta,
+as Lake had suspected--but, owing to their prodigious toughness and
+longevity, and consequent lack of replacement needs, they did not
+encourage the large-scale development of new prothallia except when
+they had new regions to colonize.
+
+The young matured swiftly, and received an education evidently beyond
+any standard we can imagine. The prevailing intellectual and æsthetic
+life was highly evolved, and produced a tenaciously enduring set of
+customs and institutions which I shall describe more fully in my coming
+monograph. These varied slightly according to sea or land residence,
+but had the same foundations and essentials.
+
+Though able, like vegetables, to derive nourishment from inorganic
+substances; they vastly preferred organic and especially animal food.
+They ate uncooked marine life under the sea, but cooked their viands on
+land. They hunted game and raised meat herds--slaughtering with sharp
+weapons whose odd marks on certain fossil bones our expedition had
+noted.
+
+They resisted all ordinary temperatures marvelously, and in their
+natural state could live in water down to freezing. When the great
+chill of the Pleistocene drew on, however--nearly a million years
+ago--the land dwellers had to resort to special measures, including
+artificial heating--until, at last, the deadly cold appears to have
+driven them back into the sea.
+
+For their prehistoric flights through cosmic space, legend said, they
+had absorbed certain chemicals and become almost independent of eating,
+breathing, or heat conditions--but by the time of the great cold
+they had lost track of the method. In any case, they could not have
+prolonged the artificial state indefinitely without harm.
+
+Being nonpairing and semivegetable in structure, the Old Ones had
+no biological basis for the family phase of mammal life, but seemed
+to organize large households on the principles of comfortable
+space-utility and--as we deduced from the pictured occupations and
+diversions of codwellers--congenial mental association.
+
+In furnishing their homes they kept everything in the center of the
+huge rooms, leaving all wall spaces free for decorative treatment.
+Lighting, in the case of the land inhabitants, was accomplished by a
+device probably electro-chemical in nature.
+
+Both on land and under water they used curious tables, chairs and
+couches like cylindrical frames--for they rested and slept upright with
+folded-down tentacles--and racks for the hinged sets of dotted surfaces
+forming their books.
+
+       *       *       *       *       *
+
+Government was evidently complex and probably socialistic, though no
+certainties in this regard could be deduced from the sculptures we
+saw. There was extensive commerce, both local and between different
+cities--certain small, flat counters, five-pointed and inscribed,
+serving as money. Probably the smaller of the various greenish
+soapstones found by our expedition were pieces of such currency.
+
+Though the culture was mainly urban, some agriculture and much stock
+raising existed. Mining and a limited amount of manufacturing were also
+practiced. Travel was very frequent, but permanent migration seemed
+relatively rare except for the vast colonizing movements by which the
+race expanded.
+
+For personal locomotion no external aid was used, since in land, air,
+and water movement alike the Old Ones seemed to possess excessively
+vast capacities for speed. Loads, however, were drawn by beasts of
+burden--Shoggoths under the sea, and a curious variety of primitive
+vertebrates in the later years of land existence.
+
+These vertebrates, as well as an infinity of other life forms--animal
+and vegetable, marine, terrestrial, and aërial--were the products of
+unguided evolution acting on life cells made by the Old Ones, but
+escaping beyond their radius of attention. They had been suffered
+to develop unchecked because they had not come in conflict with the
+dominant beings. Bothersome forms, of course, were mechanically
+exterminated.
+
+It interested us to see in some of the very last and most decadent
+sculptures a shambling, primitive mammal, used sometimes for food and
+sometimes as an amusing buffoon by the land dwellers, whose vaguely
+simian and human foreshadowings were unmistakable. In the building of
+land cities the huge stone blocks of the high towers were generally
+lifted by vast-winged pterodactyls of a species heretofore unknown to
+palæontology.
+
+The persistence with which the Old Ones survived various geologic
+changes and convulsions of the earth's crust was little short of
+miraculous. Though few or none of their first cities seem to have
+remained beyond the Archæan Age, there was no interruption in their
+civilization or in the transmission of their records.
+
+Their original place of advent to the planet was the Antarctic Ocean,
+and it is likely that they came not long after the matter forming the
+moon was wrenched from the neighboring South Pacific. According to one
+of the sculptured maps, the whole globe was then under water, with
+stone cities scattered farther and farther from the antarctic as æons
+passed.
+
+Another map shows a vast bulk of dry land around the south pole, where
+it is evident that some of the beings made experimental settlements,
+though their main centers were transferred to the nearest sea bottom.
+
+Later maps, which display this land mass as cracking and drifting, and
+sending certain detached parts northward, uphold in a striking way the
+theories of continental drift lately advanced by Taylor, Wegener, and
+Joly.
+
+With the upheaval of new land in the South Pacific, tremendous events
+began. Some of the marine cities were hopelessly shattered, yet that
+was not the worst misfortune. Another race--a land race of beings
+shaped like octopi and probably corresponding to the fabulous prehuman
+spawn of Cthulhu--soon began filtering down from cosmic infinity and
+precipitated a monstrous war which for a time drove the Old Ones
+wholly back to the sea--a colossal blow in view of the increasing land
+settlements.
+
+Later, peace was made, and the new lands were given to the Cthulhu
+spawn whilst the Old Ones held the sea and the older lands. New land
+cities were founded--the greatest of them in the antarctic, for this
+region of first arrival was sacred.
+
+From then on, as before, the antarctic remained the center of the Old
+Ones' civilization, and all the cities built there by the Cthulhu spawn
+were blotted out.
+
+Then, suddenly, the lands of the Pacific sank again, taking with them
+the frightful stone city of R'lyeh and all the cosmic octopi, so that
+the Old Ones were again supreme on the planet, except for one shadowy
+fear about which they did not like to speak.
+
+At a rather later age their cities dotted all the land and water areas
+of the globe--hence the recommendation in my coming monograph that some
+archæologist make systematic borings with Pabodie's type of apparatus
+in certain widely separated regions.
+
+       *       *       *       *       *
+
+The steady trend down the ages was from water to land--a movement
+encouraged by the rise of new land masses, though the ocean was never
+wholly deserted. Another cause of the landward movement was the new
+difficulty in breeding and managing the Shoggoths upon which successful
+sea life depended.
+
+With the march of time, as the sculptures sadly confessed, the art of
+creating new life from inorganic matter had been lost, so that the Old
+Ones had to depend on the molding of forms already in existence. On
+land the great reptiles proved highly tractable; but the Shoggoths of
+the sea, reproducing by fission and acquiring a dangerous degree of
+accidental intelligence, presented for a time a formidable problem.
+
+They had always been controlled through the hypnotic suggestion of
+the Old Ones, and had modeled their tough plasticity into various
+useful temporary limbs and organs; but now their self-modeling powers
+were sometimes exercised independently, and in various imitative
+forms implanted by past suggestion. They had, it seems, developed a
+semistable brain whose separate and occasionally stubborn volition
+echoed the will of the Old Ones without always obeying it.
+
+Sculptured images of these Shoggoths filled Danforth and me with
+horror and loathing. They were normally shapeless entities composed
+of a viscous jelly which looked like an agglutination of bubbles, and
+each averaged about fifteen feet in diameter when a sphere. They had,
+however, a constantly shifting shape and volume--throwing out temporary
+developments or forming apparent organs of sight, hearing, and speech
+in imitation of their masters, either spontaneously or according to
+suggestion.
+
+They seem to have become peculiarly intractable toward the middle of
+the Permian Age, perhaps one hundred and fifty million years ago, when
+a veritable war of resubjugation was waged upon them by the marine Old
+Ones. Pictures of this war, and of the headless, slime-coated fashion
+in which the Shoggoths typically left their slain victims, held a
+marvelously fearsome quality despite the intervening abyss of untold
+ages.
+
+The Old Ones had used curious weapons of molecular disturbance against
+the rebel entities, and in the end had achieved a complete victory.
+Thereafter the sculptures showed a period in which Shoggoths were tamed
+and broken by armed Old Ones as the wild horses of the American west
+were tamed by cowboys.
+
+Though during the rebellion the Shoggoths had shown an ability to
+live out of water, this transition was not encouraged--since their
+usefulness on land would hardly have been commensurate with the trouble
+of their management.
+
+During the Jurassic Age the Old Ones met fresh adversity in the
+form of a new invasion from outer space--this time by half-fungous,
+half-crustacean creatures--creatures undoubtedly the same as those
+figuring in certain whispered hill legends of the north, and remembered
+in the Himalayas as the Mi-Go, or Abominable Snow Men.
+
+To fight these beings the Old Ones attempted, for the first time
+since their terrene advent, to sally forth again into the planetary
+ether; but, despite all traditional preparations, found it no longer
+possible to leave the earth's atmosphere. Whatever the old secret of
+interstellar travel had been, it was now definitely lost to the race.
+
+In the end the Mi-Go drove the Old Ones out of all the northern lands,
+though they were powerless to disturb those in the sea. Little by
+little the slow retreat of the elder race to their original antarctic
+habitat was beginning.
+
+       *       *       *       *       *
+
+It was curious to note from the pictured battles that both the Cthulhu
+spawn and the Mi-Go seem to have been composed of matter more widely
+different from that which we know than was the substance of the Old
+Ones. They were able to undergo transformations and reintegrations
+impossible for their adversaries, and seem therefore to have originally
+come from even remoter gulfs of cosmic space.
+
+The Old Ones, but for their abnormal toughness and peculiar vital
+properties, were strictly material, and must have had their absolute
+origin within the known space-time continuum--whereas the first
+sources of the other beings can only be guessed at with bated breath.
+All this, of course, assuming that the nonterrestrial linkages and
+the anomalies ascribed to the invading foes are not pure mythology.
+Conceivably, the Old Ones might have invented a cosmic framework
+to account for their occasional defeats, since historical interest
+and pride obviously formed their chief psychological element. It is
+significant that their annals failed to mention many advanced and
+potent races of beings whose mighty cultures and towering ethics figure
+persistently in certain obscure legends.
+
+The changing state of the world through long geologic ages appeared
+with startling vividness in many of the sculptured maps and scenes. In
+certain cases existing science will require revision, while in other
+cases its bold deductions are magnificently confirmed.
+
+As I have said, the hypothesis of Taylor, Wegener, and Joly that all
+the continents are fragments of an original antarctic land mass which
+cracked from centrifugal force and drifted apart over a technically
+viscous lower surface--an hypothesis suggested by such things as the
+complimentary outlines of Africa and South America, and the way the
+great mountain chains are rolled and shoved up--receives striking
+support from this uncanny source.
+
+Maps evidently showing the Carboniferous of a hundred million or
+more years ago displayed significant rifts and chasms destined later
+to separate Africa from the once continuous realms of Europe (then
+the Valusia of primal legend), Asia, the Americas, and the antarctic
+continent.
+
+Other charts--and most significantly one in connection with the
+founding fifty million years ago of the vast dead city around
+us--showed all the present continents well differentiated. And in
+the latest discoverable specimen--dating perhaps from the Pliocene
+Age--the approximate world of to-day appeared quite clearly despite the
+linkage of Alaska with Siberia, of North America with Europe through
+Greenland, and of South America with the antarctic continent through
+Graham Land.
+
+In the Carboniferous map the whole globe--ocean floor and rifted land
+mass alike--bore symbols of the Old Ones' vast stone cities, but in the
+later charts the gradual recession toward the antarctic became very
+plain.
+
+The final Pliocene specimen showed no land cities except on the
+antarctic continent and the tip of South America, nor any ocean
+cities north of the fiftieth parallel of South Latitude. Knowledge
+and interest in the northern world, save for a study of coast lines
+probably made during long exploration flights on those fan-like
+membranous wings, had evidently declined to zero among the Old Ones.
+
+Destruction of cities through the up-thrust of mountains, the
+centrifugal rending of continents, the seismic convulsions of land or
+sea bottom, and other natural causes was a matter of common record; and
+it was curious to observe how fewer and fewer replacements were made as
+the ages wore on.
+
+The vast dead megalopolis that yawned around us seemed to be the last
+general center of the race--built early in the Cretaceous Age after a
+titanic earth buckling had obliterated a still vaster predecessor not
+far distant.
+
+It appeared that this general region was the most sacred spot of
+all, where reputedly the first Old Ones had settled on a primal sea
+bottom. In the new city--many of whose features we could recognize
+in the sculptures, but which stretched fully a hundred miles along
+the mountain range in each direction beyond the farthest limits of
+our aërial survey--there were reputed to be preserved certain sacred
+stones forming part of the first sea-bottom city, which were thrust up
+to light after long epochs in the course of the general crumpling of
+strata.
+
+
+
+
+                                 VIII.
+
+
+Naturally, Danforth and I studied with special interest and a
+peculiarly personal sense of awe everything pertaining to the immediate
+district in which we were. Of this local material there was naturally a
+vast abundance.
+
+On the tangled ground level of the city we were lucky enough to find
+a house of very late date whose walls, though somewhat damaged by a
+neighboring rift, contained sculptures of decadent workmanship carrying
+the story of the region, much beyond the Pliocene map, whence we
+derived our last general glimpse of the prehuman world. This was the
+last place we examined in detail, since what we found there set upon us
+a fresh, immediate objective.
+
+Certainly, we were in one of the strangest, weirdest, and most terrible
+of all the corners of earth's globe. Of all existing lands it was
+infinitely the most ancient. The conviction grew upon us that this
+hideous upland must indeed be the fabled nightmare plateau of Leng
+which even the mad author of the _Necronomicon_ was reluctant to
+discuss.
+
+The great mountain chain was tremendously long--starting as a low range
+at Luitpold Land on the coast of Weddell Sea and virtually crossing the
+entire continent. The really high part stretched in a mighty arc from
+about Latitude 82°, E. Longitude 60° to Latitude 70°, East Longitude
+115°, with its concave side toward our camp and its seaward end in the
+region of that long, ice-locked coast whose hills were glimpsed by
+Wilkes and Mawson at the antarctic circle.
+
+Yet even more monstrous exaggerations of nature seemed disturbingly
+close at hand. I have said that these peaks are higher than the
+Himalayas, but the sculptures forbid me to say that they are earth's
+highest. That grim honor is beyond doubt reserved for something
+which half the sculptures hesitated to record at all, whilst others
+approached it with obvious repugnance and trepidation.
+
+It seems that there was one part of the ancient land--the first part
+that ever rose from the waters after the earth had flung off the moon
+and the Old Ones had seeped down from the stars--which had come to be
+shunned as vaguely and namelessly evil. Cities built there had crumbled
+before their time, and had been found suddenly deserted.
+
+Then when the first great earth buckling had convulsed the region in
+the Comanchean Age, a frightful line of peaks had shot suddenly up
+amidst the most appalling din and chaos--and earth had received her
+loftiest and most terrible mountains.
+
+If the scale of the carvings was correct, these abhorred things must
+have been much over forty thousand feet high--radically vaster than
+even the shocking mountains of madness we had crossed. They extended,
+it appeared, from about Latitude 77°, E. Longitude 70° to Latitude 70°,
+E. Longitude 100°--less than three hundred miles away from the dead
+city, so that we would have spied their dreaded summits in the dim
+western distance had it not been for that vague, opalescent haze. Their
+northern end must likewise be visible from the long antarctic circle
+coast line at Queen Mary Land.
+
+Some of the Old Ones, in the decadent days, had made strange prayers
+to those mountains--but none ever went near them or dared to guess
+what lay beyond. No human eye had ever seen them, and as I studied the
+emotions conveyed in the carvings I prayed that none ever might.
+
+There are protecting hills along the coast beyond them--Queen Mary and
+Kaiser Wilhelm Lands--and I thank Heaven no one has been able to land
+and climb those hills. I am not as sceptical about old tales and fears
+as I used to be, and I do not laugh now at the prehuman sculptor's
+notion that lightning paused meaningfully now and then at each of the
+brooding crests, and that an unexplained glow shone from one of those
+terrible pinnacles all through the long polar night. There may be a
+very real and very monstrous meaning in the old Pnakotic whispers about
+Kadath in the Cold Waste.
+
+But the terrain close at hand was hardly less strange, even if less
+namelessly accursed. Soon after the founding of the city the great
+mountain range became the seat of the principal temples, and many
+carvings showed what grotesque and fantastic towers had pierced the sky
+where now we saw only the curiously clinging cubes and ramparts.
+
+In the course of ages the caves had appeared, and had been shaped into
+adjuncts of the temples. With the advance of still later epochs all
+the limestone veins of the region were hollowed out by ground waters,
+so that the mountains, the foothills, and the plains below them were
+a veritable network of connected caverns and galleries. Many graphic
+sculptures told of explorations deep underground, and of the final
+discovery of the Stygian sunless sea that lurked at earth's bowels.
+
+       *       *       *       *       *
+
+This vast nighted gulf had undoubtedly been worn by the great river
+which flowed down from the nameless and horrible westward mountains,
+and which had formerly turned at the base of the Old Ones' range and
+flowed beside that chain into the Indian Ocean between Budd and Totten
+Lands on Wilkes's coast line. Little by little it had eaten away the
+limestone hill base at its turning, till at last its sapping currents
+reached the caverns of the ground waters and joined with them in
+digging a deeper abyss.
+
+Finally its whole bulk emptied into the hollow hills and left the old
+bed toward the ocean dry. Much of the later city as we now found it
+had been built over that former bed. The Old Ones, understanding what
+had happened, and exercising their always keen artistic sense, had
+carved into ornate pylons those headlands of the foothills where the
+great stream began its descent into eternal darkness.
+
+This river, once crossed by scores of noble stone bridges, was plainly
+the one whose extinct course we had seen in our aëroplane survey.
+Its position in different carvings of the city helped us to orient
+ourselves to the scene as it had been at various stages of the region's
+age-long, æon-dead history, so that we were able to sketch a hasty but
+careful map of the salient features--squares, important buildings, and
+the like--for guidance in further explorations.
+
+We could soon reconstruct in fancy the whole stupendous thing as it was
+a million or ten million or fifty million years ago, for the sculptures
+told us exactly what the buildings and mountains and squares and
+suburbs and landscape setting and luxuriant Tertiary vegetation had
+looked like.
+
+It must have had a marvelous and mystic beauty, and as I thought of
+it I almost forgot the clammy sense of sinister oppression with which
+the city's inhuman age and massiveness and deadness and remoteness and
+glacial twilight had choked and weighed on my spirit.
+
+Yet, according to certain carvings the denizens of that city had
+themselves known the clutch of oppressive terror; for there was a
+somber and recurrent type of scene in which the Old Ones were shown in
+the act of recoiling affrightedly from some object--never allowed to
+appear in the design--found in the great river and indicated as having
+been washed down through waving, vine-draped cycad forests from those
+horrible westward mountains.
+
+It was only in the one late-built house with the decadent carvings that
+we obtained any foreshadowing of the final calamity leading to the
+city's desertion. Undoubtedly there must have been many sculptures of
+the same age elsewhere, even allowing for the slackened energies and
+aspirations of a stressful and uncertain period; indeed, very certain
+evidence of the existence of others came to us shortly afterward. But
+this was the first and only set we directly encountered.
+
+We meant to look farther later on; but as I have said, immediate
+conditions dictated another present objective. There would, though,
+have been a limit--for after all hope of a long future occupancy of the
+place had perished among the Old Ones, there could not but have been a
+complete cessation of mural decoration. The ultimate blow, of course,
+was the coming of the great cold which once held most of the earth in
+thrall, and which has never departed from the ill-fated poles--the
+great cold that, at the world's other extremity, put an end to the
+fabled lands of Lomar and Hyperborea.
+
+Just when this tendency began in the antarctic it would be hard to say
+in terms of exact years. Nowadays we set the beginning of the general
+glacial periods at a distance of about five hundred thousand years from
+the present, but at the poles the terrible scourge must have commenced
+much earlier. All quantitative estimates are partly guesswork, but it
+is quite likely that the decadent sculptures were made considerably
+less than a million years ago, and that the actual desertion of
+the city was complete long before the conventional opening of the
+Pleistocene--five hundred thousand years ago--as reckoned in terms of
+the earth's whole surface.
+
+       *       *       *       *       *
+
+In the decadent sculptures there were signs of thinner vegetation
+everywhere, and of a decreased country life on the part of the Old
+Ones. Heating devices were shown in the houses, and winter travelers
+were represented as muffled in protective fabrics. Then we saw a
+series of cartouches--the continuous band arrangement being frequently
+interrupted in these late carvings--depicting a constantly growing
+migration to the nearest refuges of greater warmth--some fleeing to
+cities under the sea off the far-away coast, and some clambering down
+through networks of limestone caverns in the hollow hills to the
+neighboring black abyss of subterrane waters.
+
+In the end, it seems to have been the neighboring abyss which received
+the greatest colonization. This was partly due, no doubt, to the
+traditional sacredness of this special region, but may have been more
+conclusively determined by the opportunities it gave for continuing
+the use of the great temples on the honeycombed mountains, and for
+retaining the vast land city as a place of summer residence and base of
+communication with various mines.
+
+The linkage of old and new abodes was made more effective by means
+of several gradings and improvements along the connecting routes,
+including the chiseling of numerous direct tunnels from the ancient
+metropolis to the black abyss--sharply down-pointing tunnels whose
+mouths we carefully drew, according to our most thoughtful estimates,
+on the guide map we were compiling.
+
+It was obvious that at least two of these tunnels lay within a
+reasonable exploring distance of where we were--both being on the
+mountainward edge of the city, one less than a quarter of a mile toward
+the ancient rivercourse, and the other perhaps twice that distance in
+the opposite direction.
+
+The abyss, it seems, had shelving shores of dry land at certain places,
+but the Old Ones built their new city under water--no doubt because of
+its greater certainty of uniform warmth. The depth of the hidden sea
+appears to have been very great, so that the earth's internal heat
+could insure its habitability for an indefinite period.
+
+The beings seem to have had no trouble in adapting themselves to
+part-time--and eventually, of course, whole-time--residence under
+water, since they had never allowed their gill systems to atrophy.
+
+There were many sculptures which showed how they had always frequently
+visited their submarine kinsfolk elsewhere, and how they had habitually
+bathed on the deep bottom of their great river. The darkness of inner
+earth could likewise have been no deterrent to a race accustomed to
+long antarctic nights.
+
+Decadent though their style undoubtedly was, these latest carvings
+had a truly epic quality where they told of the building of
+the new city in the cavern sea. The Old Ones had gone about it
+scientifically--quarrying insoluble rocks from the heart of the
+honeycombed mountains, and employing expert workers from the nearest
+submarine city to perform the construction according to the best
+methods.
+
+These workers brought with them all that was necessary to establish
+the new venture--Shoggoth tissue from which to breed stone lifters and
+subsequent beasts of burden for the cavern city, and other protoplasmic
+matter to mold into phosphorescent organisms for lighting purposes.
+
+       *       *       *       *       *
+
+At last a mighty metropolis rose on the bottom of that Stygian sea,
+its architecture much like that of the city above, and its workmanship
+displaying relatively little decadence because of the precise
+mathematical element inherent in building operations.
+
+The newly bred Shoggoths grew to enormous size and singular
+intelligence, and were represented as taking and executing orders with
+marvelous quickness. They seemed to converse with the Old Ones by
+mimicking their voices--a sort of musical piping over a wide range,
+if poor Lake's dissection had indicated aright--and to work more from
+spoken commands than from hypnotic suggestions as in earlier times.
+
+They were, however, kept in admirable control. The phosphorescent
+organisms supplied light with vast effectiveness, and doubtless atoned
+for the loss of the familiar polar auroras of the outer-world night.
+
+Art and decoration were pursued, though, of course, with a certain
+decadence. The Old Ones seemed to realize this falling off themselves,
+and in many cases anticipated the policy of Constantine the Great by
+transplanting especially fine blocks of ancient carving from their
+land city, just as the emperor, in a similar age of decline, stripped
+Greece and Asia of their finest art to give his new Byzantine capital
+greater splendors than its own people could create. That the transfer
+of sculptured blocks had not been more extensive, was doubtless owing
+to the fact that the land city was not at first wholly abandoned.
+
+By the time total abandonment did occur--and it surely must have
+occurred before the polar Pleistocene was far advanced--the Old Ones
+had perhaps become satisfied with their decadent art--or had ceased
+to recognize the superior merit of the older carvings. At any rate,
+the æon-silent ruins around us had certainly undergone no wholesale
+sculptural denudation, though all the best separate statues, like other
+movables, had been taken away.
+
+The decadent cartouches and dados telling this story were, as I have
+said, the latest we could find in our limited search. They left us with
+a picture of the Old Ones shuttling back and forth betwixt the land
+city in summer and the sea-cavern city in winter, and sometimes trading
+with the sea-bottom cities off the antarctic coast.
+
+By this time the ultimate doom of the land city must have been
+recognized, for the sculptures showed many signs of the cold's malign
+encroachments. Vegetation was declining, and the terrible snows of the
+winter no longer melted completely even in midsummer.
+
+The saurian live stock were nearly all dead, and the mammals were
+standing it none too well. To keep on with the work of the upper
+world it had become necessary to adapt some of the amorphous and
+curiously cold-resistant Shoggoths to land life--a thing the Old Ones
+had formerly been reluctant to do. The great river was now lifeless,
+and the upper sea had lost most of its denizens except the seals and
+whales. All the birds had flown away, save only the great, grotesque
+penguins.
+
+What had happened afterward we could only guess. How long had the new
+sea-cavern city survived? Was it still down there, a stony corpse in
+eternal blackness? Had the subterranean waters frozen at last? To what
+fate had the ocean-bottom cities of the outer world been delivered?
+Had any of the Old Ones shifted north ahead of the creeping ice cap?
+Existing geology shows no trace of their presence. Had the frightful
+Mi-Go been still a menace in the outer land world of the north? Could
+one be sure of what might or might not linger, even to this day, in the
+lightless and unplumbed abysses of earth's deepest water?
+
+Those things had seemingly been able to withstand any amount of
+pressure--and men of the sea have fished up curious objects at
+times. And has the killer-whale theory really explained the savage
+and mysterious scars on antarctic seals noticed a generation ago by
+Borchgrevingk?
+
+The specimens found by poor Lake did not enter into these guesses, for
+their geologic setting proved them to have lived at what must have been
+a very early date in the land city's history. They were, according to
+their location, certainly not less than thirty million years old, and
+we reflected that in their day the sea-cavern city, and indeed the
+cavern itself, had had no existence.
+
+They would have remembered an older scene, with lush Tertiary
+vegetation everywhere, a younger land city of flourishing arts around
+them, and a great river sweeping northward along the base of the mighty
+mountains toward a far-away tropic ocean.
+
+And yet we could not help thinking about these specimens--especially
+about the eight perfect ones that were missing from Lake's hideously
+ravaged camp. There was something abnormal about that whole
+business--the strange things we had tried so hard to lay to somebody's
+madness--those frightful graves--the amount _and nature_ of the
+missing material--Gedney--the unearthly toughness of those archaic
+monstrosities, and the queer vital freaks the sculptures now showed
+the race to have----Danforth and I had seen a good deal in the last
+few hours, and were prepared to believe and keep silent about many
+appalling and incredible secrets of primal nature.
+
+
+
+
+                                  IX.
+
+
+I have said that our study of the decadent sculptures brought about a
+change in our immediate objective. This, of course, had to do with the
+chiseled avenues to the black inner world, of whose existence we had
+not known before, but which we were now eager to find and traverse.
+
+From the evident scale of the carvings we deduced that a steeply
+descending walk of about a mile through either of the neighboring
+tunnels would bring us to the brink of the dizzy, sunless cliffs about
+the great abyss, down whose side paths, improved by the Old Ones, led
+to the rocky shore of the hidden and nighted ocean. To behold this
+fabulous gulf in stark reality was a lure which seemed impossible of
+resistance once we knew of the thing--yet we realized we must begin the
+quest at once if we expected to include it in our present trip.
+
+In was now eight p.m., and we had not enough battery replacements to
+let our torches burn on forever. We had done so much of our studying
+and copying below the glacial level that our battery supply had had at
+least five hours of nearly continuous use, and despite the special dry
+cell formula would obviously be good for only about four more--though
+by keeping one torch unused, except for especially interesting or
+difficult places, we might manage to eke out a safe margin beyond that.
+
+It would not do to be without a light in these Cyclopean catacombs,
+hence in order to make the abyss trip we must give up all further
+mural deciphering. Of course, we intended to revisit the place for days
+and perhaps weeks of intensive study and photography--curiosity having
+long ago gotten the better of horror--but just now we must hasten.
+
+Our supply of trail-blazing paper was far from unlimited, and we were
+reluctant to sacrifice spare notebooks or sketching paper to augment
+it, but we did let one large notebook go. If worst came to worst, we
+could resort to rock chipping--and, of course, it would be possible,
+even in case of really lost direction, to work up to full daylight by
+one channel or another if granted sufficient time for plentiful trial
+and error. So, at last, we set off eagerly in the indicated direction
+of the nearest tunnel.
+
+According to the carvings from which we had made our map, the desired
+tunnel mouth could not be much more than a quarter of a mile from where
+we stood; the intervening space showing solid-looking buildings quite
+likely to be penetrable still at a subglacial level. The opening itself
+would be in the basement--on the angle nearest the foothills--of a
+vast five-pointed structure of evidently public and perhaps ceremonial
+nature, which we tried to identify from our aërial survey of the ruins.
+
+No such structure came to our minds as we recalled our flight, hence we
+concluded that its upper parts had been greatly damaged, or that it had
+been totally shattered in an ice rift we had noticed. In the latter
+case the tunnel would probably turn out to be choked, so that we would
+have to try the next nearest one--the one less than a mile to the north.
+
+The intervening river course prevented our trying any of the more
+southern tunnels on this trip; and indeed, if both of the neighboring
+ones were choked it was doubtful whether our batteries would warrant
+an attempt on the next northerly one--about a mile beyond our second
+choice.
+
+       *       *       *       *       *
+
+As we threaded our dim way through the labyrinth with the aid of map
+and compass--traversing rooms and corridors in every stage of ruin or
+preservation, clambering up ramps, crossing upper floors and bridges
+and clambering down again, encountering choked doorways and piles of
+débris, hastening now and then along finely preserved and uncannily
+immaculate stretches, taking false leads and retracing our way (in such
+cases removing the blind paper trail we had left), and once in a while
+striking the bottom of an open shaft through which daylight poured or
+trickled down--we were repeatedly tantalized by the sculptured walls
+along our route.
+
+We had wormed our way very close to the computed site of the tunnel's
+mouth--having crossed a second-story bridge to what seemed plainly the
+tip of a pointed wall, and descended to a ruinous corridor especially
+rich in decadently elaborate and apparently ritualistic sculptures of
+late workmanship--when, about eight thirty p.m., Danforth's keen young
+nostrils gave us the first hint of something unusual.
+
+If we had had a dog with us, I suppost we would have been warned
+before. At first we could not precisely say what was wrong with the
+formerly crystal-pure air, but after a few seconds our memories reached
+only too definitely. Let me try to state the thing without flinching.
+There was an odor--and that odor was vaguely, subtly, and unmistakably
+akin to what had nauseated us upon opening the insane grave of the
+horror poor Lake had dissected.
+
+Of course, the revelation was not as clearly cut at the time as it
+sounds now. There were several conceivable explanations, and we did a
+good deal of indecisive whispering. Most important of all, we did not
+retreat without further investigation; for having come this far, we
+were loath to be balked by anything short of certain disaster.
+
+Anyway, what we must have suspected was altogether too wild to believe.
+Such things did not happen in any normal world. It was probably sheer
+irrational instinct which made us dim our single torch--tempted no
+longer by the decadent and sinister sculptures that leered menacingly
+from the oppressive walls--and which softened our progress to a
+cautious tiptoeing and crawling over the increasingly littered floor
+and heaps of débris.
+
+Danforth's eyes as well as nose proved better than mine, for it was
+likewise he who first noticed the queer aspect of the débris after we
+had passed many half-choked arches leading to chambers and corridors
+on the ground level. It did not look quite as it ought after countless
+thousands of years of desertion, and when we cautiously turned on more
+light we saw that a kind of swath seemed to have been lately tracked
+through it. The irregular nature of the latter precluded any definite
+marks, but in the smoother places there were suggestions of the
+dragging of heavy objects. Once we thought there was a hint of parallel
+tracks, as if of runners. This was what made us pause again.
+
+It was during that pause that we caught--simultaneously this time--the
+other odor ahead. Paradoxically, it was both a less frightful and a
+more frightful odor--less frightful intrinsically, but infinitely
+appalling in this place under the known circumstances--unless, of
+course, Gedney----For the odor was the plain and familiar one of common
+petrol--every-day gasoline.
+
+       *       *       *       *       *
+
+Our motivation after that is something I will leave to psychologists.
+We knew now that some terrible extension of the camp horrors must
+have crawled into this nighted burial place of the æons, hence could
+not doubt any longer the existence of nameless conditions--present
+or at least recent--just ahead. Yet in the end we did let sheer
+burning curiosity--or anxiety--or autohypnotism--or vague thoughts of
+responsibility toward Gedney--of what not--drive us on.
+
+Danforth whispered again of the print he thought he had seen at
+the alley turning in the ruins above; and of the faint musical
+piping--potentially of tremendous significance in the light of Lake's
+dissection report, despite its close resemblance to the cave-mouth
+echoes of the windy peaks--which he thought he had shortly afterward
+half heard from unknown depths below.
+
+I, in my turn, whispered of how the camp was left--of what had
+disappeared, and of how the madness of a lone survivor might have
+conceived the inconceivable--a wild trip across the monstrous mountains
+and a descent into the unknown, primal masonry----
+
+But we could not convince each other, or even ourselves, of anything
+definite. We had turned off all light as we stood still, and vaguely
+noticed that a trace of deeply filtered upper daylight kept the
+blackness from being absolute.
+
+Having automatically begun to move ahead, we guided ourselves by
+occasional flashes from our torch. The disturbed débris formed an
+impression we could not shake off, and the smell of gasoline grew
+stronger. More and more ruin met our eyes and hampered our feet, until
+very soon we saw that the forward way was about to cease. We had been
+all too correct in our pessimistic guess about that rift glimpsed from
+the air. Our tunnel quest was a blind one, and we were not even going
+to be able to reach the basement out of which the abyssward aperture
+opened.
+
+The torch, flashing over the grotesquely carved walls of the blocked
+corridor in which we stood, showed several doorways in various
+states of obstruction; and from one of them the gasoline odor--quite
+submerging that other hint of odor--came with especial distinctness. As
+we looked more steadily, we saw that beyond a doubt there had been a
+slight and recent clearing away of débris from that particular opening.
+Whatever the lurking horror might be, we believed the direct avenue
+toward it was now plainly manifest. I do not think any one will wonder
+that we waited an appreciable time before making any further motion.
+
+And yet, when we did venture inside that black arch, our first
+impression was one of anticlimax. For amidst the littered expanse
+of that sculptured crypt--a perfect cube with sides of about twenty
+feet--there remained no recent object of instantly discernible size; so
+that we looked instinctively, though in vain, for a farther doorway.
+
+In another moment, however, Danforth's sharp vision had discovered a
+place where the floor débris had been disturbed. We turned on both
+torches full strength. Though what we saw in that light was actually
+simple and trifling, I am none the less reluctant to tell of it because
+of what it implied.
+
+It was a rough leveling of the débris, upon which several small objects
+lay carelessly scattered, and at one corner of which a considerable
+amount of gasoline must have been spilled lately enough to leave a
+strong odor even at this extreme superplateau altitude. In other words,
+it could not be other than a sort of camp--a camp made by questing
+beings who, like us, had been turned back by the unexpectedly choked
+way to the abyss.
+
+Let me be plain. The scattered objects were, so far as substance was
+concerned, all from Lake's camp, and consisted of: tin cans as queerly
+opened as those we had seen at that ravaged place, many spent matches,
+three illustrated books more or less curiously smudged, an empty ink
+bottle with its pictorial and instructional carton, a broken fountain
+pen, some oddly snipped fragments of fur and tent cloth, a used
+electric battery with circular of directions, a folder that came with
+our type of tent heater, and a sprinkling of crumpled papers.
+
+It was all bad enough, but when we smoothed out the papers and looked
+at what was on them we felt we had come to the worst. We had found
+certain inexplicably blotted papers at the camp which might have
+prepared us, yet the effect of the sight, down there in the prehuman
+vaults of a nightmare city, was almost too much to bear.
+
+       *       *       *       *       *
+
+A mad Gedney might have made the groups of dots in imitation of
+those found on the greenish soapstones, just as the dots on those
+insane five-pointed grave mounds might have been made; and he might
+conceivably have prepared rough, hasty sketches--varying in their
+accuracy--or lack of it--which outlined the neighboring parts of the
+city and traced the way from a circularly represented place outside
+our previous route--a place we identified as a great cylindrical tower
+in the carvings and as a vast circular gulf glimpsed in our aërial
+survey--to the present five-pointed structure and the tunnel mouth
+therein.
+
+He might, I repeat, have prepared such sketches; for those before
+us were quite obviously compiled, as our own had been, from late
+sculptures somewhere in the glacial labyrinth, though not from the
+ones which we had seen and used. But what this art-blind bungler could
+never have done was to execute those sketches in a strange and assured
+technique perhaps superior, despite haste and carelessness, to any of
+the decadent carvings from which they were taken--the characteristic
+and unmistakable technique of the Old Ones themselves in the dead
+city's heyday.
+
+There are those who will say Danforth and I were utterly mad not
+to flee for our lives after that; since our conclusions were
+now--notwithstanding their wildness--completely fixed, and of a nature
+I need not even mention to those who have read my account as far as
+this. Perhaps we were mad--for have I not said those horrible peaks
+were mountains of madness? But I think I can detect something of the
+same spirit--albeit in a less extreme form--in the men who stalk
+deadly beasts through African jungles to photograph them or study
+their habits. Half paralyzed with terror though we were, there was
+nevertheless fanned within us a blazing flame of awe and curiosity
+which triumphed in the end.
+
+Of course, we did not mean to face that--or those--which we knew had
+been there, but we felt that they must be gone by now. They would by
+this time have found the other neighboring entrance to the abyss, and
+have passed within, to whatever night-black fragments of the past might
+await them in the ultimate gulf--the ultimate gulf they had never seen.
+Or if that entrance, too, was blocked, they would have gone on to the
+north seeking another. They were, we remembered, partly independent of
+light.
+
+Looking back to that moment, I can scarcely recall just what precise
+form our new emotions took--just what change of immediate objective it
+was that so sharpened our sense of expectancy. We certainly did not
+mean to face what we feared--yet I will not deny that we may have had
+a lurking, unconscious wish to spy certain things from some hidden
+vantage point.
+
+Probably we had not given up our zeal to glimpse the abyss itself,
+though there was interposed a new goal in the form of that great
+circular place shown on the crumpled sketches we had found. We had at
+once recognized it as a monstrous cylindrical tower in the carvings,
+but appearing only as a prodigious, round aperture from above.
+
+Something about the impressiveness of its rendering, even in these
+hasty diagrams, made us think that its subglacial levels must
+still form a feature of peculiar importance. Perhaps it embodied
+architectural marvels as yet unencountered by us. It was certainly of
+incredible age, according to the sculptures in which it figured--being
+indeed among the first things built in the city. Its carvings, if
+preserved, could not but be highly significant. Moreover, it might form
+a good present link with the upper world--a shorter route than the one
+we were so carefully blazing and probably that by which those others
+had descended.
+
+       *       *       *       *       *
+
+At any rate, the thing we did was to study the terrible sketches--which
+quite perfectly confirmed our own--and start back over the indicated
+course to the circular place; the course which our nameless
+predecessors must have traversed twice before us. The other neighboring
+gate to the abyss would lie beyond that. I need not speak of our
+journey--during which we continued to leave an economical trail of
+paper--for it was precisely the same in kind as that by which we had
+reached the cul-de-sac, except that it tended to adhere more closely to
+the ground level and even descend to basement corridors.
+
+Every now and then we could trace certain disturbing marks
+in the débris or litter underfoot; and, after we had passed
+outside the radius of the gasoline scent, we were again faintly
+conscious--spasmodically--of that more hideous and more persistent
+scent. After the way had branched from our former course, we sometimes
+gave the rays of our single torch a furtive sweep along the walls;
+noting in almost every case the well-nigh omnipresent sculptures, which
+indeed seem to have formed a main æsthetic outlet for the Old Ones.
+
+About nine-thirty p.m., while traversing a vaulted corridor whose
+increasingly glaciated floor seemed somewhat below the ground level and
+whose roof grew lower as we advanced, we began to see strong daylight
+ahead and were able to turn off our torch. It appeared that we were
+coming to the vast, circular place, and that our distance from the
+upper air could not be very great.
+
+The corridor ended in an arch, surprisingly low for these megalithic
+ruins, but we could see much through it even before we emerged. Beyond,
+there stretched a prodigious round space--fully two hundred feet in
+diameter--strewn with débris and containing many choked archways
+corresponding to the one we were about to cross. The walls were--in
+available spaces--boldly sculptured into a spiral band of heroic
+proportions; and displayed, despite the destructive weathering caused
+by the openness of the spot, an artistic splendor far beyond anything
+we had encountered before. The littered floor was quite heavily
+glaciated, and we fancied that the true bottom lay at a considerably
+lower depth.
+
+But the salient object of the place was the titanic stone ramp which,
+eluding the archways by a sharp turn outward into the open floor, wound
+spirally up the stupendous cylindrical wall like an inside counterpart
+of those once climbing outside the monstrous towers or zikkurats of
+antique Babylon. Only the rapidity of our flight, and the perspective
+which confounded the descent with the tower's inner wall, had
+prevented our noticing this feature from the air, and thus caused us to
+seek another avenue to the subglacial level.
+
+Pabodie might have been able to tell what sort of engineering held it
+in place, but Danforth and I could merely admire and marvel. We could
+see mighty stone corbels and pillars here and there, but what we saw
+seemed inadequate to the function performed. The thing was excellently
+preserved up to the present top of the tower--a highly remarkable
+circumstance in view of its exposure--and its shelter had done much to
+protect the bizarre and disturbing cosmic sculptures on the walls.
+
+       *       *       *       *       *
+
+As we stepped out into the awesome half daylight of this monstrous
+cylinder bottom--fifty million years old, and without doubt the most
+primally ancient structure ever to meet our eyes--we saw that the
+ramp-traversed sides stretched dizzily up to a height of fully sixty
+feet.
+
+This, we recalled from our aërial survey, meant an outside glaciation
+of some forty feet; since the yawning gulf we had seen from the plane
+had been at the top of an approximately twenty-foot mound of crumbled
+masonry, somewhat sheltered for three fourths of its circumference by
+the massive curving walls of a line of higher ruins. According to the
+sculptures the original tower had stood in the center of an immense
+circular plaza, and had been perhaps five hundred or six hundred
+feet high, with tiers of horizontal disks near the top, and a row of
+needlelike spires along the upper rim.
+
+Most of the masonry had obviously toppled outward rather than inward--a
+fortunate happening, since otherwise the ramp might have been shattered
+and the whole interior choked. As it was, the ramp showed sad
+battering; whilst the choking was such that all the archways seemed to
+have been half cleared.
+
+It took us only a moment to conclude that this was indeed the route by
+which those others had descended, and that this would be the logical
+route for our own ascent, despite the long trail of paper we had left
+elsewhere. The tower's mouth was no farther from the foothills and our
+waiting plane than was the great terraced building we had entered, and
+any further subglacial exploration we might make on this trip would lie
+in this general region.
+
+Oddly, we were still thinking about possible later trips--even after
+all we had seen and guessed. Then, as we picked our way cautiously over
+the débris of the great floor, there came a sight which for the time
+excluded all other matters.
+
+It was the neatly huddled array of three sledges in that farther angle
+of the ramp's lower and outward-projecting course which had hitherto
+been screened from our view. There they were--the three sledges missing
+from Lake's camp--shaken by a hard usage which must have included
+forcible dragging along great reaches of snowless masonry and débris,
+as well as much hand portage over utterly unnavigable places.
+
+They were carefully and intelligently packed and strapped, and
+contained things memorably familiar enough: the gasoline stove, fuel
+cans, instrument cases, provision tins, tarpaulins obviously bulging
+with books, and some bulging with less obvious contents--everything
+derived from Lake's equipment.
+
+After what we had found in that other room, we were in a measure
+prepared for this encounter. The really great shock came when we
+stepped over and undid one tarpaulin, whose outlines had peculiarly
+disquieted us. It seems that others as well as Lake had been interested
+in collecting typical specimens; for there were two here, both stiffly
+frozen, perfectly preserved, patched with adhesive plaster where some
+wounds around the neck had occurred, and wrapped with care to prevent
+further damage. They were the bodies of young Gedney and the missing
+dog.
+
+
+
+
+                                  X.
+
+
+Many people will probably judge us callous as well as mad for thinking
+about the northward tunnel and the abyss so soon after our somber
+discovery, and I am not prepared to say that we would have immediately
+revived such thoughts but for a specific circumstance which broke in
+upon us and set up a whole new train of speculations.
+
+We had replaced the tarpaulin over poor Gedney and were standing
+in a kind of mute bewilderment when the sounds finally reached our
+consciousness--the first sounds we had heard since descending out of
+the open where the mountain wind whined faintly from its unearthly
+heights. Well-known and mundane though they were, their presence in
+this remote world of death was more unexpected and unnerving than any
+grotesque or fabulous tones could possibly have been--since they gave a
+fresh upsetting to all our notions of cosmic harmony.
+
+Had it been some trace of that bizarre musical piping over a wide
+range, which Lake's dissection report had led us to expect in those
+others--and which, indeed, our overwrought fancies had been reading
+into every wind howl we had heard since coming on the camp horror--it
+would have had a kind of hellish congruity with the æon-dead region
+around us. A voice from other epochs belongs in a graveyard of other
+epochs.
+
+As it was, however, the noise shattered all our profoundly seated
+adjustments--all out tacit acceptance of the inner antarctic as a waste
+utterly and irrevocably void of every vestige of normal life.
+
+What we heard was not the fabulous note of any buried blasphemy of
+elder earth from whose supernal toughness an age-denied polar sun had
+evoked a monstrous response. Instead, it was a thing so mockingly
+normal and so unerringly familiarized by our sea days off Victoria Land
+and our camp days at McMurdo Sound that we shuddered to think of it
+here, where such things ought not to be. To be brief--it was simply the
+raucous squawking of a penguin.
+
+The muffled sound floated from subglacial recesses nearly opposite to
+the corridor whence we had come--regions manifestly in the direction
+of that other tunnel to the vast abyss. The presence of a living water
+bird in such a direction--in a world whose surface was one of age-long
+and uniform lifelessness--could lead to only one conclusion; hence our
+first thought was to verify the objective reality of the sound. It was,
+indeed, repeated, and seemed at times to come from more than one throat.
+
+Seeking its source, we entered an archway from which much débris had
+been cleared; resuming our trail blazing--with an added paper supply
+taken with curious repugnance from one of the tarpaulin bundles on the
+sledges--when we left daylight behind.
+
+As the glaciated floor gave place to a litter of detritus, we plainly
+discerned some curious, dragging tracks; and once Danforth found
+a distinct print of a sort whose description would be only too
+superfluous. The course indicated by the penguin cries was precisely
+what our map and compass prescribed as an approach to the more
+northerly tunnel mouth, and we were glad to find that a bridgeless
+thoroughfare on the ground and basement levels seemed open.
+
+The tunnel, according to the chart, ought to start from the basement of
+a large pyramidal structure which we seemed vaguely to recall from our
+aërial survey as remarkably well-preserved. Along our path the single
+torch showed a customary profusion of carvings, but we did not pause to
+examine any of these.
+
+       *       *       *       *       *
+
+Suddenly a bulky white shape loomed up ahead of us, and we flashed on
+the second torch. It is odd how wholly this new quest had turned our
+minds from earlier fears of what might lurk near. Those other ones,
+having left their supplies in the great circular place, must have
+planned to return after their scouting trip toward or into the abyss;
+yet we had now discarded all caution concerning them as completely as
+if they had never existed.
+
+This white, waddling thing was fully six feet high, yet we seemed to
+realize at once that it was not one of those others. They were larger
+and dark, and, according to the sculptures, their motion over land
+surfaces was a swift, assured matter despite the queerness of their
+sea-born tentacle equipment. But to say that the white thing did not
+profoundly frighten us would be vain. We were indeed clutched for an
+instant by a primitive dread almost sharper than the worst of our
+reasoned fears regarding those others.
+
+Then came a flash of anticlimax as the white shape sidled into a
+lateral archway to our left, to join two others of its kind which
+had summoned it in raucous tones. For it was only a penguin--albeit
+of a huge, unknown species larger than the greatest of the known
+king penguins, and monstrous in its combined albinism and virtual
+eyelessness.
+
+When we had followed the thing into the archway and turned both our
+torches on the indifferent and unheeding group of three, we saw that
+they were all eyeless albinos of the same unknown and gigantic species.
+
+Their size reminded us of some of the archaic penguins depicted in the
+Old Ones' sculptures, and it did not take us long to conclude that
+they were descended from the same stock--undoubtedly surviving through
+a retreat to some warmer inner region whose perpetual blackness had
+destroyed their pigmentation and atrophied their eyes to mere useless
+slits.
+
+That their present habitat was the vast abyss we sought, was not for a
+moment to be doubted; and this evidence of the gulf's continued warmth
+and habitability filled us with the most curious and subtly perturbing
+fancies.
+
+We wondered, too, what had caused these three birds to venture out
+of their usual domain. The state and silence of the great dead city
+made it clear that it had at no time been a habitual seasonal rookery,
+whilst the manifest indifference of the trio to our presence made it
+seem odd that any passing party of those others should have startled
+them.
+
+Was it possible that those others had taken some aggressive notion or
+tried to increase their meat supply? We doubted whether that pungent
+odor which the dogs had hated could cause an equal antipathy in these
+penguins; since their ancestors had obviously lived on excellent terms
+with the Old Ones--an amicable relationship which must have survived in
+the abyss below as long as any of the Old Ones remained.
+
+Regretting--in a flare-up of the old spirit of pure science--that we
+could not photograph these anomalous creatures, we shortly left them
+to their squawking and pushed on toward the abyss whose openness was
+now so positively proved to us, and whose exact direction occasional
+penguin tracks made clear.
+
+       *       *       *       *       *
+
+Not long afterward a steep descent in a long, low, doorless, and
+peculiarly sculptureless corridor led us to believe that we were
+approaching the tunnel mouth at last. We had passed two more penguins.
+
+Then the corridor ended in a prodigious open space which made us
+gasp involuntarily--a perfect inverted hemisphere, obviously deep
+underground, fully a hundred feet in diameter and fifty feet high, with
+low archways opening around all parts of the circumference but one, and
+that one yawning cavernously with a black, arched aperture which broke
+the symmetry of the vault to a height of nearly fifteen feet. It was
+the entrance to the great abyss.
+
+In this vast hemisphere, whose concave roof was impressively though
+decadently carved to a likeness of the primordial celestial dome, a few
+albino penguins waddled--aliens there, but indifferent and unseeing.
+The black tunnel yawned indefinitely off at a steep, descending grade,
+its aperture adorned with grotesquely chiseled jambs and lintel.
+
+From that cryptical mouth we fancied a current of slightly warmer air
+and perhaps even a suspicion of vapor proceeded; and we wondered what
+living entities other than penguins the limitless void below, and the
+contiguous honeycombings of the land and the titan mountains, might
+conceal.
+
+We wondered, too, whether the trace of mountaintop smoke at first
+suspected by poor Lake, as well as the odd haze we had ourselves
+perceived around the rampart-crowned peak, might not be caused by
+the tortuous-channeled rising of some such vapor from the unfathomed
+regions of earth's core.
+
+Entering the tunnel, we saw that its outline was--at least at the
+start--about fifteen feet each way--sides, floor, and arched roof
+composed of the usual megalithic masonry. The sides were sparsely
+decorated with cartouches of conventional designs in a later, decadent
+style; and all the construction and carving were marvellously
+well-preserved.
+
+The floor was quite clear, except for a slight detritus bearing
+outgoing penguin tracks and the inward tracks of those others. The
+farther one advanced, the warmer it became; so that we were soon
+unbuttoning our heavy garments. We wondered whether there were any
+actually igneous manifestations below, and whether the waters of that
+sunless sea were hot.
+
+After a short distance the masonry gave place to solid rock, though
+the tunnel kept the same proportions and presented the same aspect of
+carved regularity. Occasionally its varying grade became so steep that
+grooves were cut in the floor.
+
+Several times we noted the mouths of small lateral galleries not
+recorded in our diagrams; none of them such as to complicate the
+problem of our return, and all of them welcome as possible refuges in
+case we met unwelcome entities on their way back from the abyss.
+
+The nameless scent of such things was very distinct. Doubtless it
+was suicidally foolish to venture into that tunnel under the known
+conditions, but the lure of the unplumbed is stronger in certain
+persons than most suspect--indeed, it was just such a lure which had
+brought us to this unearthly polar waste in the first place.
+
+We saw several penguins as we passed along, and speculated on the
+distance we would have to traverse. The carvings had led us to expect
+a steep downhill walk of about a mile to the abyss, but our previous
+wanderings had shown us that matters of scale were not wholly to be
+depended on.
+
+After about a quarter of a mile that nameless scent became greatly
+accentuated, and we kept very careful track of the various lateral
+openings we passed. There was no visible vapor as at the mouth, but
+this was doubtless due to the lack of contrasting cooler air. The
+temperature was rapidly ascending, and we were not surprised to come
+upon a careless heap of material shudderingly familiar to us. It was
+composed of furs and tent cloths taken from Lake's camp, and we did
+not pause to study the bizarre forms into which the fabrics had been
+slashed.
+
+Slightly beyond this point we noticed a decided increase in the size
+and number of the side galleries, and concluded that the densely
+honeycombed region beneath the higher foothills must now have been
+reached.
+
+The nameless scent was now curiously mixed with another and scarcely
+less offensive odor--of what nature we could not guess, though we
+thought of decaying organisms and perhaps unknown subterrane fungi.
+
+Then came a startling expansion of the tunnel for which the
+carvings had not prepared us--a broadening and rising into a lofty,
+natural-looking elliptical cavern with a level floor, some seventy-five
+feet long and fifty broad, and with many immense side passages leading
+away into cryptical darkness.
+
+       *       *       *       *       *
+
+Though this cavern was natural in appearance, an inspection with both
+torches suggested that it had been formed by the artificial destruction
+of several walls between adjacent honeycombings. The walls were
+rough, and the high, vaulted roof was thick with stalactites; but the
+solid rock floor had been smoothed off, and was free from all débris,
+detritus, or even dust to a positively abnormal extent.
+
+Except for the avenue through which we had come, this was true of
+the floors of all the great galleries opening off from it; and the
+singularity of the condition was such as to set us vainly puzzling.
+
+The curious new fetor which had supplemented the nameless scent was
+excessively pungent here; so much so that it destroyed all trace of the
+other. Something about this whole place, with its polished and almost
+glistening floor, struck us as more vaguely baffling and horrible than
+any of the monstrous things we have previously encountered.
+
+The regularity of the passage immediately ahead, prevented all
+confusion as to the right course amidst this plethora of equally great
+cave mouths. Nevertheless we resolved to resume our paper trail blazing
+if any further complexity should develop; for dust tracks, of course,
+could no longer be expected.
+
+Upon resuming our direct progress we cast a beam of torchlight over the
+tunnel walls--and stopped short in amazement at the supremely radical
+change which had come over the carvings in this part of the passage.
+We realized, of course, the great decadence of the Old Ones' sculpture
+at the time of the tunneling, and had indeed noticed the inferior
+workmanship of the arabesques in the stretches behind us.
+
+But now, in this deeper section beyond the cavern, there was a sudden
+difference wholly transcending explanation--a difference in basic
+nature as well as in mere quality, and involving so profound and
+calamitous a degradation of skill that nothing in the hitherto observed
+rate of decline could have led one to expect it.
+
+This new and degenerate work was coarse, bold, and wholly lacking in
+delicacy of detail. It was countersunk with exaggerated depth in bands
+following the same general line as the sparse cartouches of the earlier
+sections, but the height of the reliefs did not reach the level of the
+general surface.
+
+Danforth had the idea that it was a second carving--a sort of
+palimpsest formed after the obliteration of a previous design. In
+nature it was wholly decorative and conventional, and consisted of
+crude spirals and angles roughly following the quintile mathematical
+tradition of the Old Ones, yet seeming more like a parody than a
+perpetuation of that tradition.
+
+Since we could not afford to spend any considerable time in study, we
+resumed our advance after a cursory look.
+
+We saw and heard fewer penguins, but thought we caught a vague
+suspicion of an infinitely distant chorus of them somewhere deep within
+the earth. The new and inexplicable odor was abominably strong, and we
+could detect scarcely a sign of that other nameless scent.
+
+Puffs of visible vapor ahead bespoke increasing contrasts in
+temperature, and the relative nearness of the sunless sea cliffs of the
+great abyss. Then, quite unexpectedly, we saw certain obstructions on
+the polished floor ahead--obstructions which were quite definitely not
+penguins--and turned on our second torch after making sure that the
+objects were quite stationary.
+
+
+
+
+                                  XI.
+
+
+Still another time have I come to a place where it is very difficult
+to proceed. I ought to be hardened by this stage; but there are some
+experiences and intimations which scar too deeply to permit of healing,
+and leave only such added sensitiveness that memory re-inspired all the
+original horror.
+
+We saw, as I have said, certain obstructions on the polished
+floor ahead; and I may add that our nostrils were assailed almost
+simultaneously by a very curious intensification of the strange,
+prevailing fetor, now quite plainly mixed with the nameless stench of
+those others which had gone before us.
+
+The light of the second torch left no doubt of what the obstructions
+were, and we dared approach them only because we could see, even from
+a distance, that they were quite as past all harming power as had been
+the six similar specimens unearthed from the monstrous star-mounded
+graves at poor Lake's camp.
+
+They were, indeed, as lacking in completeness as most of those we
+had unearthed--though it grew plain from the thick, dark-green pool
+gathering around them that their incompleteness was of infinitely
+greater recency. There seemed to be only four of them, whereas Lake's
+bulletins would have suggested no less than eight as forming the
+group which had preceded us. To find them in this state was wholly
+unexpected, and we wondered what sort of monstrous struggle had
+occurred down here in the dark.
+
+Penguins, attacked in a body, retaliate savagely with their beaks; and
+our ears now made certain the existence of a rookery far beyond. Had
+those others disturbed such a place and aroused murderous pursuit? The
+obstructions did not suggest it, for penguin beaks against the tough
+tissues Lake had dissected could hardly account for the terrible damage
+our approaching glance was beginning to make out. Besides, the huge
+blind birds we had seen appeared to be singularly peaceful.
+
+Had there, then, been a struggle among those others, and were the
+absent four responsible? If so, where were they? Were they close at
+hand and likely to form an immediate menace to us? We glanced anxiously
+at some of the smooth-floored lateral passages as we continued our slow
+and frankly reluctant approach.
+
+Whatever the conflict was, it had clearly been that which had
+frightened the penguins into their unaccustomed wandering. It must,
+then, have arisen near that faintly heard rookery in the incalculable
+gulf beyond, since there were no signs that any birds had normally
+dwelt here.
+
+Perhaps, we reflected, there had been a hideous running fight, with
+the weaker party seeking to get back to the cached sledges when their
+pursuers finished them. One could picture the demonic fray between
+namelessly monstrous entities as it surged out of the black abyss with
+great clouds of frantic penguins squawking and scurrying ahead.
+
+I say that we approached those sprawling and incomplete obstructions
+slowly and reluctantly. Would to Heaven we had never approached them at
+all, but had run back at top speed out of that blasphemous tunnel with
+the greasily smooth floors and the degenerate murals aping and mocking
+the things they had superseded--run back, before we had seen what we
+did see, and before our minds were burned with something which will
+never let us breathe easily again!
+
+       *       *       *       *       *
+
+Both of our torches were turned on the prostrate objects, so that we
+soon realized the dominant factor in their incompleteness. Mauled,
+compressed, twisted, and ruptured as they were, their chief common
+injury was total decapitation.
+
+From each one the tentacled starfish head had been removed; and as
+we drew near we saw that the manner of removal looked more like some
+hellish tearing or suction than like any ordinary form of cleavage.
+
+Their noisome dark-green ichor formed a large, spreading pool; but its
+stench was half overshadowed by that newer and stranger stench, here
+more pungent than at any other point along our route.
+
+Only when we had come very close to the sprawling obstructions could we
+trace that second, unexplainable fetor to any immediate source--and the
+instant we did so Danforth, remembering certain very vivid sculptures
+of the Old Ones' history in the Permian Age one hundred and fifty
+million years ago, gave vent to a nerve-tortured cry which echoed
+hysterically through that vaulted and archaic passage with the evil,
+palimpsest carvings.
+
+I came only just short of echoing his cry myself; for I had seen those
+primal sculptures, too, and had shudderingly admired the way the
+nameless artist had suggested that hideous slime coating found on
+certain incomplete and prostrate Old Ones--those whom the frightful
+Shoggoths had characteristically slain and sucked to a ghastly
+headlessness in the great war of resubjugation.
+
+They were infamous, nightmare sculptures even when telling of age-old,
+bygone things; for Shoggoths and their work ought not to be seen by
+human beings or portrayed by any beings.
+
+The mad author of the _Necronomicon_ had nervously tried to swear that
+none had been bred on this planet, and that only drugged dreamers
+had ever conceived them. Formless protoplasm able to mock and
+reflect all forms and organs and processes--viscous agglutinations
+of bubbling cells--rubbery fifteen-foot spheroids infinitely plastic
+and ductile--slaves of suggestion, builders of cities--more and more
+sullen, more and more intelligent, more and more amphibious, more and
+more imitative! Great Heaven! What madness made even those blasphemous
+Old Ones willing to use and to carve such things?
+
+And now, when Danforth and I saw the freshly glistening and
+reflectively iridescent black slime which clung thickly to those
+headless bodies and stank obscenely with that new, unknown odor whose
+cause only a diseased fancy could envisage--clung to those bodies
+and sparkled less voluminously on a smooth part of the accursedly
+resculptured wall in a series of grouped dots--we understood the
+quality of cosmic fear to its uttermost depths.
+
+It was not fear of those four missing others--for all too well did we
+suspect they would do no harm again. Poor devils! After all, they were
+not evil things of their kind. They were the men of another age and
+another order of being. Nature had played a hellish jest on them--as
+it will on any others that human madness, callousness, or cruelty may
+hereafter drag up in that hideously dead or sleeping polar waste--and
+this was their tragic homecoming.
+
+They had not been even savages--for what indeed had they done? That
+awful awakening in the cold of an unknown epoch--perhaps an attack by
+the furry, frantically barking quadrupeds, and a dazed defense against
+them and the equally frantic white simians with the queer wrappings and
+paraphernalia! Poor Lake. Poor Gedney. And poor Old Ones! Scientists
+to the last--what had they done that we would not have done in their
+place? Lord, what intelligence and persistence! What a facing of the
+incredible, just as those carven kinsmen and forbears had faced things
+only a little less incredible! Radiates, vegetables, monstrosities,
+star spawn--whatever they had been, they were men!
+
+       *       *       *       *       *
+
+They had crossed the icy peaks on whose templed slopes they had once
+worshiped and roamed among the tree ferns. They had found their dead
+city brooding under its curse, and had read its carven latter days as
+we had done. They had tried to reach their living fellows in fabled
+depths of blackness they had never seen--and what had they found?
+
+All this flashed in unison through the thoughts of Danforth and me as
+we looked from those headless, slime-coated shapes to the loathsome
+palimpsest sculptures and the diabolical dot groups of fresh slime on
+the wall beside them--looked and understood what must have triumphed
+and survived down there in the Cyclopean water city of that nighted,
+penguin-fringed abyss, whence even now a sinister curling mist had
+begun to belch pallidly as if in answer to Danforth's hysterical scream.
+
+The shock of recognizing that monstrous slime and headlessness had
+frozen us into mute, motionless statues, and it is only through later
+conversations that we have learned of the complete identity of our
+thoughts at that moment.
+
+It seemed æons that we stood there, but actually it could not have been
+more than ten or fifteen seconds. That hateful, pallid mist curled
+forward as if veritably driven by some remoter advancing bulk--and then
+came a sound which upset much of what we had just decided, and in so
+doing broke the spell and enabled us to run like mad past squawking,
+confused penguins over our former trail back to the city, along
+ice-sunken megalithic corridors to the great open circle, and up that
+archaic spiral ramp in a frenzied, automatic plunge for the sane outer
+air and light of day.
+
+[Illustration: _And then came a sound--a horrible sound--which enabled
+us to run like mad for the sane outer air_----]
+
+The new sound, as I have intimated, upset much that we had decided;
+because it was what poor Lake's dissection had led us to attribute
+to those we had just judged dead. It was, Danforth later told me,
+precisely what he had caught in infinitely muffled form when at that
+spot beyond the alley corner above the glacial level; and it certainly
+had a shocking resemblance to the wind pipings we had both heard around
+the lofty mountain caves.
+
+At the risk of seeming puerile I will add another thing, too, if
+only because of the surprising way Danforth's impression chimed with
+mine. Of course, common reading is what prepared us both to make the
+interpretation, though Danforth has hinted at queer notions about
+unsuspected and forbidden sources to which Poe may have had access when
+writing his "Arthur Gordon Pym" a century ago.
+
+It will be remembered that in that fantastic tale there is a word of
+unknown but terrible and prodigious significance connected with the
+antarctic and screamed eternally by the gigantic, spectrally snowy
+birds of that malign region's core. "_Tekeli-li! Tekeli-li!_" That, I
+may admit, is exactly what we thought we heard conveyed by that sudden
+sound behind the advancing white mist--that insidious, musical piping
+over a singularly wide range.
+
+       *       *       *       *       *
+
+We were in full flight before three notes or syllables had been
+uttered, though we knew that the swiftness of the Old Ones would enable
+any scream-roused and pursuing survivor of the slaughter to overtake us
+in a moment if it really wished to do so.
+
+We had a vague hope, however, that nonaggressive conduct and a display
+of kindred reason might cause such a being to spare us in case of
+capture, if only from scientific curiosity.
+
+After all, if such a one had nothing to fear for itself it would have
+no motive in harming us. Concealment being futile at this juncture, we
+used our torch for a running glance behind, and perceived that the mist
+was thinning. Would we see at last, a complete and living specimen of
+those others? Again came that insidious musical piping--"_Tekeli-li!
+Tekeli-li!_"
+
+Then, noting that we were actually gaining on our pursuer, it occurred
+to us that the entity might be wounded. We could take no chances,
+however, since it was very obviously approaching in answer to
+Danforth's scream, rather than in flight from any other entity. The
+timing was too close to admit of doubt.
+
+Of the whereabouts of that less conceivable and less mentionable
+nightmare--that fetid, unglimpsed mountain of slime-spewing protoplasm
+whose race had conquered the abyss and sent land pioneers to recarve
+and squirm through the burrows of the hills--we could form no guess;
+and it cost us a genuine pang to leave this probably crippled Old
+One--perhaps a lone survivor--to the peril of recapture and a nameless
+fate.
+
+Thank Heaven we did not slacken our run. The curling mist had thickened
+again, and was driving ahead with increased speed; whilst the straying
+penguins in our rear were squawking and screaming and displaying
+signs of a panic really surprising in view of their relatively minor
+confusion when we had passed them.
+
+Once more came that sinister, wide-ranged piping--"_Tekeli-li!
+Tekeli-li!_" We had been wrong. The thing was not wounded, but had
+merely paused on encountering the bodies of its fallen kindred and the
+hellish slime inscription above them. We could never know what that
+demon message was--but those burials at Lake's camp had shown how much
+importance the beings attached to their dead.
+
+Our recklessly used torch now revealed ahead of us the large open
+cavern where various ways converged, and we were glad to be leaving
+those morbid palimpsest sculptures--almost felt even when scarcely
+seen--behind.
+
+Another thought which the advent of the cave inspired was the
+possibility of losing our pursuer at this bewildering focus of large
+galleries. There were several of the blind albino penguins in the open
+space, and it seemed clear that their fear of the oncoming entity was
+extreme to the point of unaccountability.
+
+If at that point we dimmed our torch to the very lowest limit of
+traveling need, keeping it strictly in front of us, the frightened
+squawking motions of the huge birds in the mist might muffle our
+footfalls, screen our true course, and somehow set up a false lead.
+
+Amidst the churning, spiraling fog, the littered and unglistening floor
+of the main tunnel beyond this point, as differing from the other
+morbidly polished burrows, could hardly form a highly distinguishing
+feature; even, so far as we could conjecture, for those indicated
+special senses which made the Old Ones partly, though imperfectly,
+independent of light in emergencies.
+
+In fact, we were somewhat apprehensive lest we go astray ourselves
+in our haste. For we had, of course, decided to keep straight on
+toward the dead city; since the consequences of loss in those unknown
+foothill honeycombings would be unthinkable.
+
+The fact that we survived and emerged is sufficient proof that the
+thing did take a wrong gallery whilst we providentially hit on
+the right one. The penguins alone could not have saved us, but in
+conjunction with the mist they seem to have done so. Only a benign fate
+kept the curling vapors thick enough at the right moment, for they were
+constantly shifting and threatening to vanish.
+
+Indeed, they did lift for a second just before we emerged from the
+nauseously resculptured tunnel into the cave; so that we actually
+caught one first and only half glimpse of the oncoming entity as we
+cast a final, desperately fearful glance backward before dimming the
+torch and mixing with the penguins in the hope of dodging pursuit. If
+the fate which screened us was benign, that which gave us the half
+glimpse was infinitely the opposite; for to that flash of semivision
+can be traced a full half of the horror which has ever since haunted us.
+
+       *       *       *       *       *
+
+Our exact motive in looking back again was perhaps no more than the
+immemorial instinct of the pursued to gauge the nature and course
+of its pursuer; or perhaps it was an automatic attempt to answer a
+subconscious question raised by one of our senses.
+
+In the midst of our flight, with all our faculties centered on the
+problem of escape, we were in no condition to observe and analyze
+details; yet even so our latent brain cells must have wondered at the
+message brought them by our nostrils. Afterward, we realized what it
+was--that our retreat from the fetid slime coating on those headless
+obstructions, and the coincident approach of the pursuing entity, had
+not brought us the exchange of stenches which logic called for.
+
+In the neighborhood of the prostrate things that new and lately
+unexplainable fetor had been wholly dominant; but by this time it ought
+to have largely given place to the nameless stench associated with
+those others. This it had not done--for instead, the newer and less
+bearable smell was now virtually undiluted, and growing more and more
+poisonously insistent each second.
+
+So we glanced back--simultaneously, it would appear; though no doubt
+the incipient motion of one prompted the imitation of the other. As
+we did so we flashed both torches full strength at the momentarily
+thinned mist; either from sheer primitive anxiety to see all we could,
+or in a less primitive but equally unconscious effort to dazzle the
+entity before we dimmed our light and dodged among the penguins of the
+labyrinth center ahead.
+
+Unhappy act! Not Orpheus himself, or Lot's wife, paid much more dearly
+for a backward glance. And again came that shocking, wide-ranged
+piping--"_Tekeli-li! Tekeli-li!_"
+
+Danforth was totally unstrung, and the first thing I remember of the
+rest of the journey was hearing him light-headedly chant a hysterical
+formula in which I alone of mankind could have found anything but
+insane irrelevance. It reverberated in falsetto echoes among the
+squawks of the penguins; reverberated through the vaulting ahead,
+and--thank Heaven--through the now empty vaultings behind. He could not
+have begun it at once--else we would not have been alive and blindly
+racing. I shudder to think of what a shade of difference in his nervous
+reactions might have brought.
+
+"South Station Under--Washington Under--Park Street
+Under--Kendall--Central--Harvard----" The poor fellow was chanting the
+familiar stations of the Boston-Cambridge tunnel that burrowed through
+our peaceful native soil thousands of miles away in New England, yet to
+me the ritual had neither irrelevance nor home feeling. It had only
+horror, because I knew unerringly the monstrous, nefandous analogy that
+had suggested it.
+
+We had expected, upon looking back, to see a terrible and incredible
+moving entity if the mists were thin enough; but of that entity we had
+formed a clear idea. What we did see--for the mists were indeed all too
+malignly thinned--was something altogether different, and immeasurably
+more hideous and detestable. It was the utter, objective embodiment of
+the fantastic novelist's 'thing that should not be'; and its nearest
+comprehensible analogue is a vast, onrushing subway train as one sees
+it from a station platform--the great black front looming colossally
+out of infinite subterraneous distance, constellated with strangely
+colored lights and filling the prodigious burrow.
+
+But we were not on a station platform. We were on the track ahead as
+the nightmare, plastic column of fetid black iridescence oozed tightly
+onward through its fifteen-foot sinus, gathering unholy speed and
+driving before it a spiral, rethickening cloud of the pallid abyss
+vapor.
+
+It was a terrible, indescribable thing, vaster than any subway train--a
+shapeless congeries of protoplasmic bubbles, faintly self-luminous, and
+with myriads of temporary eyes forming and unforming as pustules of
+greenish light all over the tunnel-filling front that bore down upon
+us, crushing the frantic penguins and slithering over the glistening
+floor that it and its kind had swept so evilly free of all litter.
+
+Still came that eldritch, mocking cry--"_Tekeli-li! Tekeli-li!_" And at
+last we remembered that the demonic Shoggoths--given life, though, and
+plastic organ patterns solely by the Old Ones, and having no language
+save that which the dot groups expressed--had likewise no voice save
+the imitated accents of their bygone masters.
+
+
+
+
+                                 XII.
+
+
+Danforth and I have recollections of emerging into the great sculptured
+hemisphere and of threading our back trail through the Cyclopean rooms
+and corridors of the dead city; yet these are purely dream fragments
+involving no memory of volition, details, or physical exertion.
+
+There was something vaguely appropriate about our departure from those
+buried epochs; for as we wound our panting way up the sixty-foot
+cylinder of primal masonry we glimpsed beside us a continuous
+procession of heroic sculptures in the dead race's early and undecayed
+technique--a farewell from the Old Ones, written fifty million years
+ago.
+
+Finally, scrambling out at the top, we found ourselves on a great mound
+of tumbled blocks, with the curved walls of higher stonework rising
+westward, and the brooding peaks of the great mountains showing beyond
+the more crumbled structures toward the east.
+
+The sky above was a churning and opalescent mass of tenuous ice vapors,
+and the cold clutched at our vitals.
+
+In less than a quarter of an hour we had found the steep grade to the
+foothills--the probable ancient terrace--by which we had descended, and
+could see the dark bulk of our great plane amidst the sparse ruins on
+the rising slope ahead.
+
+Halfway uphill toward our goal we paused for a momentary breathing
+spell, and turned to look again at the fantastic tangle of incredible
+stone shapes below us--once more outlined mystically against an unknown
+west. As we did so we saw that the sky beyond had lost its morning
+haziness; the restless ice vapors having moved up to the zenith, where
+their mocking outlines seemed on the point of settling into some
+bizarre pattern which they feared to make quite definite or conclusive.
+
+       *       *       *       *       *
+
+There now lay revealed on the ultimate white horizon behind
+the grotesque city a dim, elfin line of pinnacled violet whose
+needle-pointed heights loomed dreamlike against the beckoning rose
+color of the western sky. Up toward this shimmering rim sloped the
+ancient table-land, the depressed course of the bygone river traversing
+it as an irregular ribbon of shadow.
+
+For a second we gasped in admiration of the scene's unearthly cosmic
+beauty, and then vague horror began to creep into our souls. For this
+far violet line could be nothing else than the terrible mountains of
+the forbidden land--highest of earth's peaks and focus of earth's evil;
+harborers of nameless horrors and Archæan secrets; shunned and prayed
+to by those who feared to carve their meaning; untrodden by any living
+thing of earth, but visited by the sinister lightnings and sending
+strange beams across the plains in the polar night.
+
+If the sculptured maps and pictures in that prehuman city had told
+truly, these cryptic violet mountains could not be much less than three
+hundred miles away; yet none the less sharply did their dim elfin
+essence jut above that remote and snowy rim, like the serrated edge of
+a monstrous alien planet about to rise into unaccustomed heavens.
+
+Looking at them, I thought nervously of certain sculptured hints of
+what the great bygone river had washed down into the city from their
+accursed sloping--and wondered how much sense and how much folly had
+lain in the fears of those Old Ones who carved them so reticently.
+
+I recalled how their northerly end must come near the coast at Queen
+Mary Land, where even at that moment Sir Douglas Mawson's expedition
+was doubtless working less than a thousand miles away; and hoped that
+no evil fate would give Sir Douglas and his men a glimpse of what
+might lie beyond the protecting coastal range. Such thoughts formed a
+measure of my overwrought condition at the time--and Danforth seemed to
+be even worse.
+
+Yet before we had passed the great star-shaped ruin and reached our
+plane our fears had become transferred to the lesser, but vast enough,
+range whose re-crossing lay ahead of us.
+
+From these foothills the black, ruin-crusted slopes reared up starkly
+and hideously against the east, again reminding us of those strange
+Asian paintings of Nicholas Roerich; and when we thought of the
+damnable honeycombings inside them, and of the frightful amorphous
+entities that might have pushed their fetidly squirming sway even to
+the topmost hollow pinnacles, we could not face without panic the
+prospect of again sailing by those suggestive skyward cave mouths where
+the wind made sounds like an evil musical piping over a wide range.
+
+To make matters worse, we saw distinct traces of local mist around
+several of the summits--as poor Lake must have done when he made that
+early mistake about volcanism--and thought shiveringly of that kindred
+mist from which we had just escaped--of that, and of the blasphemous,
+horror-fostering abyss whence all such vapors came.
+
+       *       *       *       *       *
+
+All was well with the plane, and we clumsily hauled on our heavy flying
+furs. Danforth got the engine started without trouble, and we made a
+very smooth take-off over the nightmare city.
+
+At a very high level there must have been great disturbance, since the
+ice-dust clouds of the zenith were doing all sorts of fantastic things;
+but at twenty-four thousand feet, the height we needed for the pass, we
+found navigation quite practicable.
+
+As we drew close to the jutting peaks the wind's strange piping again
+became manifest, and I could see Danforth's hands trembling at the
+controls. Rank amateur though I was, I thought at that moment that I
+might be a better navigator than he in effecting the dangerous crossing
+between pinnacles; and when I made motions to change seats and take
+over his duties he did not protest.
+
+I tried to keep all my skill and self-possession about me, and stared
+at the sector of reddish farther sky betwixt the walls of the pass.
+
+But Danforth, released from his piloting and keyed up to a dangerous
+nervous pitch, could not keep quiet. I felt him turning and wriggling
+about as he looked back at the terrible receding city, ahead at the
+cave-riddled, cube-barnacled peaks, sidewise at the bleak sea of snowy,
+rampart-strown foothills, and upward at the seething, grotesquely
+clouded sky.
+
+It was then, just as I was trying to steer safely through the pass,
+that his mad shrieking brought us so close to disaster, by shattering
+my tight hold on myself and causing me to fumble helplessly with the
+controls for a moment. A second afterward my resolution triumphed and
+we made the crossing safely----Yet I am afraid that Danforth will never
+be the same again.
+
+I have said that Danforth refused to tell me what final horror made him
+scream out so insanely--a horror which, I feel sadly sure, is mainly
+responsible for his present breakdown. We had snatches of shouted
+conversation above the wind's piping and the engine's buzzing as we
+reached the safe side of the range and swooped slowly down toward the
+camp, but that had mostly to do with the pledges of secrecy we had made
+as we prepared to leave the nightmare city.
+
+       *       *       *       *       *
+
+All that Danforth has ever hinted is that the final horror was a
+mirage. It was not, he declares, anything connected with the cubes
+and caves of those echoing, vaporous, wormily honeycombed mountains
+of madness which we crossed; but a single fantastic, demonic glimpse,
+among the churning westward zenith clouds, of what lay back of those
+other violet westward mountains which the Old Ones had shunned and
+feared.
+
+He has on rare occasions whispered disjointed and irresponsible things
+about "the black pit," "the carven rim," "the proto-Shoggoths," "the
+windowless solids with five dimensions," "the nameless cylinders," "the
+elder pharos," "Yog-Sothoth," "the primal white jelly," "the color out
+of space," "the wings," "the eyes in darkness," "the moon-ladder," "the
+original, the eternal, the undying," and other bizarre conceptions;
+but when he is fully himself he repudiates all this and attributes it
+to his curious and macabre reading of earlier years. Danforth, indeed,
+is known to be among the few who have ever dared go completely through
+that worm-riddled copy of the _Necronomicon_ kept under lock and key in
+the college library.
+
+The higher sky, as we crossed the range, was surely vaporous and
+disturbed enough; and although I did not see the zenith I can well
+imagine that its swirls of ice dust may have taken strange forms.
+Imagination, knowing how vividly distant scenes can sometimes be
+reflected, refracted, and magnified by such layers of restless cloud,
+might easily have supplied the rest--and, of course, Danforth did not
+hint any of these specific horrors till after his memory had had a
+chance to draw on his bygone reading. He could never have seen so much
+in one instantaneous glance.
+
+At the time, his shrieks were confined to the repetition of a single,
+mad word of all too obvious source: "_Tekeli-li! Tekeli-li!_"
+
+
+                                THE END

--- a/corpora/originals/colourOG.txt
+++ b/corpora/originals/colourOG.txt
@@ -1,0 +1,1515 @@
+﻿The Project Gutenberg eBook of The colour out of space
+    
+This ebook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this ebook or online
+at www.gutenberg.org. If you are not located in the United States,
+you will have to check the laws of the country where you are located
+before using this eBook.
+
+Title: The colour out of space
+
+Author: H. P. Lovecraft
+
+Illustrator: J. M. de Aragon
+
+Release date: June 4, 2022 [eBook #68236]
+                Most recently updated: October 18, 2024
+
+Language: English
+
+Original publication: United States: Experimenter Publishing Company, 1927
+
+Credits: Greg Weeks, Mary Meehan and the Online Distributed Proofreading Team at http://www.pgdp.net
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK THE COLOUR OUT OF SPACE ***
+
+                        THE COLOUR OUT OF SPACE
+
+                          By H. P. Lovecraft
+
+           [Transcriber's Note: This etext was produced from
+                    Amazing Stories September 1927.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+            _Here is a totally different story that we can
+           highly recommend to you. We could wax rhapsodical
+           in our praise, as the story is one of the finest
+         pieces of literature it has been our good fortune to
+            read. The theme is original, and yet fantastic
+            enough to make it rise head and shoulders above
+          many contemporary scientifiction stories. You will
+             not regret having read this marvellous tale._
+
+
+West of Arkham the hills rise wild, and there are valleys with deep
+woods that no axe has ever cut. There are dark narrow glens where the
+trees slope fantastically, and where thin brooklets trickle without
+ever having caught the glint of sunlight. On the gentler slopes there
+are farms, ancient and rocky, with squat, moss-coated cottages brooding
+eternally over old New England secrets in the lee of great ledges; but
+these are all vacant now, the wide chimneys crumbling and the shingled
+sides bulging perilously beneath low gambrel roofs.
+
+The old folk have gone away, and foreigners do not like to live there.
+French-Canadians have tried it, Italians have tried it, and the Poles
+have come and departed. It is not because of anything that can be seen
+or heard or handled, but because of something that is imagined. The
+place is not good for imagination, and does not bring restful dreams at
+night. It must be this which keeps the foreigners away, for old Ammi
+Pierce has never told them of anything he recalls from the strange
+days. Ammi, whose head has been a little queer for years, is the only
+one who still remains, or who ever talks of the strange days; and he
+dares to do this because his house is so near the open fields and the
+travelled roads around Arkham.
+
+There was once a road over the hills and through the valleys, that ran
+straight where the blasted heath is now; but people ceased to use it
+and a new road was laid curving far toward the south. Traces of the
+old one can still be found amidst the weeds of a returning wilderness,
+and some of them will doubtless linger even when half the hollows are
+flooded for the new reservoir. Then the dark woods will be cut down and
+the blasted heath will slumber far below blue waters whose surface will
+mirror the sky and ripple in the sun. And the secrets of the strange
+days will be one with the deep's secrets; one with the hidden lore of
+old ocean, and all the mystery of primal earth.
+
+When I went into the hills and vales to survey for the new reservoir
+they told me the place was evil. They told me this in Arkham, and
+because that is a very old town full of witch legends I thought the
+evil must be something which grandmas had whispered to children
+through centuries. The name "blasted heath" seemed to me very odd
+and theatrical, and I wondered how it had come into the folklore of
+a Puritan people. Then I saw that dark westward tangle of glens and
+slopes for myself, and ceased to wonder at anything besides its own
+elder mystery. It was morning when I saw it, but shadow lurked always
+there. The trees grew too thickly, and their trunks were too big for
+any healthy New England wood. There was too much silence in the dim
+alleys between them, and the floor was too soft with the dank moss and
+mattings of infinite years of decay.
+
+In the open spaces, mostly along the line of the old road, there were
+little hillside farms; sometimes with all the buildings standing,
+sometimes with only one or two, and sometimes with only a lone chimney
+or fast-filling cellar. Weeds and briers reigned, and furtive wild
+things rustled in the undergrowth. Upon everything was a haze of
+restlessness and oppression; a touch of the unreal and the grotesque,
+as if some vital element of perspective or chiaroscuro were awry. I did
+not wonder that the foreigners would not stay, for this was no region
+to sleep in. It was too much like a landscape of Salvator Rosa; too
+much like some forbidden woodcut in a tale of terror.
+
+But even all this was not so bad as the blasted heath. I knew it the
+moment I came upon it at the bottom of a spacious valley; for no other
+name could fit such thing, or any other thing fit such a name. It
+was as if the poet had coined the phrase from having seen this one
+particular region. It must, I thought as I viewed it, be the outcome
+of a fire; but why had nothing new ever grown over those five acres of
+grey desolation that sprawled open to the sky like a great spot eaten
+by acid in the woods and fields? It lay largely to the north of the
+ancient road line, but encroached a little on the other side. I felt
+an odd reluctance about approaching, and did so at last only because
+my business took me through and past it. There was no vegetation of
+any kind on that broad expanse, but only a fine grey dust or ash which
+no wind seemed ever to blow about. The trees near it were sickly
+and stunted, and many dead trunks stood or lay rotting at the rim.
+As I walked hurriedly by I saw the tumbled bricks and stones of an
+old chimney and cellar on my right, and the yawning black maw of an
+abandoned well whose stagnant vapours played strange tricks with the
+hues of the sunlight. Even the long, dark woodland climb beyond seemed
+welcome in contrast, and I marvelled no more at the frightened whispers
+of Arkham people. There had been no house or ruin near; even in the
+old days the place must have been lonely and remote. And at twilight,
+dreading to repass that ominous spot, I walked circuitously back to the
+town by the curving road on the south. I vaguely wished some clouds
+would gather, for an odd timidity about the deep skyey voids above had
+crept into my soul.
+
+In the evening I asked old people in Arkham about the blasted heath,
+and what was meant by that phrase "strange days" which so many
+evasively muttered. I could not, however, get any good answers, except
+that all the mystery was much more recent than I had dreamed. It was
+not a matter of old legendry at all, but something within the lifetime
+of those who spoke. It had happened in the 'eighties, and a family had
+disappeared or was killed. Speakers would not be exact; and because
+they all told me to pay no attention to old Ammi Pierce's crazy tales,
+I sought him out the next morning, having heard that he lived alone in
+the ancient tottering cottage where the trees first begin to get very
+thick. It was a fearsomely ancient place, and had begun to exude the
+faint miasmal odour which clings about houses that have stood too long.
+Only with persistent knocking could I rouse the aged man, and when he
+shuffled timidly to the door I could tell he was not glad to see me. He
+was not so feeble as I had expected; but his eyes drooped in a curious
+way, and his unkempt clothing and white beard made him seem very worn
+and dismal.
+
+Not knowing just how he could best be launched on his tales, I feigned
+a matter of business; told him of my surveying, and asked vague
+questions about the district. He was far brighter and more educated
+than I had been led to think, and before I knew it had grasped quite
+as much of the subject as any man I had talked with in Arkham. He was
+not like other rustics I had known in the sections where reservoirs
+were to be. From him there were no protests at the miles of old wood
+and farmland to be blotted out, though perhaps there would have been
+had not his home lain outside the bounds of the future lake. Relief
+was all that he showed; relief at the doom of the dark ancient valleys
+through which he had roamed all his life. They were better under water
+now--better under water since the strange days. And with this opening
+his husky voice sank low, while his body leaned forward and his right
+forefinger began to point shakily and impressively.
+
+       *       *       *       *       *
+
+It was then that I heard the story, and as the rambling voice scraped
+and whispered on I shivered again and again despite the summer day.
+Often I had to recall the speaker from ramblings, piece out scientific
+points which he knew only by a fading parrot memory of professors'
+talk, or bridge over gaps, where his sense of logic and continuity
+broke down. When he was done I did not wonder that his mind had snapped
+a trifle, or that the folk of Arkham would not speak much of the
+blasted heath. I hurried back before sunset to my hotel, unwilling to
+have the stars come out above me in the open; and the next day returned
+to Boston to give up my position. I could not go into that dim chaos
+of old forest and slope again, or face another time that grey blasted
+heath where the black well yawned deep beside the tumbled bricks and
+stones. The reservoir will soon be built now, and all those elder
+secrets will lie safe forever under watery fathoms. But even then I do
+not believe I would like to visit that country by night--at least not
+when the sinister stars are out; and nothing could bribe me to drink
+the new city water of Arkham.
+
+It all began, old Ammi said, with the meteorite. Before that time there
+had been no wild legends at all since the witch trials, and even then
+these western woods were not feared half so much as the small island
+in the Miskatonic where the devil held court beside a curious stone
+altar older than the Indians. These were not haunted woods, and their
+fantastic dusk was never terrible till the strange days. Then there
+had come that white noontide cloud, that string of explosions in the
+air, and that pillar of smoke from the valley far in the wood. And by
+night all Arkham had heard of the great rock that fell out of the sky
+and bedded itself in the ground beside the well at the Nahum Gardner
+place. That was the house which had stood where the blasted heath was
+to come--the trim white Nahum Gardner house amidst its fertile gardens
+and orchards.
+
+Nahum had come to town to tell people about the stone, and had dropped
+in at Ammi Pierce's on the way. Ammi was forty then, and all the queer
+things were fixed very strongly in his mind. He and his wife had gone
+with the three professors from Miskatonic University who hastened out
+the next morning to see the weird visitor from unknown stellar space,
+and had wondered why Nahum had called it so large the day before. It
+had shrunk, Nahum said as he pointed out the big brownish mound above
+the ripped earth and charred grass near the archaic well-sweep in his
+front yard; but the wise men answered that stones do not shrink. Its
+heat lingered persistently, and Nahum declared it had glowed faintly in
+the night. The professors tried it with a geologist's hammer and found
+it was oddly soft. It was, in truth, so soft as to be almost plastic;
+and they gouged rather than chipped a specimen to take back to the
+college for testing. They took it in an old pail borrowed from Nahum's
+kitchen, for even the small piece refused to grow cool. On the trip
+back they stopped at Ammi's to rest, and seemed thoughtful when Mrs.
+Pierce remarked that the fragment was growing smaller and burning the
+bottom of the pail. Truly, it was not large, but perhaps they had taken
+less than they thought.
+
+The day after that--all this was in June of '82--the professors had
+trooped out again in a great excitement. As they passed Ammi's they
+told him what queer things the specimen had done, and how it had
+faded wholly away when they put it in a glass beaker. The beaker had
+gone, too, and the wise men talked of the strange stone's affinity
+for silicon. It had acted quite unbelievably in that well-ordered
+laboratory; doing nothing at all and showing no occluded gases when
+heated on charcoal, being wholly negative in the borax bead, and soon
+proving itself absolutely non-volatile at any producible temperature,
+including that of the oxy-hydrogen blowpipe. On an anvil it appeared
+highly malleable, and in the dark its luminosity was very marked.
+Stubbornly refusing to grow cool, it soon had the college in a state
+of real excitement; and when upon heating before the spectroscope it
+displayed shining bands unlike any known colours of the normal spectrum
+there was much breathless talk of new elements, bizarre optical
+properties, and other things which puzzled men of science are wont to
+say when faced by the unknown.
+
+Hot as it was, they tested it in a crucible with all the proper
+reagents. Water did nothing. Hydrochloric acid was the same. Nitric
+acid and even aqua regia merely hissed and spattered against its torrid
+invulnerability. Ammi had difficulty in recalling all these things, but
+recognized some solvents as I mentioned them in the usual order of use.
+There were ammonia and caustic soda, alcohol and ether, nauseous carbon
+disulphide and a dozen others; but although the weight grew steadily
+less as time passed, and the fragment seemed to be slightly cooling,
+there was no change in the solvents to show that they had attacked
+the substance at all. It was a metal, though, beyond a doubt. It was
+magnetic, for one thing; and after its immersion in the acid solvents
+there seemed to be faint traces of the WidmÃ¤nstÃ¤tten figures found
+on meteoric iron. When the cooling had grown very considerable, the
+testing was carried on in glass; and it was in a glass beaker that they
+left all the chips made of the original fragment during the work. The
+next morning both chips and beaker were gone without trace, and only a
+charred spot marked the place on the wooden shelf where they had been.
+
+All this the professors told Ammi as they paused at his door, and
+once more he went with them to see the stony messenger from the
+stars, though this time his wife did not accompany him. It had now
+most certainly shrunk, and even the sober professors could not doubt
+the truth of what they saw. All around the dwindling brown lump near
+the well was a vacant space, except where the earth had caved in;
+and whereas it had been a good seven feet across the day before, it
+was now scarcely five. It was still hot, and the sages studied its
+surface curiously as they detached another and larger piece with hammer
+and chisel. They gouged deeply this time, and as they pried away
+the smaller mass they saw that the core of the thing was not quite
+homogeneous.
+
+       *       *       *       *       *
+
+They had uncovered what seemed to be the side of a large coloured
+globule embedded in the substance. The colour, which resembled some
+of the bands in the meteor's strange spectrum, was almost impossible
+to describe; and it was only by analogy that they called it colour at
+all. Its texture was glossy, and upon tapping it appeared to promise
+both brittleness and hollowness. One of the professors gave it a smart
+blow with a hammer, and it burst with a nervous little pop. Nothing was
+emitted, and all trace of the thing vanished with the puncturing. It
+left behind a hollow spherical space about three inches across, and all
+thought it probable that others would be discovered as the enclosing
+substance wasted away.
+
+Conjecture was vain; so after a futile attempt to find additional
+globules by drilling, the seekers left again with their new
+specimen--which proved, however, as baffling in the laboratory as
+its predecessor. Aside from being almost plastic, having heat,
+magnetism, and slight luminosity, cooling slightly in powerful acids,
+possessing an unknown spectrum, wasting away in air, and attacking
+silicon compounds with mutual destruction as a result, it presented
+no identifying features whatsoever; and at the end of the tests the
+college scientists were forced to own that they could not place it. It
+was nothing of this earth, but a piece of the great outside; and as
+such dowered with outside properties and obedient to outside laws.
+
+That night there was a thunderstorm, and when the professors went out
+to Nahum's the next day they met with a bitter disappointment. The
+stone, magnetic as it had been, must have had some peculiar electrical
+property; for it had "drawn the lightning," as Nahum said, with a
+singular persistence. Six times within an hour the farmer saw the
+lightning strike the furrow in the front yard, and when the storm was
+over nothing remained but a ragged pit by the ancient well-sweep,
+half-chocked with caved-in earth. Digging had borne no fruit, and the
+scientists verified the fact of the utter vanishment. The failure was
+total; so that nothing was left to do but go back to the laboratory and
+test again the disappearing fragment left carefully cased in lead. That
+fragment lasted a week, at the end of which nothing of value had been
+learned of it. When it had gone, no residue was left behind, and in
+time the professors felt scarcely sure they had indeed seen with waking
+eyes that cryptic vestige of the fathomless gulfs outside; that lone,
+weird message from other universes and other realms of matter, force,
+and entity.
+
+As was natural, the Arkham papers made much of the incident with its
+collegiate sponsoring, and sent reporters to talk with Nahum Gardner
+and his family. At least one Boston daily also sent a scribe, and Nahum
+quickly became a kind of local celebrity. He was a lean, genial person
+of about fifty, living with his wife and three sons on the pleasant
+farmstead in the valley. He and Ammi exchanged visits frequently, as
+did their wives; and Ammi had nothing but praise for him after all
+these years. He seemed slightly proud of the notice his place had
+attracted, and talked often of the meteorite in the succeeding weeks.
+That July and August were hot; and Nahum worked hard at his haying in
+the ten-acre pasture across Chapman's Brook; his rattling wain wearing
+deep ruts in the shadowy lanes between. The labour tired him more than
+it had in other years, and he felt that age was beginning to tell on
+him.
+
+Then fell the time of fruit and harvest. The pears and apples slowly
+ripened, and Nahum vowed that his orchards were prospering as never
+before. The fruit was growing to phenomenal size and unwonted gloss,
+and in such abundance that extra barrels were ordered to handle the
+future crop. But with the ripening came sore disappointment, for of all
+that gorgeous array of specious lusciousness not one single jot was
+fit to eat. Into the fine flavour of the pears and apples had crept
+a stealthy bitterness and sickishness, so that even the smallest of
+bites induced a lasting disgust. It was the same with the melons and
+tomatoes, and Nahum sadly saw that his entire crop was lost. Quick to
+connect events, he declared that the meteorite had poisoned the soil,
+and thanked Heaven that most of the other crops were in the upland lot
+along the road.
+
+       *       *       *       *       *
+
+Winter came early, and was very cold. Ammi saw Nahum less often than
+usual, and observed that he had begun to look worried. The rest of his
+family too, seemed to have grown taciturn; and were far from steady
+in their churchgoing or their attendance at the various social events
+of the countryside. For this reserve or melancholy no cause could be
+found, though all the household confessed now and then to poorer health
+and a feeling of vague disquiet. Nahum himself gave the most definite
+statement of anyone when he said he was disturbed about certain
+footprints in the snow. They were the usual winter prints of red
+squirrels, white rabbits, and foxes, but the brooding farmer professed
+to see something not quite right about their nature and arrangement.
+He was never specific, but appeared to think that they were not as
+characteristic of the anatomy and habits of squirrels and rabbits and
+foxes as they ought to be. Ammi listened without interest to this talk
+until one night when he drove past Nahum's house in his sleigh on the
+way back from Clark's Corners. There had been a moon, and a rabbit had
+run across the road; and the leaps of that rabbit were longer than
+either Ammi or his horse liked. The latter, indeed, had almost run away
+when brought up by a firm rein. Thereafter Ammi gave Nahum's tales
+more respect, and wondered why the Gardner dogs seemed so cowed and
+quivering every morning. They had, it developed, nearly lost the spirit
+to bark.
+
+In February the McGregor boys from Meadow Hill were out shooting
+woodchucks, and not far from the Gardner place bagged a very peculiar
+specimen. The proportions of its body seemed slightly altered in a
+queer way impossible to describe, while its face had taken on an
+expression which no one ever saw in a woodchuck before. The boys were
+genuinely frightened, and threw the thing away at once, so that only
+their grotesque tales of it ever reached the people of the countryside.
+But the shying of horses near Nahum's house had now become an
+acknowledged thing, and all the basis for a cycle of whispered legend
+was fast taking form.
+
+People vowed that the snow melted faster around Nahum's than it did
+anywhere else, and early in March there was an awed discussion in
+Potter's general store at Clark's Corners. Stephen Rice had driven past
+Gardner's in the morning, and had noticed the skunk-cabbages coming
+up through the mud by the woods across the road. Never were things of
+such size seen before, and they held strange colours that could not
+be put into any words. Their shapes were monstrous, and the horse had
+snorted at an odour which struck Stephen as wholly unprecedented. That
+afternoon several persons drove past to see the abnormal growth, and
+all agreed that plants of that kind ought never to sprout in a healthy
+world. The bad fruit of the fall before was freely mentioned, and it
+went from mouth to mouth that there was poison in Nahum's ground. Of
+course it was the meteorite; and remembering how strange the men from
+the college had found that stone to be, several farmers spoke about the
+matter to them.
+
+One day they paid Nahum a visit; but having no love of wild tales and
+folklore were very conservative in what they inferred. The plants were
+certainly odd, but all skunk-cabbages are more or less odd in shape
+and hue. Perhaps some mineral element from the stone had entered the
+soil, but it would soon be washed away. And as for the footprints and
+frightened horses--of course this was mere country talk which such
+a phenomenon as the aerolite would be certain to start. There was
+really nothing for serious men to do in cases of wild gossip, for
+superstitious rustics will say and believe anything. And so all through
+the strange days the professors stayed away in contempt. Only one
+of them, when given two phials of dust for analysis in a police job
+over a year and a half later, recalled that the queer colour of that
+skunk-cabbage had been very like one of the anomalous bands of light
+shown by the meteor fragment in the college spectroscope, and like the
+brittle globule found imbedded in the stone from the abyss. The samples
+in this analysis case gave the same odd bands at first, though later
+they lost the property.
+
+The trees budded prematurely around Nahum's, and at night they swayed
+ominously in the wind. Nahum's second son Thaddeus, a lad of fifteen,
+swore that they swayed also when there was no wind; but even the
+gossips would not credit this. Certainly, however, restlessness was
+in the air. The entire Gardner family developed the habit of stealthy
+listening, though not for any sound which they could consciously
+name. The listening was, indeed, rather a product of moments when
+consciousness seemed half to slip away. Unfortunately such moments
+increased week by week, till it became common speech that "something
+was wrong with all Nahum's folks." When the early saxifrage came out it
+had another strange colour; not quite like that of the skunk-cabbage,
+but plainly related and equally unknown to anyone who saw it. Nahum
+took some blossoms to Arkham and showed them to the editor of the
+_Gazette_, but that dignitary did no more than write a humorous article
+about them, in which the dark fears of rustics were held up to polite
+ridicule. It was a mistake of Nahum's to tell a stolid city man about
+the way the great, overgrown mourning-cloak butterflies behaved in
+connection with these saxifrages.
+
+April brought a kind of madness to the country folk, and began that
+disuse of the road past Nahum's which led to its ultimate abandonment.
+It was next the vegetation. All the orchard trees blossomed forth in
+strange colours, and through the stony soil of the yard and adjacent
+pasturage there sprang up a bizarre growth which only a botanist could
+connect with the proper flora of the region. No sane wholesome colours
+were anywhere to be seen except in the green grass and leafage; but
+everywhere were those hectic and prismatic variants of some diseased,
+underlying primary tone without a place among the known tints of earth.
+The "Dutchman's breeches" became a thing of sinister menace, and the
+bloodroots grew insolent in their chromatic perversion. Ammi and the
+Gardners thought that most of the colours had a sort of haunting
+familiarity, and decided that they reminded one of the brittle globule
+in the meteor. Nahum ploughed and sowed the ten-acre pasture and the
+upland lot, but did nothing with the land around the house. He knew it
+would be of no use, and hoped that the summer's strange growths would
+draw all the poison from the soil. He was prepared for almost anything
+now, and had grown used to the sense of something near him waiting
+to be heard. The shunning of his house by neighbours told on him, of
+course; but it told on his wife more. The boys were better off, being
+at school each day; but they could not help being frightened by the
+gossip. Thaddeus, an especially sensitive youth, suffered the most.
+
+       *       *       *       *       *
+
+In May the insects came, and Nahum's place became a nightmare of
+buzzing and crawling. Most of the creatures seemed not quite usual in
+their aspects and motions, and their nocturnal habits contradicted all
+former experience. The Gardners took to watching at night--watching in
+all directions at random for something they could not tell what. It was
+then that they all owned that Thaddeus had been right about the trees.
+Mrs. Gardner was the next to see it from the window as she watched the
+swollen boughs of a maple against a moonlit sky. The boughs surely
+moved, and there was no wind. It must be the sap. Strangeness had come
+into everything growing now. Yet it was none of Nahum's family at all
+who made the next discovery. Familiarity had dulled them, and what they
+could not see was glimpsed by a timid windmill salesman from Bolton who
+drove by one night in ignorance of the country legends. What he told in
+Arkham was given a short paragraph in the _Gazette_; and it was there
+that all the farmers, Nahum included, saw it first. The night had been
+dark and the buggy-lamps faint, but around a farm in the valley which
+everyone knew from the account must be Nahum's, the darkness had been
+less thick. A dim though distinct luminosity seemed to inhere in all
+the vegetation, grass, leaves, and blossoms alike, while at one moment
+a detached piece of the phosphorescence appeared to stir furtively in
+the yard near the barn.
+
+The grass had so far seemed untouched, and the cows were freely
+pastured in the lot near the house, but toward the end of May the milk
+began to be bad. Then Nahum had the cows driven to the uplands, after
+which this trouble ceased. Not long after this the change in grass and
+leaves became apparent to the eye. All the verdure was going grey,
+and was developing a highly singular quality of brittleness. Ammi
+was now the only person who ever visited the place, and his visits
+were becoming fewer and fewer. When school closed the Gardners were
+virtually cut off from the world, and sometimes let Ammi do their
+errands in town. They were failing curiously both physically and
+mentally, and no one was surprised when the news of Mrs. Gardner's
+madness stole around.
+
+It happened in June, about the anniversary of the meteor's fall, and
+the poor woman screamed about things in the air which she could not
+describe. In her raving there was not a single specific noun, but
+only verbs and pronouns. Things moved and changed and fluttered, and
+ears tingled to impulses which were not wholly sounds. Something
+was taken away--she was being drained of something--something was
+fastening itself on her that ought not to be--someone must make it
+keep off--nothing was ever still in the night--the walls and windows
+shifted. Nahum did not send her to the county asylum, but let her
+wander about the house as long as she was harmless to herself and
+others. Even when her expression changed he did nothing. But when the
+boys grew afraid of her, and Thaddeus nearly fainted at the way she
+made faces at him, he decided to keep her locked in the attic. By July
+she had ceased to speak and crawled on all fours, and before that month
+was over Nahum got the mad notion that she was slightly luminous in the
+dark, as he now clearly saw was the case with the nearby vegetation.
+
+It was a little before this that the horses had stampeded. Something
+had aroused them in the night, and their neighing and kicking in their
+stalls had been terrible. There seemed virtually nothing to do to calm
+them, and when Nahum opened the stable door they all bolted out like
+frightened woodland deer. It took a week to track all four, and when
+found they were seen to be quite useless and unmanageable. Something
+had snapped in their brains, and each one had to be shot for its own
+good. Nahum borrowed a horse from Ammi for his haying, but found it
+would not approach the barn. It shied, balked, and whinnied, and in
+the end he could do nothing but drive it into the yard while the men
+used their own strength to get the heavy wagon near enough the hayloft
+for convenient pitching. And all the while the vegetation was turning
+grey and brittle. Even the flowers whose hues had been so strange
+were graying now, and the fruit was coming out grey and dwarfed and
+tasteless. The asters and goldenrod bloomed grey and distorted, and
+the roses and zinnias and hollyhocks in the front yard were such
+blasphemous-looking things that Nahum's oldest boy Zenas cut them down.
+The strangely puffed insects died about that time, even the bees that
+had left their hives and taken to the woods.
+
+By September all the vegetation was fast crumbling to a greyish
+powder, and Nahum feared that the trees would die before the poison
+was out of the soil. His wife now had spells of terrific screaming,
+and he and the boys were in a constant state of nervous tension.
+They shunned people now, and when school opened the boys did not go.
+But it was Ammi, on one of his rare visits, who first realized that
+the well water was no longer good. It had an evil taste that was not
+exactly fetid nor exactly salty, and Ammi advised his friend to dig
+another well on higher ground to use till the soil was good again.
+Nahum, however, ignored the warning, for he had by that time become
+calloused to strange and unpleasant things. He and the boys continued
+to use the tainted supply, drinking it as listlessly and mechanically
+as they ate their meagre and ill-cooked meals and did their thankless
+and monotonous chores through the aimless days. There was something of
+stolid resignation about them all, as if they walked half in another
+world between lines of nameless guards to a certain and familiar doom.
+
+Thaddeus went mad in September after a visit to the well. He had gone
+with a pail and had come back empty-handed, shrieking and waving his
+arms, and sometimes lapsing into an inane titter or a whisper about
+"the moving colours down there." Two in one family was pretty bad,
+but Nahum was very brave about it. He let the boy run about for a
+week until he began stumbling and hurting himself, and then he shut
+him in an attic room across the hall from his mother's. The way they
+screamed at each other from behind their locked doors was very
+terrible, especially to little Merwin, who fancied they talked in some
+terrible language that was not of earth. Merwin was getting frightfully
+imaginative, and his restlessness was worse after the shutting away of
+the brother who had been his greatest playmate.
+
+Almost at the same time the mortality among the livestock commenced.
+Poultry turned greyish and died very quickly, their meat being found
+dry and noisome upon cutting. Hogs grew inordinately fat, then suddenly
+began to undergo loathsome changes which no one could explain. Their
+meat was of course useless, and Nahum was at his wit's end. No rural
+veterinary would approach his place, and the city veterinary from
+Arkham was openly baffled. The swine began growing grey and brittle
+and falling to pieces before they died, and their eyes and muzzles
+developed singular alterations. It was very inexplicable, for they had
+never been fed from the tainted vegetation. Then something struck the
+cows. Certain areas or sometimes the whole body would be uncannily
+shrivelled or compressed, and atrocious collapses or disintegrations
+were common. In the last stages--and death was always the result--there
+would be a greying and turning brittle like that which beset the hogs.
+There could be no question of poison, for all the cases occurred in a
+locked and undisturbed barn. No bites of prowling things could have
+brought the virus, for what live beast of earth can pass through solid
+obstacles? It must be only natural disease--yet what disease could
+wreak such results was beyond any mind's guessing. When the harvest
+came there was not an animal surviving on the place, for the stock
+and poultry were dead and the dogs had run away. These dogs, three
+in number, had all vanished one night and were never heard of again.
+The five cats had left some time before, but their going was scarcely
+noticed since there now seemed to be no mice, and only Mrs. Gardner had
+made pets of the graceful felines.
+
+       *       *       *       *       *
+
+On the nineteenth of October Nahum staggered into Ammi's house with
+hideous news. The death had come to poor Thaddeus in his attic room,
+and it had come in a way which could not be told. Nahum had dug a grave
+in the railed family plot behind the farm, and had put therein what
+he found. There could have been nothing from outside, for the small
+barred window and locked door were intact; but it was much as it had
+been in the barn. Ammi and his wife consoled the stricken man as best
+they could, but shuddered as they did so. Stark terror seemed to cling
+round the Gardners and all they touched, and the very presence of one
+in the house was a breath from regions unnamed and unnameable. Ammi
+accompanied Nahum home with the greatest reluctance, and did what he
+might to calm the hysterical sobbing of little Merwin. Zenas needed no
+calming. He had come of late to do nothing but stare into space and
+obey what his father told him; and Ammi thought that his fate was very
+merciful. Now and then Merwin's screams were answered faintly from the
+attic, and in response to an inquiring look Nahum said that his wife
+was getting very feeble. When night approached, Ammi managed to get
+away; for not even friendship could make him stay in that spot when the
+faint glow of the vegetation began and the trees may or may not have
+swayed without wind. It was really lucky for Ammi that he was not more
+imaginative. Even as things were, his mind was bent ever so slightly;
+but had he been able to connect and reflect upon all the portents
+around him he must inevitably have turned a total maniac. In the
+twilight he hastened home, the screams of the mad woman and the nervous
+child ringing horrible in his ears.
+
+Three days later Nahum burst into Ammi's kitchen in the early morning,
+and in the absence of his host stammered out a desperate tale once
+more, while Mrs. Pierce listened in a clutching fright. It was little
+Merwin this time. He was gone. He had gone out late at night with a
+lantern and pail for water, and had never come back. He'd been going
+to pieces for days, and hardly knew what he was about. Screamed at
+everything. There had been a frantic shriek from the yard then, but
+before the father could get to the door the boy was gone. There was no
+glow from the lantern he had taken, and of the child himself no trace.
+At the time Nahum thought the lantern and pail were gone too; but when
+dawn came, and the man had plodded back from his all-night search of
+the woods and fields, he had found some very curious things near the
+well. There was a crushed and apparently somewhat melted mass of iron
+which had certainly been the lantern; while a bent pail and twisted
+iron hoops beside it, both half-fused, seemed to hint at the remnants
+of the pail. That was all. Nahum was past imagining, Mrs. Pierce was
+blank, and Ammi, when he had reached home and heard the tale, could
+give no guess. Merwin was gone, and there would be no use in telling
+the people around, who shunned all Gardners now. No use, either, in
+telling the city people at Arkham who laughed at everything. Thad was
+gone, and now Merwin was gone. Something was creeping and creeping and
+waiting to be seen and heard. Nahum would go soon, and he wanted Ammi
+to look after his wife and Zenas if they survived him. It must all be a
+judgment of some sort; though he could not fancy what for, since he had
+always walked uprightly in the Lord's ways so far as he knew.
+
+For over two weeks Ammi saw nothing of Nahum; and then, worried about
+what might have happened, he overcame his fears and paid the Gardner
+place a visit. There was no smoke from the great chimney, and for a
+moment the visitor was apprehensive of the worst. The aspect of the
+whole farm was shocking--greyish withered grass and leaves on the
+ground, vines falling in brittle wreckage from archaic walls and
+gables, and great bare trees clawing up at the grey November sky with
+a studied malevolence which Ammi could not but feel had come from some
+subtle change in the tilt of the branches. But Nahum was alive, after
+all. He was weak, and lying in a couch in the low-ceiled kitchen,
+but perfectly conscious and able to give simple orders to Zenas. The
+room was deadly cold; and as Ammi visibly shivered, the host shouted
+huskily to Zenas for more wood. Wood, indeed, was sorely needed; since
+the cavernous fireplace was unlit and empty, with a cloud of soot
+blowing about in the chill wind that came down the chimney. Presently
+Nahum asked him if the extra wood had made him any more comfortable,
+and then Ammi saw what had happened. The stoutest cord had broken at
+last, and the hapless farmer's mind was proof against more sorrow.
+
+Questioning tactfully, Ammi could get no clear data at all about the
+missing Zenas. "In the well--he lives in the well--" was all that the
+clouded father would say. Then there flashed across the visitor's mind
+a sudden thought of the mad wife, and he changed his line of inquiry.
+"Nabby? Why, here she is!" was the surprised response of poor Nahum,
+and Ammi soon saw that he must search for himself. Leaving the harmless
+babbler on the couch, he took the keys from their nail beside the door
+and climbed the creaking stairs to the attic. It was very close and
+noisome up there, and no sound could be heard from any direction. Of
+the four doors in sight, only one was locked, and on this he tried
+various keys on the ring he had taken. The third key proved the right
+one, and after some fumbling Ammi threw open the low white door.
+
+It was quite dark inside, for the window was small and half-obscured
+by the crude wooden bars; and Ammi could see nothing at all on the
+wide-planked floor. The stench was beyond enduring, and before
+proceeding further he had to retreat to another room and return
+with his lungs filled with breathable air. When he did enter he saw
+something dark in the corner, and upon seeing it more clearly he
+screamed outright. While he screamed he thought a momentary cloud
+eclipsed the window, and a second later he felt himself brushed as if
+by some hateful current of vapour. Strange colours danced before his
+eyes; and had not a present horror numbed him he would have thought of
+the globule in the meteor that the geologist's hammer had shattered,
+and of the morbid vegetation that had sprouted in the spring. As it
+was he thought only of the blasphemous monstrosity which confronted
+him, and which all too clearly had shared the nameless fate of young
+Thaddeus and the livestock. But the terrible thing about the horror was
+that it very slowly and perceptibly moved as it continued to crumble.
+
+       *       *       *       *       *
+
+Ammi would give me no added particulars of this scene, but the shape
+in the corners does not re-appear in his tale as a moving object.
+There are things which cannot be mentioned, and what is done in common
+humanity is sometimes cruelly judged by the law. I gathered that no
+moving thing was left in that attic room, and that to leave anything
+capable of motion there would have been a deed so monstrous as to damn
+any accountable being to eternal torment. Anyone but a stolid farmer
+would have fainted or gone mad, but Ammi walked conscious through that
+low doorway and locked the accursed secret behind him. There would be
+Nahum to deal with now; he must be fed and tended, and removed to some
+place where he could be cared for.
+
+Commencing his descent of the dark stairs, Ammi heard a thud below him.
+He even thought a scream had been suddenly choked off, and recalled
+nervously the clammy vapour which had brushed by him in that frightful
+room above. What presence had his cry and entry started up? Halted by
+some vague fear, he heard still further sounds below. Indubitably there
+was a sort of heavy dragging, and a most detestably sticky noise as
+of some fiendish and unclean species of suction. With an associative
+sense goaded to feverish heights, he thought unaccountably of what he
+had seen upstairs. Good God! What eldritch dream-world was this into
+which he had blundered? He dared move neither backward nor forward, but
+stood there trembling at the black curve of the boxed-in staircase.
+Every trifle of the scene burned itself into his brain. The sounds, the
+sense of dread expectancy, the darkness, the steepness of the narrow
+steps--and merciful Heaven!--the faint but unmistakable luminosity of
+all the woodwork in sight; steps, sides, exposed laths, and beams alike.
+
+Then there burst forth a frantic whinny from Ammi's horse outside,
+followed at once by a clatter which told of a frenzied runaway. In
+another moment horse and buggy had gone beyond earshot, leaving the
+frightened man on the dark stairs to guess what had sent them. But that
+was not all. There had been another sound out there. A sort of liquid
+splash--water--it must have been the well. He had left Hero untied
+near it, and a buggy-wheel must have brushed the coping and knocked in
+a stone. And still the pale phosphorescense glowed in that detestably
+ancient woodwork. God! how old the house was! Most of it built before
+1700.
+
+A feeble scratching on the floor downstairs now sounded distinctly, and
+Ammi's grip tightened on a heavy stick he had picked up in the attic
+for some purpose. Slowly nerving himself, he finished his descent and
+walked boldly toward the kitchen. But he did not complete the walk,
+because what he sought was no longer there. It had come to meet him,
+and it was still alive after a fashion. Whether it had crawled or
+whether it had been dragged by any external forces, Ammi could not
+say; but the death had been at it. Everything had happened in the last
+half-hour, but collapse, greying, and disintegration were already far
+advanced. There was a horrible brittleness, and dry fragments were
+scaling off. Ammi could not touch it, but looked horrifiedly into the
+distorted parody that had been a face. "What was it, Nahum--what
+was it?" He whispered, and the cleft, bulging lips were just able to
+crackle out a final answer.
+
+"Nothin' ... nothin' ... the colour ... it burns ... cold an' wet, but
+it burns ... it lived in the well.... I seen it ... a kind o' smoke ...
+jest like the flowers last spring ... the well shone at night.... Thad
+an' Merwin an' Zenas ... everything alive ... suckin' the life out of
+everything ... in that stone ... it must o' come in that stone ...
+pizened the whole place ... dun't know what it wants ... that round
+thing them men from the college dug outen the stone ... they smashed
+it ... it was that same colour ... jest the same, like the flowers an'
+plants ... must a' ben more of 'em ... seeds ... seeds ... they
+growed ... I seen it the fust time this week ... must a' got strong
+on Zenas ... he was a big boy, full o' life ... it beats down your
+mind an' then gits ye ... burns ye up ... in the well water ... you
+was right about that ... evil water ... Zenas never come back from the
+well ... can't git away ... draws ye ... ye know summ'at's comin', but
+'tain't no use ... I seen it time an' agin Zenas was took ... whar's
+Nabby, Ammi? ... my head's no good ... dun't know how long sence I fed
+her ... it'll git her ef we ain't keerful ... jest a colour ... her
+face is gittin' to hev that colour sometimes towards night ... an' it
+burns an' sucks ... it come from some place whar things ain't as they
+is here ... one o' them professors said so ... he was right ... look
+out, Ammi, it'll do suthin' more ... sucks the life out...."
+
+But that was all. That which spoke could speak no more because it had
+completely caved in. Ammi laid a red checked tablecloth over what was
+left and reeled out the back door into the fields. He climbed the slope
+to the ten-acre pasture and stumbled home by the north road and the
+woods. He could not pass that well from which his horses had run away.
+He had looked at it through the window, and had seen that no stone
+was missing from the rim. Then the lurching buggy had not dislodged
+anything after all--the splash had been something else--something which
+went into the well after it had done with poor Nahum....
+
+When Ammi reached his house the horses and buggy had arrived before
+him and thrown his wife into fits of anxiety. Reassuring her without
+explanations, he set out at once for Arkham and notified the
+authorities that the Gardner family was no more. He indulged in no
+details, but merely told of the deaths of Nahum and Nabby, that of
+Thaddeus being already known, and mentioned that the cause seemed to
+be the same strange ailment which had killed the livestock. He also
+stated that Merwin and Zenas had disappeared. There was considerable
+questioning at the police station, and in the end Ammi was compelled
+to take three officers to the Gardner farm, together with the coroner,
+the medical examiner, and the veterinary who had treated the diseased
+animals. He went much against his will, for the afternoon was advancing
+and he feared the fall of night over that accursed place, but it was
+some comfort to have so many people with him.
+
+The six men drove out in a democrat-wagon, following Ammi's buggy, and
+arrived at the pest-ridden farmhouse about four o'clock. Used as the
+officers were to gruesome experiences, not one remained unmoved at
+what was found in the attic and under the red checked tablecloth on
+the floor below. The whole aspect of the farm with its grey desolation
+was terrible enough, but those two crumbling objects were beyond all
+bounds. No one could look long at them, and even the medical examiner
+admitted that there was very little to examine. Specimens could be
+analysed, of course, so he busied himself in obtaining them--and here
+it develops that a very puzzling aftermath occurred at the college
+laboratory where the two phials of dust were finally taken. Under the
+spectroscope both samples gave off an unknown spectrum, in which many
+of the baffling bands were precisely like those which the strange
+meteor had yielded in the previous year. The property of emitting this
+spectrum vanished in a month, the dust thereafter consisting mainly of
+alkaline phosphates and carbonates.
+
+       *       *       *       *       *
+
+Ammi would not have told the men about the well if he had thought they
+meant to do anything then and there. It was getting toward sunset, and
+he was anxious to be away. But he could not help glancing nervously
+at the stony curb by the great sweep, and when a detective questioned
+him he admitted that Nahum had feared something down there--so much so
+that he had never even thought of searching it for Merwin or Zenas.
+After that nothing would do but that they empty and explore the well
+immediately, so Ammi had to wait trembling while pail after pail of
+rank water was hauled up and splashed on the soaking ground outside.
+The men sniffed in disgust at the fluid, and toward the last held their
+noses against the foetor they were uncovering. It was not so long a
+job as they had feared it would be, since the water was phenomenally
+low. There is no need to speak too exactly of what they found. Merwin
+and Zenas were both there, in part, though the vestiges were mainly
+skeletal. There were also a small deer and a large dog in about the
+same state, and a number of bones of smaller animals. The ooze and
+slime at the bottom seemed inexplicably porous and bubbling, and a man
+who descended on hand-holds with a long pole found that he could sink
+the wooden shaft to any depth in the mud of the floor without meeting
+any solid obstruction.
+
+Twilight had now fallen, and lanterns were brought from the house.
+Then, when it was seen that nothing further could be gained from the
+well, everyone went indoors and conferred in the ancient sitting-room
+while the intermittent light of a spectral half-moon played wanly on
+the grey desolation outside. The men were frankly nonplussed by the
+entire case, and could find no convincing common element to link the
+strange vegetable conditions, the unknown disease of livestock and
+humans, and the unaccountable deaths of Merwin and Zenas in the tainted
+well. They had heard the common country talk, it is true; but could not
+believe that anything contrary to natural law had occurred. No doubt
+the meteor had poisoned the soil, but the illness of person and animals
+who had eaten nothing grown in that soil was another matter. Was it the
+well water? Very possibly. It might be a good idea to analyse it. But
+what peculiar madness could have made both boys jump into the well?
+Their deeds were so similar--and the fragments showed that they had
+both suffered from the grey brittle death. Why was everything so grey
+and brittle?
+
+It was the coroner, seated near a window overlooking the yard, who
+first noticed the glow about the well. Night had fully set in, and all
+the abhorrent grounds seemed faintly luminous with more than the fitful
+moonbeams; but this new glow was something definite and distinct, and
+appeared to shoot up from the black pit like a softened ray from a
+searchlight, giving dull reflections in the little ground pools where
+the water had been emptied. It had a very queer colour, and as all the
+men clustered round the window Ammi gave a violent start. For this
+strange beam of ghastly miasma was to him of no unfamiliar hue. He had
+seen that colour before, and feared to think what it might mean. He
+had seen it in the nasty brittle globule in that aerolite two summers
+ago, had seen it in the crazy vegetation of the springtime, and had
+thought he had seen it for an instant that very morning against the
+small barred window of that terrible attic room where nameless things
+had happened. It had flashed there a second, and a clammy and hateful
+current of vapour had brushed past him--and then poor Nahum had been
+taken by something of that colour. He had said so at the last--said it
+was like the globule and the plants. After that had come the runaway
+in the yard and the splash in the well--and now that well was belching
+forth to the night a pale insidious beam of the same demoniac tint.
+
+It does credit to the alertness of Ammi's mind that he puzzled even
+at that tense moment over a point which was essentially scientific.
+He could not but wonder at his gleaning of the same impression from
+a vapour glimpsed in the daytime, against a window opening in the
+morning sky, and from a nocturnal exhalation seen as a phosphorescent
+mist against the black and blasted landscape. It wasn't right--it was
+against Nature--and he thought of those terrible last words of his
+stricken friend, "It come from some place whar things ain't as they is
+here ... one o' them professors said so...."
+
+All three horses outside, tied to a pair of shrivelled saplings by
+the road, were now neighing and pawing frantically. The wagon driver
+started for the door to do something, but Ammi laid a shaky hand on his
+shoulder. "Dun't go out thar," he whispered. "They's more to this nor
+what we know. Nahum said somethin' lived in the well that sucks your
+life out. He said it must be some'at growed from a round ball like one
+we all seen in the meteor stone that fell a year ago June. Sucks an'
+burns, he said, an' is jest a cloud of colour like that light out thar
+now, that ye can hardly see an' can't tell what it is. Nahum thought it
+feeds on everything livin' an' gits stronger all the time. He said he
+seen it this last week. It must be somethin' from away off in the sky
+like the men from the college last year says the meteor stone was. The
+way it's made an' the way it works ain't like no way o' God's world.
+It's some'at from beyond."
+
+So the men paused indecisively as the light from the well grew stronger
+and the hitched horses pawed and whinnied in increasing frenzy. It was
+truly an awful moment; with terror in that ancient and accursed house
+itself, four monstrous sets of fragments--two from the house and two
+from the well--in the woodshed behind, and that shaft of unknown and
+unholy iridescence from the slimy depths in front. Ammi had restrained
+the driver on impulse, forgetting how uninjured he himself was after
+the clammy brushing of that coloured vapour in the attic room, but
+perhaps it is just as well that he acted as he did. No one will ever
+know what was abroad that night; and though the blasphemy from beyond
+had not so far hurt any human of unweakened mind, there is no telling
+what it might not have done at that last moment, and with its seemingly
+increased strength and the special signs of purpose it was soon to
+display beneath the half-clouded moonlit sky.
+
+       *       *       *       *       *
+
+All at once one of the detectives at the window gave a short, sharp
+gasp. The others looked at him, and then quickly followed his own
+gaze upward to the point at which its idle straying had been suddenly
+arrested. There was no need for words. What had been disputed in
+country gossip was disputable no longer, and it is because of the
+thing which every man of that party agreed in whispering later on,
+that strange days are never talked about in Arkham. It is necessary to
+premise that there was no wind at that hour of the evening. One did
+arise not long afterward, but there was absolutely none then. Even
+the dry tips of the lingering hedge-mustard, grey and blighted, and
+the fringe on the roof of the standing democrat-wagon were unstirred.
+And yet amid that tense, godless calm the high bare boughs of all
+the trees in the yard were moving. They were twitching morbidly and
+spasmodically, clawing in convulsive and epileptic madness at the
+moonlit clouds; scratching impotently in the noxious air as if jerked
+by some allied and bodiless line of linkage with sub-terrene horrors
+writhing and struggling below the black roots.
+
+Not a man breathed for several seconds. Then a cloud of darker depth
+passed over the moon, and the silhouette of clutching branches faded
+out momentarily. At this there was a general cry; muffled with awe,
+but husky and almost identical from every throat. For the terror had
+not faded with the silhouette, and in a fearsome instant of deeper
+darkness the watchers saw wriggling at the treetop height a thousand
+tiny points of faint and unhallowed radiance, tipping each bough like
+the fire of St. Elmo or the flames that come down on the apostles'
+heads at Pentecost. It was a monstrous constellation of unnatural
+light, like a glutted swarm of corpse-fed fireflies dancing hellish
+sarabands over an accursed marsh; and its colour was that same nameless
+intrusion which Ammi had come to recognise and dread. All the while
+the shaft of phosphorescence from the well was getting brighter and
+brighter, bringing to the minds of the huddled men, a sense of doom and
+abnormality which far outraced any image their conscious minds could
+form. It was no longer _shining_ out; it was _pouring_ out; and as the
+shapeless stream of unplaceable colour left the well it seemed to flow
+directly into the sky.
+
+[Illustration: ... and in the fearsome instant of deeper darkness, the
+watchers saw wriggling at that treetop height, a thousand tiny points
+of faint and unhallowed radiance, tipping each bough like the fire
+of St. Elmo ... and all the while the shaft of phosphorescence from
+the well was getting brighter and brighter and bringing to the minds
+of the huddled men, a sense of doom and abnormality.... It was no
+longer shining out; it was pouring out; and as the shapeless stream of
+unplaceable colour left the well, it seemed to flow directly into the
+sky.]
+
+The veterinary shivered, and walked to the front door to drop the heavy
+extra bar across it. Ammi shook no less, and had to tug and point for
+lack of a controllable voice when he wished to draw notice to the
+growing luminosity of the trees. The neighing and stamping of the
+horses had become utterly frightful, but not a soul of that group in
+the old house would have ventured forth for any earthly reward. With
+the moments the shining of the trees increased, while their restless
+branches seemed to strain more and more toward verticality. The wood
+of the well-sweep was shining now, and presently a policeman dumbly
+pointed to some wooden sheds and beehives near the stone wall on the
+west. They were commencing to shine, too, though the tethered vehicles
+of the visitors seemed so far unaffected. Then there was a wild
+commotion and clopping in the road, and as Ammi quenched the lamp for
+better seeing they realized that the span of frantic grays had broken
+their sapling and run off with the democrat-wagon.
+
+The shock served to loosen several tongues, and embarrassed whispers
+were exchanged. "It spreads on everything organic that's been around
+here," muttered the medical examiner. No one replied, but the man who
+had been in the well gave a hint that his long pole must have stirred
+up something intangible. "It was awful," he added. "There was no bottom
+at all. Just ooze and bubbles and the feeling of something lurking
+under there." Ammi's horse still pawed and screamed deafeningly in
+the road outside, and nearly drowned its owner's faint quaver as he
+mumbled his formless reflections. "It come from that stone--it growed
+down thar--it got everything livin'--it fed itself on 'em, mind and
+body--Thad an' Merwin, Zenas an' Nabby--Nahum was the last--they all
+drunk the water--it got strong on 'em--it come from beyond, whar things
+ain't like they be here--now it's goin' home--"
+
+At this point, as the column of unknown colour flared suddenly stronger
+and began to weave itself into fantastic suggestions of shape which
+each spectator later described differently, there came from poor
+tethered Hero such a sound as no man before or since ever heard from
+a horse. Every person in that low-pitched sitting-room stopped his
+ears, and Ammi turned away from the window in horror and nausea. Words
+could not convey it--when Ammi looked out again the hapless beast lay
+huddled inert on the moonlit ground between the splintered shafts of
+the buggy. That was the last of Hero till they buried him next day.
+But the present was no time to mourn, for almost at this instant a
+detective silently called attention to something terrible in the very
+room with them. In the absence of the lamplight it was clear that a
+faint phosphorescence had begun to pervade the entire apartment. It
+glowed on the broad-planked floor where the rag carpet left it bare,
+and shimmered over the sashes of the small-paned windows. It ran up
+and down the exposed corner-posts, coruscated about the shelf and
+mantel, and infected the very doors and furniture. Each minute saw it
+strengthen, and at last it was very plain that healthy living things
+must leave that house.
+
+Ammi showed them the back door and the path up through the fields to
+the ten-acre pasture. They walked and stumbled as in a dream, and did
+not dare look back till they were far away on the high ground. They
+were glad of the path, for they could not have gone the front way, by
+that well. It was bad enough passing the glowing barn and sheds, and
+those shining orchard trees with their gnarled, fiendish contours; but
+thank Heaven the branches did their worst twisting high up. The moon
+went under some very black clouds as they crossed the rustic bridge
+over Chapman's Brook, and it was blind groping from there to the open
+meadows.
+
+       *       *       *       *       *
+
+When they looked back toward the valley and the distant Gardner place
+at the bottom they saw a fearsome sight. All the farm was shining
+with the hideous unknown blend of colour; trees, buildings, and even
+such grass and herbage as had not been wholly changed to lethal grey
+brittleness. The boughs were all straining skyward, tipped with tongues
+of foul flame, and lambent tricklings of the same monstrous fire were
+creeping about the ridgepoles of the house, barn and sheds. It was a
+scene from a vision of Fuseli, and over all the rest reigned that riot
+of luminous amorphousness, that alien and undimensioned rainbow of
+cryptic poison from the well--seething, feeling, lapping, reaching,
+scintillating, straining, and malignly bubbling in its cosmic and
+unrecognizable chromaticism.
+
+Then without warning the hideous thing shot vertically up toward the
+sky like a rocket or meteor, leaving behind no trail and disappearing
+through a round and curiously regular hole in the clouds before any
+man could gasp or cry out. No watcher can ever forget that sight, and
+Ammi stared blankly at the stars of Cygnus, Deneb twinkling above the
+others, where the unknown colour had melted into the Milky Way. But his
+gaze was the next moment called swiftly to earth by the crackling in
+the valley. It was just that. Only a wooden ripping and crackling, and
+not an explosion, as so many others of the party vowed. Yet the outcome
+was the same, for in one feverish kaleidoscopic instant there burst up
+from that doomed and accursed farm a gleamingly eruptive cataclysm of
+unnatural sparks and substance; blurring the glance of the few who saw
+it, and sending forth to the zenith a bombarding cloudburst of such
+coloured and fantastic fragments as our universe must needs disown.
+Through quickly re-closing vapours they followed the great morbidity
+that had vanished, and in another second they had vanished too. Behind
+and below was only a darkness to which the men dared not return, and
+all about was a mounting wind which seemed to sweep down in black,
+frore gusts from interstellar space. It shrieked and howled, and lashed
+the fields and distorted woods in a mad cosmic frenzy, till soon the
+trembling party realized it would be no use waiting for the moon to
+show what was left down there at Nahum's.
+
+Too awed even to hint theories, the seven shaking men trudged back
+toward Arkham by the north road. Ammi was worse than his fellows,
+and begged them to see him inside his own kitchen, instead of
+keeping straight on to town. He did not wish to cross the blighted,
+wind-whipped woods alone to his home on the main road. For he had had
+an added shock that the others were spared, and was crushed for ever
+with a brooding fear he dared not even mention for many years to come.
+As the rest of the watchers on that tempestuous hill had stolidly set
+their faces toward the road, Ammi had looked back an instant at the
+shadowed valley of desolation so lately sheltering his ill-starred
+friend. And from that stricken, far-away spot he had seen something
+feebly rise, only to sink down again upon the place from which the
+great shapeless horror had shot into the sky. It was just a colour--but
+not any colour of our earth or heavens. And because Ammi recognized
+that colour, and knew that this last faint remnant must still lurk down
+there in the well, he has never been quite right since.
+
+Ammi would never go near the place again. It is forty-four years now
+since the horror happened, but he has never been there, and will be
+glad when the new reservoir blots it out. I shall be glad, too, for I
+do not like the way the sunlight changed colour around the mouth of
+that abandoned well I passed. I hope the water will always be very
+deep--but even so, I shall never drink it. I do not think I shall visit
+the Arkham country hereafter. Three of the men who had been with Ammi
+returned the next morning to see the ruins by daylight, but there were
+not any real ruins. Only the bricks of the chimney, the stones of the
+cellar, some mineral and metallic litter here and there, and the rim
+of that nefandous well. Save for Ammi's dead horse, which they towed
+away and buried, and the buggy which they shortly returned to him,
+everything that had ever been living had gone. Five eldritch acres of
+dusty grey desert remained, nor has anything ever grown there since.
+To this day it sprawls open to the sky like a great spot eaten by acid
+in the woods and fields, and the few who have ever dared glimpse it in
+spite of the rural tales have named it "the blasted heath."
+
+       *       *       *       *       *
+
+The rural tales are queer. They might be even queerer if city men
+and college chemists could be interested enough to analyze the water
+from that disused well, or the grey dust that no wind seems ever to
+disperse. Botanists, too, ought to study the stunted flora on the
+borders of that spot, for they might shed light on the country notion
+that the blight is spreading--little by little, perhaps an inch a year.
+People say the colour of the neighboring herbage is not quite right
+in the spring, and that wild things leave queer prints in the light
+winter snow. Snow never seems quite so heavy on the blasted heath as
+it is elsewhere. Horses--the few that are left in this motor age--grow
+skittish in the silent valley; and hunters cannot depend on their dogs
+too near the splotch of greyish dust.
+
+They say the mental influences are very bad, too; numbers went queer in
+the years after Nahum's taking, and always they lacked the power to get
+away. Then the stronger-minded folk all left the region, and only the
+foreigners tried to live in the crumbling old homesteads. They could
+not stay, though; and one sometimes wonders what insight beyond ours
+their wild, weird stories of whispered magic have given them. Their
+dreams at night, they protest, are very horrible in that grotesque
+country; and surely the very look of the dark realm is enough to stir
+a morbid fancy. No traveler has ever escaped a sense of strangeness in
+those deep ravines, and artists shiver as they paint thick woods whose
+mystery is as much of the spirits as of the eye. I myself am curious
+about the sensation I derived from my one lone walk before Ammi told
+me his tale. When twilight came I had vaguely wished some clouds would
+gather, for odd timidity about the deep skyey voids above had crept
+into my soul.
+
+Do not ask me for my opinion. I do not know--that is all. There was no
+one but Ammi to question; for Arkham people will not talk about the
+strange days, and all three professors who saw the aerolite and its
+coloured globule are dead. There were other globules--depend upon that.
+One must have fed itself and escaped, and probably there was another
+which was too late. No doubt it is still down the well--I know there
+was something wrong with the sunlight I saw above that miasmal brink.
+The rustics say the blight creeps an inch a year, so perhaps there is
+a kind of growth or nourishment even now. But whatever demon hatchling
+is there, it must be tethered to something or else it would quickly
+spread. Is it fastened to the roots of those trees that claw the air?
+One of the current Arkham tales is about fat oaks that shine and move
+as they ought not to do at night.
+
+What it is, only God knows. In terms of matter I suppose the thing
+Ammi described would be called a gas, but this gas obeyed laws that
+are not of our cosmos. This was no fruit of such worlds and suns as
+shine on the telescopes and photographic plates of our observatories.
+This was no breath from the skies whose motions and dimensions our
+astronomers measure or deem too vast to measure. It was just a colour
+out of space--a frightful messenger from unformed realms of infinity
+beyond all Nature as we know it; from realms whose mere existence stuns
+the brain and numbs us with the black extra-cosmic gulfs it throws open
+before our frenzied eyes.
+
+I doubt very much if Ammi consciously lied to me, and I do not think
+his tale was all a freak of madness as the townsfolk had forewarned.
+Something terrible came to the hills and valleys on that meteor,
+and something terrible--though I know not in what proportion--still
+remains. I shall be glad to see the water come. Meanwhile I hope
+nothing will happen to Ammi. He saw so much of the thing--and its
+influence was so insidious. Why has he never been able to move away?
+How clearly he recalled those dying words of Nahum's--"can't git
+away--draws ye--ye know summ'at's comin', but 'tain't no use--" Ammi is
+such a good old man--when the reservoir gang gets to work I must write
+the chief engineer to keep a sharp watch on him. I would hate to think
+of him as the grey, twisted, brittle monstrosity which persists more
+and more in troubling my sleep.
+
+
+                                THE END
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK THE COLOUR OUT OF SPACE ***
+
+
+    
+
+Updated editions will replace the previous one—the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg™ electronic works to protect the PROJECT GUTENBERG™
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away—you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg™ mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg™ License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg™
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg™
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg™ electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg™ electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the person
+or entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg™ electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg™ electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg™
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the
+Foundation” or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg™ electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg™ mission of promoting
+free access to electronic works by freely sharing Project Gutenberg™
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg™ name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg™ License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg™ work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg™ License must appear
+prominently whenever any copy of a Project Gutenberg™ work (any work
+on which the phrase “Project Gutenberg” appears, or with which the
+phrase “Project Gutenberg” is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+    This eBook is for the use of anyone anywhere in the United States and most
+    other parts of the world at no cost and with almost no restrictions
+    whatsoever. You may copy it, give it away or re-use it under the terms
+    of the Project Gutenberg License included with this eBook or online
+    at www.gutenberg.org. If you
+    are not located in the United States, you will have to check the laws
+    of the country where you are located before using this eBook.
+  
+1.E.2. If an individual Project Gutenberg™ electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase “Project
+Gutenberg” associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg™
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg™ electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg™ License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg™
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg™.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg™ License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg™ work in a format
+other than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg™ website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the
+full Project Gutenberg™ License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg™ works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg™ electronic works
+provided that:
+
+    • You pay a royalty fee of 20% of the gross profits you derive from
+        the use of Project Gutenberg™ works calculated using the method
+        you already use to calculate your applicable taxes. The fee is owed
+        to the owner of the Project Gutenberg™ trademark, but he has
+        agreed to donate royalties under this paragraph to the Project
+        Gutenberg Literary Archive Foundation. Royalty payments must be paid
+        within 60 days following each date on which you prepare (or are
+        legally required to prepare) your periodic tax returns. Royalty
+        payments should be clearly marked as such and sent to the Project
+        Gutenberg Literary Archive Foundation at the address specified in
+        Section 4, “Information about donations to the Project Gutenberg
+        Literary Archive Foundation.”
+    
+    • You provide a full refund of any money paid by a user who notifies
+        you in writing (or by e-mail) within 30 days of receipt that s/he
+        does not agree to the terms of the full Project Gutenberg™
+        License. You must require such a user to return or destroy all
+        copies of the works possessed in a physical medium and discontinue
+        all use of and all access to other copies of Project Gutenberg™
+        works.
+    
+    • You provide, in accordance with paragraph 1.F.3, a full refund of
+        any money paid for a work or a replacement copy, if a defect in the
+        electronic work is discovered and reported to you within 90 days of
+        receipt of the work.
+    
+    • You comply with all other terms of this agreement for free
+        distribution of Project Gutenberg™ works.
+    
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg™ electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg™ trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg™ collection. Despite these efforts, Project Gutenberg™
+electronic works, and the medium on which they may be stored, may
+contain “Defects,” such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg™ trademark, and any other party distributing a Project
+Gutenberg™ electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’, WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg™ electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg™
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg™ work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg™ work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg™
+
+Project Gutenberg™ is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg™’s
+goals and ensuring that the Project Gutenberg™ collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg™ and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at www.gutenberg.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation’s EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state’s laws.
+
+The Foundation’s business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation’s website
+and official page at www.gutenberg.org/contact
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg™ depends upon and cannot survive without widespread
+public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit www.gutenberg.org/donate.
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate.
+
+Section 5. General Information About Project Gutenberg™ electronic works
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg™ concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg™ eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg™ eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org.
+
+This website includes information about Project Gutenberg™,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/corpora/originals/cthuluOG.txt
+++ b/corpora/originals/cthuluOG.txt
@@ -1,0 +1,1600 @@
+﻿The Project Gutenberg eBook of The call of Cthulhu
+    
+This ebook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this ebook or online
+at www.gutenberg.org. If you are not located in the United States,
+you will have to check the laws of the country where you are located
+before using this eBook.
+
+Title: The call of Cthulhu
+
+Author: H. P. Lovecraft
+
+Release date: June 10, 2022 [eBook #68283]
+                Most recently updated: October 18, 2024
+
+Language: English
+
+Original publication: United States: Popular Fiction Publishing Company, 1928
+
+Credits: Greg Weeks, Mary Meehan and the Online Distributed Proofreading Team at http://www.pgdp.net
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK THE CALL OF CTHULHU ***
+The CALL of CTHULHU
+
+By H.P. LOVECRAFT
+
+[Transcriber's Note: This etext was produced from
+Weird Tales, February 1928.
+Extensive research did not uncover any evidence that
+the U.S. copyright on this publication was renewed.]
+
+
+    "Of such great powers or beings there may be conceivably a
+    survival ... a survival of a hugely remote period when ...
+    consciousness was manifested, perhaps, in shapes and forms long
+    since withdrawn before the tide of advancing humanity ... forms
+    of which poetry and legend alone have caught a flying memory
+    and called them gods, monsters, mythical beings of all sorts
+    and kinds...."
+
+                                                --_Algernon Blackwood._
+
+
+[Illustration: "The ring of worshipers moved in endless bacchanale
+between the ring of bodies and the ring of fire."][1]
+
+[Footnote 1: Found among the papers of the late Francis Wayland
+Thurston, of Boston.]
+
+
+
+
+                       _1. The Horror in Clay._
+
+The most merciful thing in the world, I think, is the inability of the
+human mind to correlate all its contents. We live on a placid island
+of ignorance in the midst of black seas of infinity, and it was not
+meant that we should voyage far. The sciences, each straining in its
+own direction, have hitherto harmed us little; but some day the piecing
+together of dissociated knowledge will open up such terrifying vistas
+of reality, and of our frightful position therein, that we shall either
+go mad from the revelation or flee from the deadly light into the peace
+and safety of a new dark age.
+
+Theosophists have guessed at the awesome grandeur of the cosmic cycle
+wherein our world and human race form transient incidents. They have
+hinted at strange survivals in terms which would freeze the blood if
+not masked by a bland optimism. But it is not from them that there
+came the single glimpse of forbidden eons which chills me when I think
+of it and maddens me when I dream of it. That glimpse, like all dread
+glimpses of truth, flashed out from an accidental piecing together of
+separated things--in this case an old newspaper item and the notes of
+a dead professor. I hope that no one else will accomplish this piecing
+out; certainly, if I live, I shall never knowingly supply a link in
+so hideous a chain. I think that the professor, too, intended to keep
+silent regarding the part he knew, and that he would have destroyed his
+notes had not sudden death seized him.
+
+My knowledge of the thing began in the winter of 1926-27 with the death
+of my grand-uncle, George Gammell Angell, Professor Emeritus of Semitic
+languages in Brown University, Providence, Rhode Island. Professor
+Angell was widely known as an authority on ancient inscriptions, and
+had frequently been resorted to by the heads of prominent museums; so
+that his passing at the age of ninety-two may be recalled by many.
+Locally, interest was intensified by the obscurity of the cause of
+death. The professor had been stricken whilst returning from the
+Newport boat; falling suddenly, as witnesses said, after having been
+jostled by a nautical-looking negro who had come from one of the queer
+dark courts on the precipitous hillside which formed a short cut from
+the waterfront to the deceased's home in Williams Street. Physicians
+were unable to find any visible disorder, but concluded after perplexed
+debate that some obscure lesion of the heart, induced by the brisk
+ascent of so steep a hill by so elderly a man, was responsible for
+the end. At the time I saw no reason to dissent from this dictum, but
+latterly I am inclined to wonder--and more than wonder.
+
+As my granduncle's heir and executor, for he died a childless widower,
+I was expected to go over his papers with some thoroughness; and for
+that purpose moved his entire set of files and boxes to my quarters in
+Boston. Much of the material which I correlated will be later published
+by the American Archeological Society, but there was one box which I
+found exceedingly puzzling, and which I felt much averse from showing
+to other eyes. It had been locked, and I did not find the key till
+it occurred to me to examine the personal ring which the professor
+carried always in his pocket. Then, indeed, I succeeded in opening it,
+but when I did so seemed only to be confronted by a greater and more
+closely locked barrier. For what could be the meaning of the queer clay
+bas-relief and the disjointed jottings, ramblings, and cuttings which I
+found? Had my uncle, in his latter years, become credulous of the most
+superficial impostures? I resolved to search out the eccentric sculptor
+responsible for this apparent disturbance of an old man's peace of mind.
+
+The bas-relief was a rough rectangle less than an inch thick and about
+five by six inches in area; obviously of modern origin. Its designs,
+however, were far from modern in atmosphere and suggestion; for,
+although the vagaries of cubism and futurism are many and wild, they do
+not often reproduce that cryptic regularity which lurks in prehistoric
+writing. And writing of some kind the bulk of these designs seemed
+certainly to be; though my memory, despite much familiarity with the
+papers and collections of my uncle, failed in any way to identify this
+particular species, or even hint at its remotest affiliations.
+
+Above these apparent hieroglyphics was a figure of evidently pictorial
+intent, though its impressionistic execution forbade a very clear
+idea of its nature. It seemed to be a sort of monster, or symbol
+representing a monster, of a form which only a diseased fancy could
+conceive. If I say that my somewhat extravagant imagination yielded
+simultaneous pictures of an octopus, a dragon, and a human caricature,
+I shall not be unfaithful to the spirit of the thing. A pulpy,
+tentacled head surmounted a grotesque and scaly body with rudimentary
+wings; but it was the _general outline_ of the whole which made it most
+shockingly frightful. Behind the figure was a vague suggestion of a
+Cyclopean architectural background.
+
+The writing accompanying this oddity was, aside from a stack of
+press cuttings, in Professor Angell's most recent hand; and made no
+pretense to literary style. What seemed to be the main document was
+headed "_CTHULHU CULT_" in characters painstakingly printed to avoid
+the erroneous reading of a word so unheard-of. This manuscript was
+divided into two sections, the first of which was headed "1925--Dream
+and Dream Work of H. A. Wilcox, 7 Thomas St., Providence, R. I.," and
+the second, "Narrative of Inspector John R. Legrasse, 121 Bienville
+St., New Orleans, La., at 1908 A. A. S. Mtg--Notes on Same, & Prof.
+Webb's Acct." The other manuscript papers were all brief notes, some
+of them accounts of the queer dreams of different persons, some of
+them citations from theosophical books and magazines (notably W.
+Scott-Eliott's _Atlantis and the Lost Lemuria_), and the rest comments
+on long-surviving secret societies and hidden cults, with references
+to passages in such mythological and anthropological source-books
+as Frazer's _Golden Bough_ and Miss Murray's _Witch-Cult in Western
+Europe_. The cuttings largely alluded to outré mental illnesses and
+outbreaks of group folly or mania in the spring of 1925.
+
+       *       *       *       *       *
+
+The first half of the principal manuscript told a very peculiar
+tale. It appears that on March 1st, 1925, a thin, dark young man of
+neurotic and excited aspect had called upon Professor Angell bearing
+the singular clay bas-relief, which was then exceedingly damp and
+fresh. His card bore the name of Henry Anthony Wilcox, and my uncle
+had recognized him as the youngest son of an excellent family slightly
+known to him, who had latterly been studying sculpture at the Rhode
+Island School of Design and living alone at the Fleur-de-Lys Building
+near that institution. Wilcox was a precocious youth of known genius
+but great eccentricity, and had from childhood excited attention
+through the strange stories and odd dreams he was in the habit of
+relating. He called himself "psychically hypersensitive", but the staid
+folk of the ancient commercial city dismissed him as merely "queer".
+Never mingling much with his kind, he had dropped gradually from social
+visibility, and was now known only to a small group of esthetes from
+other towns. Even the Providence Art Club, anxious to preserve its
+conservatism, had found him quite hopeless.
+
+On the occasion of the visit, ran the professor's manuscript, the
+sculptor abruptly asked for the benefit of his host's archeological
+knowledge in identifying the hieroglyphics on the bas-relief. He
+spoke in a dreamy, stilted manner which suggested pose and alienated
+sympathy; and my uncle showed some sharpness in replying, for the
+conspicuous freshness of the tablet implied kinship with anything but
+archeology. Young Wilcox's rejoinder, which impressed my uncle enough
+to make him recall and record it verbatim, was of a fantastically
+poetic cast which must have typified his whole conversation, and which
+I have since found highly characteristic of him. He said, "It is new,
+indeed, for I made it last night in a dream of strange cities; and
+dreams are older than brooding Tyre, or the contemplative Sphinx, or
+garden-girdled Babylon."
+
+It was then that he began that rambling tale which suddenly played upon
+a sleeping memory and won the fevered interest of my uncle. There had
+been a slight earthquake tremor the night before, the most considerable
+felt in New England for some years; and Wilcox's imagination had been
+keenly affected. Upon retiring, he had had an unprecedented dream of
+great Cyclopean cities of Titan blocks and sky-flung monoliths, all
+dripping with green ooze and sinister with latent horror. Hieroglyphics
+had covered the walls and pillars, and from some undetermined point
+below had come a voice that was not a voice; a chaotic sensation which
+only fancy could transmute into sound, but which he attempted to render
+by the almost unpronounceable jumble of letters, "_Cthulhu fhtagn_".
+
+This verbal jumble was the key to the recollection which excited and
+disturbed Professor Angell. He questioned the sculptor with scientific
+minuteness; and studied with almost frantic intensity the bas-relief
+on which the youth had found himself working, chilled and clad only
+in his nightclothes, when waking had stolen bewilderingly over him.
+My uncle blamed his old age, Wilcox afterward said, for his slowness
+in recognizing both hieroglyphics and pictorial design. Many of his
+questions seemed highly out of place to his visitor, especially those
+which tried to connect the latter with strange cults or societies;
+and Wilcox could not understand the repeated promises of silence
+which he was offered in exchange for an admission of membership in
+some widespread mystical or paganly religious body. When Professor
+Angell became convinced that the sculptor was indeed ignorant of any
+cult or system of cryptic lore, he besieged his visitor with demands
+for future reports of dreams. This bore regular fruit, for after the
+first interview the manuscript records daily calls of the young man,
+during which he related startling fragments of nocturnal imagery whose
+burden was always some terrible Cyclopean vista of dark and dripping
+stone, with a subterrene voice or intelligence shouting monotonously
+in enigmatical sense-impacts uninscribable save as gibberish. The two
+sounds most frequently repeated are those rendered by the letters
+"_Cthulhu_" and "_R'lyeh_".
+
+On March 23rd, the manuscript continued, Wilcox failed to appear; and
+inquiries at his quarters revealed that he had been stricken with an
+obscure sort of fever and taken to the home of his family in Waterman
+Street. He had cried out in the night, arousing several other artists
+in the building, and had manifested since then only alternations of
+unconsciousness and delirium. My uncle at once telephoned the family,
+and from that time forward kept close watch of the case; calling
+often at the Thayer Street office of Dr. Tobey, whom he learned to
+be in charge. The youth's febrile mind, apparently, was dwelling on
+strange things; and the doctor shuddered now and then as he spoke of
+them. They included not only a repetition of what he had formerly
+dreamed, but touched wildly on a gigantic thing "miles high" which
+walked or lumbered about. He at no time fully described this object,
+but occasional frantic words, as repeated by Dr. Tobey, convinced the
+professor that it must be identical with the nameless monstrosity
+he had sought to depict in his dream-sculpture. Reference to this
+object, the doctor added, was invariably a prelude to the young man's
+subsidence into lethargy. His temperature, oddly enough, was not
+greatly above normal; but the whole condition was otherwise such as to
+suggest true fever rather than mental disorder.
+
+On April 2nd at about 3 p. m. every trace of Wilcox's malady suddenly
+ceased. He sat upright in bed, astonished to find himself at home and
+completely ignorant of what had happened in dream or reality since the
+night of March 22nd. Pronounced well by his physician, he returned
+to his quarters in three days; but to Professor Angell he was of no
+further assistance. All traces of strange dreaming had vanished with
+his recovery, and my uncle kept no record of his night-thoughts after a
+week of pointless and irrelevant accounts of thoroughly usual visions.
+
+       *       *       *       *       *
+
+Here the first part of the manuscript ended, but references to certain
+of the scattered notes gave me much material for thought--so much, in
+fact, that only the ingrained skepticism then forming my philosophy
+can account for my continued distrust of the artist. The notes in
+question were those descriptive of the dreams of various persons
+covering the same period as that in which young Wilcox had had his
+strange visitations. My uncle, it seems, had quickly instituted a
+prodigiously far-flung body of inquiries amongst nearly all the friends
+whom he could question without impertinence, asking for nightly reports
+of their dreams, and the dates of any notable visions for some time
+past. The reception of his request seems to have been varied; but
+he must, at the very least, have received more responses than any
+ordinary man could have handled without a secretary. This original
+correspondence was not preserved, but his notes formed a thorough and
+really significant digest. Average people in society and business--New
+England's traditional "salt of the earth"--gave an almost completely
+negative result, though scattered cases of uneasy but formless
+nocturnal impressions appear here and there, always between March
+23rd and April 2nd--the period of young Wilcox's delirium. Scientific
+men were little more affected, though four cases of vague description
+suggest fugitive glimpses of strange landscapes, and in one case there
+is mentioned a dread of something abnormal.
+
+It was from the artists and poets that the pertinent answers came,
+and I know that panic would have broken loose had they been able to
+compare notes. As it was, lacking their original letters, I half
+suspected the compiler of having asked leading questions, or of having
+edited the correspondence in corroboration of what he had latently
+resolved to see. That is why I continued to feel that Wilcox, somehow
+cognizant of the old data which my uncle had possessed, had been
+imposing on the veteran scientist. These responses from esthetes told
+a disturbing tale. From February 28th to April 2nd a large proportion
+of them had dreamed very bizarre things, the intensity of the dreams
+being immeasurably the stronger during the period of the sculptor's
+delirium. Over a fourth of those who reported anything, reported
+scenes and half-sounds not unlike those which Wilcox had described;
+and some of the dreamers confessed acute fear of the gigantic nameless
+thing visible toward the last. One case, which the note describes with
+emphasis, was very sad. The subject, a widely known architect with
+leanings toward theosophy and occultism, went violently insane on
+the date of young Wilcox's seizure, and expired several months later
+after incessant screamings to be saved from some escaped denizen of
+hell. Had my uncle referred to these cases by name instead of merely
+by number, I should have attempted some corroboration and personal
+investigation; but as it was, I succeeded in tracing down only a
+few. All of these, however, bore out the notes in full. I have often
+wondered if all the objects of the professor's questioning felt as
+puzzled as did this fraction. It is well that no explanation shall ever
+reach them.
+
+The press cuttings, as I have intimated, touched on cases of panic,
+mania, and eccentricity during the given period. Professor Angell
+must have employed a cutting bureau, for the number of extracts was
+tremendous, and the sources scattered throughout the globe. Here
+was a nocturnal suicide in London, where a lone sleeper had leaped
+from a window after a shocking cry. Here likewise a rambling letter
+to the editor of a paper in South America, where a fanatic deduces
+a dire future from visions he has seen. A dispatch from California
+describes a theosophist colony as donning white robes en masse for some
+"glorious fulfilment" which never arrives, whilst items from India
+speak guardedly of serious native unrest toward the end of March.
+Voodoo orgies multiply in Haiti, and African outposts report ominous
+mutterings. American officers in the Philippines find certain tribes
+bothersome about this time, and New York policemen are mobbed by
+hysterical Levantines on the night of March 22-23. The west of Ireland,
+too, is full of wild rumor and legendry, and a fantastic painter named
+Ardois-Bonnot hangs a blasphemous _Dream Landscape_ in the Paris spring
+salon of 1926. And so numerous are the recorded troubles in insane
+asylums that only a miracle can have stopped the medical fraternity
+from noting strange parallelisms and drawing mystified conclusions.
+A weird bunch of cuttings, all told; and I can at this date scarcely
+envisage the callous rationalism with which I set them aside. But I
+was then convinced that young Wilcox had known of the older matters
+mentioned by the professor.
+
+
+
+
+                 _2. The Tale of Inspector Legrasse._
+
+
+The older matters which had made the sculptor's dream and bas-relief so
+significant to my uncle formed the subject of the second half of his
+long manuscript. Once before, it appears, Professor Angell had seen the
+hellish outlines of the nameless monstrosity, puzzled over the unknown
+hieroglyphics, and heard the ominous syllables which can be rendered
+only as "_Cthulhu_"; and all this in so stirring and horrible a
+connection that it is small wonder he pursued young Wilcox with queries
+and demands for data.
+
+This earlier experience had come in 1908, seventeen years before,
+when the American Archeological Society held its annual meeting in
+St. Louis. Professor Angell, as befitted one of his authority and
+attainments, had had a prominent part in all the deliberations; and was
+one of the first to be approached by the several outsiders who took
+advantage of the convocation to offer questions for correct answering
+and problems for expert solution.
+
+The chief of these outsiders, and in a short time the focus of interest
+for the entire meeting, was a commonplace-looking middle-aged man
+who had traveled all the way from New Orleans for certain special
+information unobtainable from any local source. His name was John
+Raymond Legrasse, and he was by profession an inspector of police. With
+him he bore the subject of his visit, a grotesque, repulsive, and
+apparently very ancient stone statuette whose origin he was at a loss
+to determine.
+
+It must not be fancied that Inspector Legrasse had the least interest
+in archeology. On the contrary, his wish for enlightenment was prompted
+by purely professional considerations. The statuette, idol, fetish,
+or whatever it was, had been captured some months before in the
+wooded swamps south of New Orleans during a raid on a supposed voodoo
+meeting; and so singular and hideous were the rites connected with
+it, that the police could not but realize that they had stumbled on a
+dark cult totally unknown to them, and infinitely more diabolic than
+even the blackest of the African voodoo circles. Of its origin, apart
+from the erratic and unbelievable tales extorted from the captured
+members, absolutely nothing was to be discovered; hence the anxiety
+of the police for any antiquarian lore which might help them to place
+the frightful symbol, and through it track down the cult to its
+fountain-head.
+
+Inspector Legrasse was scarcely prepared for the sensation which his
+offering created. One sight of the thing had been enough to throw the
+assembled men of science into a state of tense excitement, and they
+lost no time in crowding around him to gaze at the diminutive figure
+whose utter strangeness and air of genuinely abysmal antiquity hinted
+so potently at unopened and archaic vistas. No recognized school of
+sculpture had animated this terrible object, yet centuries and even
+thousands of years seemed recorded in its dim and greenish surface of
+unplaceable stone.
+
+The figure, which was finally passed slowly from man to man for close
+and careful study, was between seven and eight inches in height, and of
+exquisitely artistic workmanship. It represented a monster of vaguely
+anthropoid outline, but with an octopuslike head whose face was a mass
+of feelers, a scaly, rubbery-looking body, prodigious claws on hind
+and fore feet, and long, narrow wings behind. This thing, which seemed
+instinct with a fearsome and unnatural malignancy, was of a somewhat
+bloated corpulence, and squatted evilly on a rectangular block or
+pedestal covered with undecipherable characters. The tips of the wings
+touched the back edge of the block, the seat occupied the center,
+whilst the long, curved claws of the doubled-up, crouching hind legs
+gripped the front edge and extended a quarter of the way down toward
+the bottom of the pedestal. The cephalopod head was bent forward, so
+that the ends of the facial feelers brushed the backs of huge forepaws
+which clasped the croucher's elevated knees. The aspect of the whole
+was abnormally lifelike, and the more subtly fearful because its source
+was so totally unknown. Its vast, awesome, and incalculable age was
+unmistakable; yet not one link did it show with any known type of art
+belonging to civilization's youth--or indeed to any other time.
+
+Totally separate and apart, its very material was a mystery; for the
+soapy, greenish-black stone with its golden or iridescent flecks and
+striations resembled nothing familiar to geology or mineralogy. The
+characters along the base were equally baffling; and no member present,
+despite a representation of half the world's expert learning in this
+field, could form the least notion of even their remotest linguistic
+kinship. They, like the subject and material, belonged to something
+horribly remote and distinct from mankind as we know it; something
+frightfully suggestive of old and unhallowed cycles of life in which
+our world and our conceptions have no part.
+
+And yet, as the members severally shook their heads and confessed
+defeat at the inspector's problem, there was one man in that gathering
+who suspected a touch of bizarre familiarity in the monstrous shape and
+writing, and who presently told with some diffidence of the odd trifle
+he knew. This person was the late William Channing Webb, professor of
+anthropology in Princeton University, and an explorer of no slight note.
+
+Professor Webb had been engaged, forty-eight years before, in a tour
+of Greenland and Iceland in search of some Runic inscriptions which
+he failed to unearth; and whilst high up on the West Greenland coast
+had encountered a singular tribe or cult of degenerate Eskimos whose
+religion, a curious form of devil-worship, chilled him with its
+deliberate bloodthirstiness and repulsiveness. It was a faith of which
+other Eskimos knew little, and which they mentioned only with shudders,
+saying that it had come down from horribly ancient eons before ever the
+world was made. Besides nameless rites and human sacrifices there were
+certain queer hereditary rituals addressed to a supreme elder devil or
+_tornasuk_; and of this Professor Webb had taken a careful phonetic
+copy from an aged _angekok_ or wizard-priest, expressing the sounds in
+Roman letters as best he knew how. But just now of prime significance
+was the fetish which this cult had cherished, and around which they
+danced when the aurora leaped high over the ice cliffs. It was, the
+professor stated, a very crude bas-relief of stone, comprising a
+hideous picture and some cryptic writing. And as far as he could tell,
+it was a rough parallel in all essential features of the bestial thing
+now lying before the meeting.
+
+These data, received with suspense and astonishment by the assembled
+members, proved doubly exciting to Inspector Legrasse; and he began at
+once to ply his informant with questions. Having noted and copied an
+oral ritual among the swamp cult-worshipers his men had arrested, he
+besought the professor to remember as best he might the syllables taken
+down amongst the diabolist Eskimos. There then followed an exhaustive
+comparison of details, and a moment of really awed silence when both
+detective and scientist agreed on the virtual identity of the phrase
+common to two hellish rituals so many worlds of distance apart. What,
+in substance, both the Eskimo wizards and the Louisiana swamp-priests
+had chanted to their kindred idols was something very like this--the
+word-divisions being guessed at from traditional breaks in the phrase
+as chanted aloud:
+
+        "_Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn._"
+
+Legrasse had one point in advance of Professor Webb, for several among
+his mongrel prisoners had repeated to him what older celebrants had
+told them the words meant. This text, as given, ran something like this:
+
+         "In his house at R'lyeh dead Cthulhu waits dreaming."
+
+       *       *       *       *       *
+
+And now, in response to a general urgent demand, Inspector Legrasse
+related as fully as possible his experience with the swamp worshipers;
+telling a story to which I could see my uncle attached profound
+significance. It savored of the wildest dreams of myth-maker and
+theosophist, and disclosed an astonishing degree of cosmic imagination
+among such half-castes and pariahs as might be least expected to
+possess it.
+
+On November 1st, 1907, there had come to New Orleans police a frantic
+summons from the swamp and lagoon country to the south. The squatters
+there, mostly primitive but good-natured descendants of Lafitte's men,
+were in the grip of stark terror from an unknown thing which had stolen
+upon them in the night. It was voodoo, apparently, but voodoo of a more
+terrible sort than they had ever known; and some of their women and
+children had disappeared since the malevolent tom-tom had begun its
+incessant beating far within the black haunted woods where no dweller
+ventured. There were insane shouts and harrowing screams, soul-chilling
+chants and dancing devil-flames; and, the frightened messenger added,
+the people could stand it no more.
+
+So a body of twenty police, filling two carriages and an automobile,
+had set out in the late afternoon with the shivering squatter as a
+guide. At the end of the passable road they alighted, and for miles
+splashed on in silence through the terrible cypress woods where day
+never came. Ugly roots and malignant hanging nooses of Spanish moss
+beset them, and now and then a pile of dank stones or fragments of a
+rotting wall intensified by its hint of morbid habitation a depression
+which every malformed tree and every fungous islet combined to create.
+At length the squatter settlement, a miserable huddle of huts, hove in
+sight; and hysterical dwellers ran out to cluster around the group of
+bobbing lanterns. The muffled beat of tom-toms was now faintly audible
+far, far ahead; and a curdling shriek came at infrequent intervals
+when the wind shifted. A reddish glare, too, seemed to filter through
+the pale undergrowth beyond endless avenues of forest night. Reluctant
+even to be left alone again, each one of the cowed squatters refused
+point-blank to advance another inch toward the scene of unholy
+worship, so Inspector Legrasse and his nineteen colleagues plunged on
+unguided into black arcades of horror that none of them had ever trod
+before.
+
+The region now entered by the police was one of traditionally evil
+repute, substantially unknown and untraversed by white men. There were
+legends of a hidden lake unglimpsed by mortal sight, in which dwelt a
+huge, formless white polypous thing with luminous eyes; and squatters
+whispered that bat-winged devils flew up out of caverns in inner
+earth to worship it at midnight. They said it had been there before
+D'Iberville, before La Salle, before the Indians, and before even the
+wholesome beasts and birds of the woods. It was nightmare itself, and
+to see it was to die. But it made men dream, and so they knew enough to
+keep away. The present voodoo orgy was, indeed, on the merest fringe
+of this abhorred area, but that location was bad enough; hence perhaps
+the very place of the worship had terrified the squatters more than the
+shocking sounds and incidents.
+
+Only poetry or madness could do justice to the noises heard by
+Legrasse's men as they plowed on through the black morass toward the
+red glare and the muffled tom-toms. There are vocal qualities peculiar
+to men, and vocal qualities peculiar to beasts; and it is terrible
+to hear the one when the source should yield the other. Animal fury
+and orgiastic license here whipped themselves to demoniac heights by
+howls and squawking ecstasies that tore and reverberated through those
+nighted woods like pestilential tempests from the gulfs of hell. Now
+and then the less organized ululations would cease, and from what
+seemed a well-drilled chorus of hoarse voices would rise in singsong
+chant that hideous phrase or ritual:
+
+        "_Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn._"
+
+Then the men, having reached a spot where the trees were thinner, came
+suddenly in sight of the spectacle itself. Four of them reeled, one
+fainted, and two were shaken into a frantic cry which the mad cacophony
+of the orgy fortunately deadened. Legrasse dashed swamp water on the
+face of the fainting man, and all stood trembling and nearly hypnotized
+with horror.
+
+In a natural glade of the swamp stood a grassy island of perhaps an
+acre's extent, clear of trees and tolerably dry. On this now leaped and
+twisted a more indescribable horde of human abnormality than any but a
+Sime or an Angarola could paint. Void of clothing, this hybrid spawn
+were braying, bellowing and writhing about a monstrous ring-shaped
+bonfire; in the center of which, revealed by occasional rifts in the
+curtain of flame, stood a great granite monolith some eight feet in
+height; on top of which, incongruous in its diminutiveness, rested the
+noxious carven statuette. From a wide circle of ten scaffolds set up
+at regular intervals with the flame-girt monolith as a center hung,
+head downward, the oddly marred bodies of the helpless squatters who
+had disappeared. It was inside this circle that the ring of worshipers
+jumped and roared, the general direction of the mass motion being from
+left to right in endless bacchanale between the ring of bodies and the
+ring of fire.
+
+It may have been only imagination and it may have been only echoes
+which induced one of the men, an excitable Spaniard, to fancy he heard
+antiphonal responses to the ritual from some far and unillumined spot
+deeper within the wood of ancient legendry and horror. This man, Joseph
+D. Galvez, I later met and questioned; and he proved distractingly
+imaginative. He indeed went so far as to hint of the faint beating of
+great wings, and of a glimpse of shining eyes and a mountainous white
+bulk beyond the remotest trees--but I suppose he had been hearing too
+much native superstition.
+
+Actually, the horrified pause of the men was of comparatively brief
+duration. Duty came first; and although there must have been nearly a
+hundred mongrel celebrants in the throng, the police relied on their
+firearms and plunged determinedly into the nauseous rout. For five
+minutes the resultant din and chaos were beyond description. Wild
+blows were struck, shots were fired, and escapes were made; but in
+the end Legrasse was able to count some forty-seven sullen prisoners,
+whom he forced to dress in haste and fall into line between two rows
+of policemen. Five of the worshipers lay dead, and two severely
+wounded ones were carried away on improvised stretchers by their
+fellow-prisoners. The image on the monolith, of course, was carefully
+removed and carried back by Legrasse.
+
+Examined at headquarters after a trip of intense strain and weariness,
+the prisoners all proved to be men of a very low, mixed-blooded, and
+mentally aberrant type. Most were seamen, and a sprinkling of negroes
+and mulattoes, largely West Indians or Brava Portuguese from the Cape
+Verde Islands, gave a coloring of voodooism to the heterogeneous cult.
+But before many questions were asked, it became manifest that something
+far deeper and older than negro fetishism was involved. Degraded and
+ignorant as they were, the creatures held with surprizing consistency
+to the central idea of their loathsome faith.
+
+They worshiped, so they said, the Great Old Ones who lived ages before
+there were any men, and who came to the young world out of the sky.
+Those Old Ones were gone now, inside the earth and under the sea; but
+their dead bodies had told their secrets in dreams to the first man,
+who formed a cult which had never died. This was that cult, and the
+prisoners said it had always existed and always would exist, hidden in
+distant wastes and dark places all over the world until the time when
+the great priest Cthulhu, from his dark house in the mighty city of
+R'lyeh under the waters, should rise and bring the earth again beneath
+his sway. Some day he would call, when the stars were ready, and the
+secret cult would always be waiting to liberate him.
+
+Meanwhile no more must be told. There was a secret which even torture
+could not extract. Mankind was not absolutely alone among the conscious
+things of earth, for shapes came out of the dark to visit the faithful
+few. But these were not the Great Old Ones. No man had ever seen the
+Old Ones. The carven idol was great Cthulhu, but none might say whether
+or not the others were precisely like him. No one could read the old
+writing now, but things were told by word of mouth. The chanted ritual
+was not the secret--that was never spoken aloud, only whispered. The
+chant meant only this: "In his house at R'lyeh dead Cthulhu waits
+dreaming."
+
+       *       *       *       *       *
+
+Only two of the prisoners were found sane enough to be hanged, and
+the rest were committed to various institutions. All denied a part
+in the ritual murders, and averred that the killing had been done
+by Black-winged Ones which had come to them from their immemorial
+meeting-place in the haunted wood. But of those mysterious allies no
+coherent account could ever be gained. What the police did extract
+came mainly from an immensely aged mestizo named Castro, who claimed
+to have sailed to strange ports and talked with undying leaders of the
+cult in the mountains of China.
+
+Old Castro remembered bits of hideous legend that paled the
+speculations of theosophists and made man and the world seem recent
+and transient indeed. There had been eons when other Things ruled on
+the earth, and They had had great cities. Remains of Them, he said the
+deathless Chinamen had told him, were still to be found as Cyclopean
+stones on islands in the Pacific. They all died vast epochs of time
+before man came, but there were arts which could revive Them when the
+stars had come round again to the right positions in the cycle of
+eternity. They had, indeed, come themselves from the stars, and brought
+Their images with Them.
+
+These Great Old Ones, Castro continued, were not composed altogether
+of flesh and blood. They had shape--for did not this star-fashioned
+image prove it?--but that shape was not made of matter. When the stars
+were right, They could plunge from world to world through the sky;
+but when the stars were wrong, They could not live. But although They
+no longer lived, They would never really die. They all lay in stone
+houses in Their great city of R'lyeh, preserved by the spells of mighty
+Cthulhu for a glorious resurrection when the stars and the earth might
+once more be ready for Them. But at that time some force from outside
+must serve to liberate Their bodies. The spells that preserved Them
+intact likewise prevented Them from making an initial move, and They
+could only lie awake in the dark and think whilst uncounted millions
+of years rolled by. They knew all that was occurring in the universe,
+for Their mode of speech was transmitted thought. Even now They talked
+in Their tombs. When, after infinities of chaos, the first men came,
+the Great Old Ones spoke to the sensitive among them by molding their
+dreams; for only thus could Their language reach the fleshly minds of
+mammals.
+
+Then, whispered Castro, those first men formed the cult around small
+idols which the Great Ones showed them; idols brought in dim eras
+from dark stars. That cult would never die till the stars came right
+again, and the secret priests would take great Cthulhu from His tomb
+to revive His subjects and resume His rule of earth. The time would
+be easy to know, for then mankind would have become as the Great Old
+Ones; free and wild and beyond good and evil, with laws and morals
+thrown aside and all men shouting and killing and reveling in joy. Then
+the liberated Old Ones would teach them new ways to shout and kill
+and revel and enjoy themselves, and all the earth would flame with a
+holocaust of ecstasy and freedom. Meanwhile the cult, by appropriate
+rites, must keep alive the memory of those ancient ways and shadow
+forth the prophecy of their return.
+
+In the elder time chosen men had talked with the entombed Old Ones in
+dreams, but then something had happened. The great stone city R'lyeh,
+with its monoliths and sepulchers, had sunk beneath the waves; and the
+deep waters, full of the one primal mystery through which not even
+thought can pass, had cut off the spectral intercourse. But memory
+never died, and high priests said that the city would rise again when
+the stars were right. Then came out of the earth the black spirits of
+earth, moldy and shadowy, and full of dim rumors picked up in caverns
+beneath forgotten sea-bottoms. But of them old Castro dared not speak
+much. He cut himself off hurriedly, and no amount of persuasion or
+subtlety could elicit more in this direction. The _size_ of the Old
+Ones, too, he curiously declined to mention. Of the cult, he said that
+he thought the center lay amid the pathless deserts of Arabia, where
+Irem, the City of Pillars, dreams hidden and untouched. It was not
+allied to the European witch-cult, and was virtually unknown beyond its
+members. No book had ever really hinted of it, though the deathless
+Chinamen said that there were double meanings in the _Necronomicon_
+of the mad Arab Abdul Alhazred which the initiated might read as they
+chose, especially the much-discussed couplet:
+
+    "That is not dead which can eternal lie,
+    And with strange eons even death may die."
+
+Legrasse, deeply impressed and not a little bewildered, had inquired
+in vain concerning the historic affiliations of the cult. Castro,
+apparently, had told the truth when he said that it was wholly
+secret. The authorities at Tulane University could shed no light upon
+either cult or image, and now the detective had come to the highest
+authorities in the country and met with no more than the Greenland tale
+of Professor Webb.
+
+       *       *       *       *       *
+
+The feverish interest aroused at the meeting by Legrasse's tale,
+corroborated as it was by the statuette, is echoed in the subsequent
+correspondence of those who attended, although scant mention occurs in
+the formal publication of the society. Caution is the first care of
+those accustomed to face occasional charlatanry and imposture. Legrasse
+for some time lent the image to Professor Webb, but at the latter's
+death it was returned to him and remains in his possession, where I
+viewed it not long ago. It is truly a terrible thing, and unmistakably
+akin to the dream-sculpture of young Wilcox.
+
+That my uncle was excited by the tale of the sculptor I did not
+wonder, for what thoughts must arise upon hearing, after a knowledge
+of what Legrasse had learned of the cult, of a sensitive young man
+who had _dreamed_ not only the figure and exact hieroglyphics of the
+swamp-found image and the Greenland devil tablet, but had come _in his
+dreams_ upon at least three of the precise words of the formula uttered
+alike by Eskimo diabolists and mongrel Louisianans? Professor Angell's
+instant start on an investigation of the utmost thoroughness was
+eminently natural; though privately I suspected young Wilcox of having
+heard of the cult in some indirect way, and of having invented a series
+of dreams to heighten and continue the mystery at my uncle's expense.
+The dream-narratives and cuttings collected by the professor were, of
+course, strong corroboration; but the rationalism of my mind and the
+extravagance of the whole subject led me to adopt what I thought the
+most sensible conclusions. So, after thoroughly studying the manuscript
+again and correlating the theosophical and anthropological notes with
+the cult narrative of Legrasse, I made a trip to Providence to see
+the sculptor and give him the rebuke I thought proper for so boldly
+imposing upon a learned and aged man.
+
+Wilcox still lived alone in the Fleur-de-Lys Building in Thomas
+Street, a hideous Victorian imitation of Seventeenth Century Breton
+architecture which flaunts its stuccoed front amidst the lovely
+Colonial houses on the ancient hill, and under the very shadow of the
+finest Georgian steeple in America. I found him at work in his rooms,
+and at once conceded from the specimens scattered about that his genius
+is indeed profound and authentic. He will, I believe, be heard from
+sometime as one of the great decadents; for he has crystallized in clay
+and will one day mirror in marble those nightmares and fantasies which
+Arthur Machen evokes in prose, and Clark Ashton Smith makes visible in
+verse and in painting.
+
+Dark, frail, and somewhat unkempt in aspect, he turned languidly at my
+knock and asked me my business without rising. When I told him who I
+was, he displayed some interest; for my uncle had excited his curiosity
+in probing his strange dreams, yet had never explained the reason for
+the study. I did not enlarge his knowledge in this regard, but sought
+with some subtlety to draw him out.
+
+In a short time I became convinced of his absolute sincerity, for he
+spoke of the dreams in a manner none could mistake. They and their
+subconscious residuum had influenced his art profoundly, and he showed
+me a morbid statue whose contours almost made me shake with the potency
+of its black suggestion. He could not recall having seen the original
+of this thing except in his own dream bas-relief, but the outlines had
+formed themselves insensibly under his hands. It was, no doubt, the
+giant shape he had raved of in delirium. That he really knew nothing of
+the hidden cult, save from what my uncle's relentless catechism had let
+fall, he soon made clear; and again I strove to think of some way in
+which he could possibly have received the weird impressions.
+
+He talked of his dreams in a strangely poetic fashion; making me
+see with terrible vividness the damp Cyclopean city of slimy green
+stone--whose _geometry_, he oddly said, was _all wrong_--and hear
+with frightened expectancy the ceaseless, half-mental calling from
+underground: "_Cthulhu fhtagn_," "_Cthulhu fhtagn_."
+
+These words had formed part of that dread ritual which told of dead
+Cthulhu's dream-vigil in his stone vault at R'lyeh, and I felt deeply
+moved despite my rational beliefs. Wilcox, I was sure, had heard of
+the cult in some casual way, and had soon forgotten it amidst the mass
+of his equally weird reading and imagining. Later, by virtue of its
+sheer impressiveness, it had found subconscious expression in dreams,
+in the bas-relief, and in the terrible statue I now beheld; so that his
+imposture upon my uncle had been a very innocent one. The youth was of
+a type, at once slightly affected and slightly ill-mannered, which I
+could never like; but I was willing enough now to admit both his genius
+and his honesty. I took leave of him amicably, and wish him all the
+success his talent promises.
+
+The matter of the cult still remained to fascinate me, and at times
+I had visions of personal fame from researches into its origin and
+connections. I visited New Orleans, talked with Legrasse and others
+of that old-time raiding-party, saw the frightful image, and even
+questioned such of the mongrel prisoners as still survived. Old Castro,
+unfortunately, had been dead for some years. What I now heard so
+graphically at first hand, though it was really no more than a detailed
+confirmation of what my uncle had written, excited me afresh; for I
+felt sure that I was on the track of a very real, very secret, and
+very ancient religion whose discovery would make me an anthropologist
+of note. My attitude was still one of absolute materialism, _as I wish
+it still were_, and I discounted with almost inexplicable perversity
+the coincidence of the dream notes and odd cuttings collected by
+Professor Angell.
+
+One thing which I began to suspect, and which I now fear I _know_, is
+that my uncle's death was far from natural. He fell on a narrow hill
+street leading up from an ancient waterfront swarming with foreign
+mongrels, after a careless push from a negro sailor. I did not forget
+the mixed blood and marine pursuits of the cult-members in Louisiana,
+and would not be surprized to learn of secret methods and poison
+needles as ruthless and as anciently known as the cryptic rites and
+beliefs. Legrasse and his men, it is true, have been let alone; but in
+Norway a certain seaman who saw things is dead. Might not the deeper
+inquiries of my uncle after encountering the sculptor's data have come
+to sinister ears? I think Professor Angell died because he knew too
+much, or because he was likely to learn too much. Whether I shall go as
+he did remains to be seen, for I have learned much now.
+
+
+
+
+                    _3. The Madness from the Sea._
+
+
+If heaven ever wishes to grant me a boon, it will be a total effacing
+of the results of a mere chance which fixed my eye on a certain stray
+piece of shelf-paper. It was nothing on which I would naturally have
+stumbled in the course of my daily round, for it was an old number of
+an Australian journal, _Sydney Bulletin_ for April 18, 1925. It had
+escaped even the cutting bureau which had at the time of its issuance
+been avidly collecting material for my uncle's research.
+
+I had largely given over my inquiries into what Professor Angell called
+the "Cthulhu Cult," and was visiting a learned friend of Paterson,
+New Jersey, the curator of a local museum and a mineralogist of note.
+Examining one day the reserve specimens roughly set on the storage
+shelves in a rear room of the museum, my eye was caught by an odd
+picture in one of the old papers spread beneath the stones. It was the
+_Sydney Bulletin_ I have mentioned, for my friend has wide affiliations
+in all conceivable foreign parts; and the picture was a half-tone cut
+of a hideous stone image almost identical with that which Legrasse had
+found in the swamp.
+
+Eagerly clearing the sheet of its precious contents, I scanned the item
+in detail; and was disappointed to find it of only moderate length.
+What it suggested, however, was of portentous significance to my
+flagging quest; and I carefully tore it out for immediate action. It
+read as follows:
+
+                     MYSTERY DERELICT FOUND AT SEA
+
+    _Vigilant_ Arrives With Helpless Armed New Zealand Yacht in Tow.
+    One Survivor and Dead Man Found Aboard. Tale of Desperate Battle
+    and Deaths at Sea. Rescued Seaman Refuses Particulars of Strange
+    Experience. Odd Idol Found in His Possession. Inquiry to Follow.
+
+        *       *       *       *       *
+
+    The Morrison Co.'s freighter _Vigilant_, bound from Valparaiso,
+    arrived this morning at its wharf in Darling Harbour, having in tow
+    the battled and disabled but heavily armed steam yacht _Alert_ of
+    Dunedin, N. Z., which was sighted April 12th in S. Latitude 34° 21',
+    W. Longitude 152° 17', with one living and one dead man aboard.
+
+    The _Vigilant_ left Valparaiso March 25th, and on April 2d was
+    driven considerably south of her course by exceptionally heavy
+    storms and monster waves. On April 12th the derelict was sighted;
+    and though apparently deserted, was found upon boarding to contain
+    one survivor in a half-delirious condition and one man who had
+    evidently been dead for more than a week.
+
+    The living man was clutching a horrible stone idol of unknown
+    origin, about a foot in height, regarding whose nature authorities
+    at Sydney University, the Royal Society, and the Museum in College
+    Street all profess complete bafflement, and which the survivor says
+    he found in the cabin of the yacht, in a small carved shrine of
+    common pattern.
+
+    This man, after recovering his senses, told an exceedingly strange
+    story of piracy and slaughter. He is Gustaf Johansen, a Norwegian
+    of some intelligence, and had been second mate of the two-masted
+    schooner _Emma_ of Auckland, which sailed for Callao February 20th,
+    with a complement of eleven men.
+
+    The _Emma_, he says, was delayed and thrown widely south of her
+    course by the great storm of March 1st, and on March 22d, in S.
+    Latitude 49° 51´, W. Longitude 128° 34´, encountered the _Alert_,
+    manned by a queer and evil-looking crew of Kanakas and half-castes.
+    Being ordered peremptorily to turn back, Capt. Collins refused;
+    whereupon the strange crew began to fire savagely and without
+    warning upon the schooner with a peculiarly heavy battery of brass
+    cannon forming part of the yacht's equipment.
+
+    The _Emma's_ men showed fight, says the survivor, and though the
+    schooner began to sink from shots beneath the waterline they managed
+    to heave alongside their enemy and board her, grappling with the
+    savage crew on the yacht's deck, and being forced to kill them all,
+    the number being slightly superior, because of their particularly
+    abhorrent and desperate though rather clumsy mode of fighting.
+
+    Three of the _Emma's_ men, including Capt. Collins and First Mate
+    Green, were killed; and the remaining eight under Second Mate
+    Johansen proceeded to navigate the captured yacht, going ahead in
+    their original direction to see if any reason for their ordering
+    back had existed.
+
+    The next day, it appears, they raised and landed on a small island,
+    although none is known to exist in that part of the ocean; and six
+    of the men somehow died ashore, though Johansen is queerly reticent
+    about this part of his story and speaks only of their falling into
+    a rock chasm.
+
+    Later, it seems, he and one companion boarded the yacht and tried
+    to manage her, but were beaten about by the storm of April 2nd.
+
+    From that time till his rescue on the 12th, the man remembers
+    little, and he does not even recall when William Briden, his
+    companion, died. Briden's death reveals no apparent cause, and was
+    probably due to excitement or exposure.
+
+    Cable advices from Dunedin report that the _Alert_ was well known
+    there as an island trader, and bore an evil reputation along the
+    waterfront. It was owned by a curious group of half-castes whose
+    frequent meetings and night trips to the woods attracted no little
+    curiosity; and it had set sail in great haste just after the storm
+    and earth tremors of March 1st.
+
+    Our Auckland correspondent gives the _Emma_ and her crew an
+    excellent reputation, and Johansen is described as a sober and
+    worthy man.
+
+    The admiralty will institute an inquiry on the whole matter
+    beginning tomorrow, at which every effort will be made to induce
+    Johansen to speak more freely than he has done hitherto.
+
+       *       *       *       *       *
+
+This was all, together with the picture of the hellish image; but what
+a train of ideas it started in my mind! Here were new treasuries of
+data on the Cthulhu Cult, and evidence that it had strange interests
+at sea as well as on land. What motive prompted the hybrid crew to
+order back the _Emma_ as they sailed about with their hideous idol?
+What was the unknown island on which six of the _Emma's_ crew had
+died, and about which the mate Johansen was so secretive? What had the
+vice-admiralty's investigation brought out, and what was known of the
+noxious cult in Dunedin? And most marvelous of all, what deep and more
+than natural linkage of dates was this which gave a malign and now
+undeniable significance to the various turns of events so carefully
+noted by my uncle?
+
+March 1st--our February 28th according to the International Date
+Line--the earthquake and storm had come. From Dunedin the _Alert_ and
+her noisome crew had darted eagerly forth as if imperiously summoned,
+and on the other side of the earth poets and artists had begun to
+dream of a strange, dank Cyclopean city whilst a young sculptor had
+molded in his sleep the form of the dreaded Cthulhu. March 23rd the
+crew of the _Emma_ landed on an unknown island and left six men dead;
+and on that date the dreams of sensitive men assumed a heightened
+vividness and darkened with dread of a giant monster's malign pursuit,
+whilst an architect had gone mad and a sculptor had lapsed suddenly
+into delirium! And what of this storm of April 2nd--the date on which
+all dreams of the dank city ceased, and Wilcox emerged unharmed from
+the bondage of strange fever? What of all this--and of those hints of
+old Castro about the sunken, star-born Old Ones and their coming reign;
+their faithful cult _and their mastery of dreams_? Was I tottering on
+the brink of cosmic horrors beyond man's power to bear? If so, they
+must be horrors of the mind alone, for in some way the second of April
+had put a stop to whatever monstrous menace had begun its siege of
+mankind's soul.
+
+       *       *       *       *       *
+
+That evening, after a day of hurried cabling and arranging, I bade my
+host adieu and took a train for San Francisco. In less than a month
+I was in Dunedin; where, however, I found that little was known of
+the strange cult-members who had lingered in the old sea taverns.
+Waterfront scum was far too common for special mention; though there
+was vague talk about one inland trip these mongrels had made, during
+which faint drumming and red flame were noted on the distant hills.
+
+In Auckland I learned that Johansen had returned _with yellow hair
+turned white_ after a perfunctory and inconclusive questioning at
+Sydney, and had thereafter sold his cottage in West Street and sailed
+with his wife to his old home in Oslo. Of his stirring experience
+he would tell his friends no more than he had told the admiralty
+officials, and all they could do was to give me his Oslo address.
+
+After that I went to Sydney and talked profitlessly with seamen and
+members of the vice-admiralty court. I saw the _Alert_, now sold and
+in commercial use, at Circular Quay in Sydney Cove, but gained nothing
+from its non-committal bulk. The crouching image with its cuttlefish
+head, dragon body, scaly wings, and hieroglyphed pedestal, was
+preserved in the Museum at Hyde Park; and I studied it long and well,
+finding it a thing of balefully exquisite workmanship, and with the
+same utter mystery, terrible antiquity, and unearthly strangeness of
+material which I had noted in Legrasse's smaller specimen. Geologists,
+the curator told me, had found it a monstrous puzzle; for they vowed
+that the world held no rock like it. Then I thought with a shudder of
+what old Castro had told Legrasse about the primal Great Ones: "They
+had come from the stars, and had brought Their images with Them."
+
+Shaken with such a mental revolution as I had never before known, I
+now resolved to visit Mate Johansen in Oslo. Sailing for London, I
+re-embarked at once for the Norwegian capital; and one autumn day
+landed at the trim wharves in the shadow of the Egeberg.
+
+Johansen's address, I discovered, lay in the Old Town of King Harold
+Haardrada, which kept alive the name of Oslo during all the centuries
+that the greater city masqueraded as "Christiania." I made the brief
+trip by taxicab, and knocked with palpitant heart at the door of a neat
+and ancient building with plastered front. A sad-faced woman in black
+answered my summons, and I was stung with disappointment when she told
+me in halting English that Gustaf Johansen was no more.
+
+He had not long survived his return, said his wife, for the doings at
+sea in 1925 had broken him. He had told her no more than he had told
+the public, but had left a long manuscript--of "technical matters" as
+he said--written in English, evidently in order to safeguard her from
+the peril of casual perusal. During a walk through a narrow lane near
+the Gothenburg dock, a bundle of papers falling from an attic window
+had knocked him down. Two Lascar sailors at once helped him to his
+feet, but before the ambulance could reach him he was dead. Physicians
+found no adequate cause for the end, and laid it to heart trouble and a
+weakened constitution.
+
+I now felt gnawing at my vitals that dark terror which will never leave
+me till I, too, am at rest; "accidentally" or otherwise. Persuading the
+widow that my connection with her husband's "technical matters" was
+sufficient to entitle me to his manuscript, I bore the document away
+and began to read it on the London boat.
+
+It was a simple, rambling thing--a naive sailor's effort at a
+post-facto diary--and strove to recall day by day that last awful
+voyage. I can not attempt to transcribe it verbatim in all its
+cloudiness and redundance, but I will tell its gist enough to show why
+the sound of the water against the vessel's sides became so unendurable
+to me that I stopped my ears with cotton.
+
+Johansen, thank God, did not know quite all, even though he saw the
+city and the Thing, but I shall never sleep calmly again when I think
+of the horrors that lurk ceaselessly behind life in time and in space,
+and of those unhallowed blasphemies from elder stars which dream
+beneath the sea, known and favored by a nightmare cult ready and eager
+to loose them on the world whenever another earthquake shall heave
+their monstrous stone city again to the sun and air.
+
+       *       *       *       *       *
+
+Johansen's voyage had begun just as he told it to the vice-admiralty.
+The _Emma_, in ballast, had cleared Auckland on February 20th, and had
+felt the full force of that earthquake-born tempest which must have
+heaved up from the sea-bottom the horrors that filled men's dreams.
+Once more under control, the ship was making good progress when held
+up by the _Alert_ on March 22nd, and I could feel the mate's regret as
+he wrote of her bombardment and sinking. Of the swarthy cult-fiends
+on the _Alert_ he speaks with significant horror. There was some
+peculiarly abominable quality about them which made their destruction
+seem almost a duty, and Johansen shows ingenuous wonder at the charge
+of ruthlessness brought against his party during the proceedings of the
+court of inquiry. Then, driven ahead by curiosity in their captured
+yacht under Johansen's command, the men sight a great stone pillar
+sticking out of the sea, and in S. Latitude 47° 9', W. Longitude 126°
+43' come upon a coastline of mingled mud, ooze, and weedy Cyclopean
+masonry which can be nothing less than the tangible substance of
+earth's supreme terror--the nightmare corpse-city of R'lyeh, that
+was built in measureless eons behind history by the vast, loathsome
+shapes that seeped down from the dark stars. There lay great Cthulhu
+and his hordes, hidden in green slimy vaults and sending out at last,
+after cycles incalculable, the thoughts that spread fear to the dreams
+of the sensitive and called imperiously to the faithful to come on a
+pilgrimage of liberation and restoration. All this Johansen did not
+suspect, but God knows he soon saw enough!
+
+I suppose that only a single mountain-top, the hideous monolith-crowned
+citadel whereon great Cthulhu was buried, actually emerged from the
+waters. When I think of the _extent_ of all that may be brooding down
+there I almost wish to kill myself forthwith. Johansen and his men were
+awed by the cosmic majesty of this dripping Babylon of elder demons,
+and must have guessed without guidance that it was nothing of this or
+of any sane planet. Awe at the unbelievable size of the greenish stone
+blocks, at the dizzying height of the great carven monolith, and at the
+stupefying identity of the colossal statues and bas-reliefs with the
+queer image found in the shrine on the _Alert_, is poignantly visible
+in every line of the mate's frightened description.
+
+Without knowing what futurism is like, Johansen achieved something
+very close to it when he spoke of the city; for instead of describing
+any definite structure or building, he dwells only on the broad
+impressions of vast angles and stone surfaces--surfaces too great to
+belong to anything right or proper for this earth, and impious with
+horrible images and hieroglyphs. I mention his talk about _angles_
+because it suggests something Wilcox had told me of his awful dreams.
+He had said that the _geometry_ of the dream-place he saw was abnormal,
+non-Euclidean, and loathsomely redolent of spheres and dimensions apart
+from ours. Now an unlettered seaman felt the same thing whilst gazing
+at the terrible reality.
+
+Johansen and his men landed at a sloping mud-bank on this monstrous
+Acropolis, and clambered slipperily up over titan oozy blocks which
+could have been no mortal staircase. The very sun of heaven seemed
+distorted when viewed through the polarizing miasma welling out from
+this sea-soaked perversion, and twisted menace and suspense lurked
+leeringly in those crazily elusive angles of carven rock where a second
+glance showed concavity after the first showed convexity.
+
+Something very like fright had come over all the explorers before
+anything more definite than rock and ooze and weed was seen. Each
+would have fled had he not feared the scorn of the others, and it was
+only half-heartedly that they searched--vainly, as it proved--for some
+portable souvenir to bear away.
+
+It was Rodriguez the Portuguese who climbed up the foot of the monolith
+and shouted of what he had found. The rest followed him, and looked
+curiously at the immense carved door with the now familiar squid-dragon
+bas-relief. It was, Johansen said, like a great barn-door; and they all
+felt that it was a door because of the ornate lintel, threshold, and
+jambs around it, though they could not decide whether it lay flat like
+a trap-door or slantwise like an outside cellar-door. As Wilcox would
+have said, the geometry of the place was all wrong. One could not be
+sure that the sea and the ground were horizontal, hence the relative
+position of everything else seemed fantasmally variable.
+
+Briden pushed at the stone in several places without result. Then
+Donovan felt over it delicately around the edge, pressing each point
+separately as he went. He climbed interminably along the grotesque
+stone molding--that is, one would call it climbing if the thing was not
+after all horizontal--and the men wondered how any door in the universe
+could be so vast. Then, very softly and slowly, the acre-great panel
+began to give inward at the top; and they saw that it was balanced.
+
+Donovan slid or somehow propelled himself down or along the jamb and
+rejoined his fellows, and everyone watched the queer recession of the
+monstrously carven portal. In this fantasy of prismatic distortion it
+moved anomalously in a diagonal way, so that all the rules of matter
+and perspective seemed upset.
+
+The aperture was black with a darkness almost material. That
+tenebrousness was indeed a _positive quality_; for it obscured such
+parts of the inner walls as ought to have been revealed, and actually
+burst forth like smoke from its eon-long imprisonment, visibly
+darkening the sun as it slunk away into the shrunken and gibbous sky
+on flapping membranous wings. The odor arising from the newly opened
+depths was intolerable, and at length the quick-eared Hawkins thought
+he heard a nasty, slopping sound down there. Everyone listened, and
+everyone was listening still when It lumbered slobberingly into sight
+and gropingly squeezed Its gelatinous green immensity through the black
+doorway into the tainted outside air of that poison city of madness.
+
+Poor Johansen's handwriting almost gave out when he wrote of this. Of
+the six men who never reached the ship, he thinks two perished of pure
+fright in that accursed instant. The Thing can not be described--there
+is no language for such abysms of shrieking and immemorial lunacy,
+such eldritch contradictions of all matter, force, and cosmic order.
+A mountain walked or stumbled. God! What wonder that across the earth
+a great architect went mad, and poor Wilcox raved with fever in that
+telepathic instant? The Thing of the idols, the green, sticky spawn of
+the stars, had awaked to claim his own. The stars were right again, and
+what an age-old cult had failed to do by design, a band of innocent
+sailors had done by accident. After vigintillions of years great
+Cthulhu was loose again, and ravening for delight.
+
+Three men were swept up by the flabby claws before anybody turned. God
+rest them, if there be any rest in the universe. They were Donovan,
+Guerrera and Angstrom. Parker slipped as the other three were plunging
+frenziedly over endless vistas of green-crusted rock to the boat,
+and Johansen swears he was swallowed up by an angle of masonry which
+shouldn't have been there; an angle which was acute, but behaved as
+if it were obtuse. So only Briden and Johansen reached the boat, and
+pulled desperately for the _Alert_ as the mountainous monstrosity
+flopped down the slimy stones and hesitated floundering at the edge of
+the water.
+
+Steam had not been suffered to go down entirely, despite the departure
+of all hands for the shore; and it was the work of only a few moments
+of feverish rushing up and down between wheels and engines to get
+the _Alert_ under way. Slowly, amidst the distorted horrors of that
+indescribable scene, she began to churn the lethal waters; whilst on
+the masonry of that charnel shore that was not of earth the titan Thing
+from the stars slavered and gibbered like Polypheme cursing the fleeing
+ship of Odysseus. Then, bolder than the storied Cyclops, great Cthulhu
+slid greasily into the water and began to pursue with vast wave-raising
+strokes of cosmic potency. Briden looked back and went mad, laughing
+shrilly as he kept on laughing at intervals till death found him one
+night in the cabin whilst Johansen was wandering deliriously.
+
+But Johansen had not given out yet. Knowing that the Thing could
+surely overtake the _Alert_ until steam was fully up, he resolved
+on a desperate chance; and, setting the engine for full speed, ran
+lightning-like on deck and reversed the wheel. There was a mighty
+eddying and foaming in the noisome brine, and as the steam mounted
+higher and higher the brave Norwegian drove his vessel head on against
+the pursuing jelly which rose above the unclean froth like the stern
+of a demon galleon. The awful squid-head with writhing feelers came
+nearly up to the bowsprit of the sturdy yacht, but Johansen drove on
+relentlessly.
+
+There was a bursting as of an exploding bladder, a slushy nastiness
+as of a cloven sunfish, a stench as of a thousand opened graves, and
+a sound that the chronicler would not put on paper. For an instant
+the ship was befouled by an acrid and blinding green cloud, and then
+there was only a venomous seething astern; where--God in heaven!--the
+scattered plasticity of that nameless sky-spawn was nebulously
+_recombining_ in its hateful original form, whilst its distance widened
+every second as the _Alert_ gained impetus from its mounting steam.
+
+       *       *       *       *       *
+
+That was all. After that Johansen only brooded over the idol in the
+cabin and attended to a few matters of food for himself and the
+laughing maniac by his side. He did not try to navigate after the first
+bold flight, for the reaction had taken something out of his soul. Then
+came the storm of April 2nd, and a gathering of the clouds about his
+consciousness. There is a sense of spectral whirling through liquid
+gulfs of infinity, of dizzying rides through reeling universes on a
+comet's tail, and of hysterical plunges from the pit to the moon and
+from the moon back again to the pit, all livened by a cachinnating
+chorus of the distorted, hilarious elder gods and the green, bat-winged
+mocking imps of Tartarus.
+
+Out of that dream came rescue--the _Vigilant_, the vice-admiralty
+court, the streets of Dunedin, and the long voyage back home to the
+old house by the Egeberg. He could not tell--they would think him mad.
+He would write of what he knew before death came, but his wife must not
+guess. Death would be a boon if only it could blot out the memories.
+
+That was the document I read, and now I have placed it in the tin box
+beside the bas-relief and the papers of Professor Angell. With it shall
+go this record of mine--this test of my own sanity, wherein is pieced
+together that which I hope may never be pieced together again. I have
+looked upon all that the universe has to hold of horror, and even the
+skies of spring and the flowers of summer must ever afterward be poison
+to me. But I do not think my life will be long. As my uncle went, as
+poor Johansen went, so I shall go. I know too much, and the cult still
+lives.
+
+Cthulhu still lives, too, I suppose, again in that chasm of stone
+which has shielded him since the sun was young. His accursed city is
+sunken once more, for the _Vigilant_ sailed over the spot after the
+April storm; but his ministers on earth still bellow and prance and
+slay around idol-capped monoliths in lonely places. He must have been
+trapped by the sinking whilst within his black abyss, or else the world
+would by now be screaming with fright and frenzy. Who knows the end?
+What has risen may sink, and what has sunk may rise. Loathsomeness
+waits and dreams in the deep, and decay spreads over the tottering
+cities of men. A time will come--but I must not and can not think! Let
+me pray that, if I do not survive this manuscript, my executors may put
+caution before audacity and see that it meets no other eye.
+
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK THE CALL OF CTHULHU ***
+
+
+    
+
+Updated editions will replace the previous one—the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg™ electronic works to protect the PROJECT GUTENBERG™
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away—you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg™ mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg™ License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg™
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg™
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg™ electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg™ electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the person
+or entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg™ electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg™ electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg™
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the
+Foundation” or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg™ electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg™ mission of promoting
+free access to electronic works by freely sharing Project Gutenberg™
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg™ name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg™ License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg™ work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg™ License must appear
+prominently whenever any copy of a Project Gutenberg™ work (any work
+on which the phrase “Project Gutenberg” appears, or with which the
+phrase “Project Gutenberg” is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+    This eBook is for the use of anyone anywhere in the United States and most
+    other parts of the world at no cost and with almost no restrictions
+    whatsoever. You may copy it, give it away or re-use it under the terms
+    of the Project Gutenberg License included with this eBook or online
+    at www.gutenberg.org. If you
+    are not located in the United States, you will have to check the laws
+    of the country where you are located before using this eBook.
+  
+1.E.2. If an individual Project Gutenberg™ electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase “Project
+Gutenberg” associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg™
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg™ electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg™ License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg™
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg™.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg™ License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg™ work in a format
+other than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg™ website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the
+full Project Gutenberg™ License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg™ works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg™ electronic works
+provided that:
+
+    • You pay a royalty fee of 20% of the gross profits you derive from
+        the use of Project Gutenberg™ works calculated using the method
+        you already use to calculate your applicable taxes. The fee is owed
+        to the owner of the Project Gutenberg™ trademark, but he has
+        agreed to donate royalties under this paragraph to the Project
+        Gutenberg Literary Archive Foundation. Royalty payments must be paid
+        within 60 days following each date on which you prepare (or are
+        legally required to prepare) your periodic tax returns. Royalty
+        payments should be clearly marked as such and sent to the Project
+        Gutenberg Literary Archive Foundation at the address specified in
+        Section 4, “Information about donations to the Project Gutenberg
+        Literary Archive Foundation.”
+    
+    • You provide a full refund of any money paid by a user who notifies
+        you in writing (or by e-mail) within 30 days of receipt that s/he
+        does not agree to the terms of the full Project Gutenberg™
+        License. You must require such a user to return or destroy all
+        copies of the works possessed in a physical medium and discontinue
+        all use of and all access to other copies of Project Gutenberg™
+        works.
+    
+    • You provide, in accordance with paragraph 1.F.3, a full refund of
+        any money paid for a work or a replacement copy, if a defect in the
+        electronic work is discovered and reported to you within 90 days of
+        receipt of the work.
+    
+    • You comply with all other terms of this agreement for free
+        distribution of Project Gutenberg™ works.
+    
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg™ electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg™ trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg™ collection. Despite these efforts, Project Gutenberg™
+electronic works, and the medium on which they may be stored, may
+contain “Defects,” such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg™ trademark, and any other party distributing a Project
+Gutenberg™ electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’, WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg™ electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg™
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg™ work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg™ work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg™
+
+Project Gutenberg™ is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg™’s
+goals and ensuring that the Project Gutenberg™ collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg™ and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at www.gutenberg.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation’s EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state’s laws.
+
+The Foundation’s business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation’s website
+and official page at www.gutenberg.org/contact
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg™ depends upon and cannot survive without widespread
+public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit www.gutenberg.org/donate.
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate.
+
+Section 5. General Information About Project Gutenberg™ electronic works
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg™ concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg™ eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg™ eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org.
+
+This website includes information about Project Gutenberg™,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/corpora/originals/innsmouthOG.txt
+++ b/corpora/originals/innsmouthOG.txt
@@ -1,0 +1,2106 @@
+﻿The Project Gutenberg eBook of The shadow over Innsmouth
+    
+This ebook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this ebook or online
+at www.gutenberg.org. If you are not located in the United States,
+you will have to check the laws of the country where you are located
+before using this eBook.
+
+Title: The shadow over Innsmouth
+
+Author: H. P. Lovecraft
+
+Illustrator: Hannes Bok
+
+Release date: March 16, 2024 [eBook #73181]
+
+Language: English
+
+Original publication: New York, NY: Weird Tales, 1941
+
+Credits: Greg Weeks, Mary Meehan and the Online Distributed Proofreading Team at http://www.pgdp.net
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK THE SHADOW OVER INNSMOUTH ***
+
+
+
+
+
+                       The Shadow Over Innsmouth
+
+                        _Horrifying Novelette_
+
+                          By H. P. LOVECRAFT
+
+                 _Unspeakable monstrousness over-hung
+                 the crumbling, stench-cursed town of
+               Innsmouth ... and folks there had somehow
+                   got out of the idea of dying...._
+
+           [Transcriber's Note: This etext was produced from
+                       Weird Tales January 1942.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+
+During the winter of 1927-28 Federal government officials made a
+strange and secret investigation of certain conditions in the ancient
+Massachusetts seaport of Innsmouth. The public first learned of it in
+February, when a vast series of raids and arrests occurred, followed by
+the deliberate burning and dynamiting--under suitable precautions--of
+an enormous number of crumbling, worm-eaten, and supposedly empty
+houses along the abandoned waterfront. Uninquiring souls let this
+occurrence pass as one of the major clashes in a spasmodic war on
+liquor.
+
+Keener news-followers, however, wondered at the prodigious number of
+arrests, the abnormally large force of men used in making them, and
+the secrecy surrounding the disposal of the prisoners. No trials, or
+even definite charges, were reported; nor were any of the captives
+seen thereafter in the regular jails of the nation. There were vague
+statements about disease and concentration camps, and later about
+dispersal in various naval and military prisons, but nothing positive
+ever developed.
+
+Complaints from many liberal organizations were met with long
+confidential discussions, and representatives were taken on trips
+to certain camps and prisons. As a result, these societies became
+surprisingly passive and reticent. Newspaper men were harder to
+manage, but seemed largely to cooperate with the government in the
+end. Only one paper--a tabloid always discounted because of its
+wild policy--mentioned the deep-diving submarine that discharged
+torpedoes downward in the marine abyss just beyond Devil Reef. That
+item, gathered by chance in a haunt of sailors, seemed indeed rather
+far-fetched; since the low, black reef lies a full mile and a half out
+from Innsmouth Harbor.
+
+But at last I am going to defy the ban on speech about this thing.
+Results, I am certain, are so thorough that no public harm save a shock
+of repulsion could ever accrue from a hinting of what was found by
+those horrified raiders at Innsmouth. For my contact with this affair
+has been closer than that of any other layman, and I have carried away
+impressions which are yet to drive me to drastic measures.
+
+It was I who fled frantically out of Innsmouth in the early morning
+hours of July 16, 1927, and whose frightened appeals for government
+inquiry and action brought on the whole reported episode. I was willing
+enough to stay mute while the affair was fresh and uncertain; but now
+that it is an old story, with public interest and curiosity gone, I
+have an odd craving to whisper about those few frightful hours in
+that ill-rumored and evilly-shadowed seaport of death and blasphemous
+abnormality.
+
+I never heard of Innsmouth till the day before I saw it for the first
+and--so far--last time. I was celebrating my coming of age by a tour
+of New England--sightseeing, antiquarian, and genealogical--and had
+planned to go directly from ancient Newburyport to Arkham, whence my
+mother's family was derived. I had no car, but was traveling by train,
+trolley, and motor-coach, always seeking the cheapest possible route.
+In Newburyport they told me that the steam train was the thing to
+take to Arkham; and it was only at the station ticket-office, when I
+demurred at the high fare, that I learned about Innsmouth. The stout,
+shrewd-faced agent, whose speech showed him to be no local man, seemed
+sympathetic toward my efforts at economy, and made a suggestion that
+none of my other informants had offered.
+
+"You _could_ take that old bus, I suppose," he said with a certain
+hesitation, "but it ain't thought much of hereabouts. It goes through
+Innsmouth--you may have heard about that--and so the people don't
+like it. Run by an Innsmouth fellow--Joe Sargent--but never gets any
+custom from here, or Arkham either, I guess. Leaves the Square--front
+of Hammond's Drug Store--at 10 A.M. and 7 P.M. unless they've changed
+lately. Looks like a terrible rattletrap--I've never been on it."
+
+That was the first I ever heard of shadowed Innsmouth. Any reference
+to a town not shown on common maps or listed in recent guidebooks
+would have interested me, and the agent's old manner of allusion
+roused something like real curiosity. So I asked the agent to tell me
+something about it.
+
+He was very deliberate, and spoke with an air of feeling slightly
+superior to what he said.
+
+"Innsmouth? Well, it's a queer kind of town down at the mouth of
+the Manuxet. Used to be almost a city--quite a port before the War
+of 1812--but all gone to pieces in the last hundred years or so. No
+railroad now--B. & M. never went through, and the branch line from
+Rowley was given up years ago.
+
+"More empty houses than there are people, I guess, and no business to
+speak of except fishing and lobstering. Everybody trades mostly either
+here or in Arkham or Ipswich. Once they had quite a few mills, but
+nothing's left now except one gold refinery running on the leanest kind
+of part time.
+
+"That refinery, though, used to be a big thing, and Old Man Marsh,
+who owns it, must be richer'n Croesus. Queer old duck, though, and
+sticks mighty close in his home. He's supposed to have developed
+some skin disease or deformity late in life that makes him keep out
+of sight. Grandson of Captain Obed Marsh, who founded the business.
+His mother seems to've been some kind of foreigner--they say a South
+Sea islander--so everybody raised Cain when he married an Ipswich
+girl fifty years ago. They always do that about Innsmouth people, and
+folks here and hereabouts always try to cover up any Innsmouth blood
+they have in 'em. But Marsh's children and grandchildren look just
+like anybody else so far's I can see. I've had 'em pointed out to me
+here--though, come to think of it, the elder children don't seem to be
+around lately. Never saw the old man.
+
+"And why is everybody so down on Innsmouth? Well, young fellow, you
+mustn't take too much stock in what people around here say. They're
+hard to get started, but once they do get started they never let
+up. They've been telling things about Innsmouth--whispering 'em,
+mostly--for the last hundred years, I guess, and I gather they're
+more scared than anything else. Some of the stories would make you
+laugh--about old Captain Marsh driving bargains with the devil and
+bringing imps out of hell to live in Innsmouth, or about some kind of
+devil-worship and awful sacrifices in some place near the wharves that
+people stumbled on around 1845 or there-abouts--but I come from Panton,
+Vermont, and that kind of story don't go down with me.
+
+"You ought to hear, though, what some of the old-timers tell about
+the black reef off the coast--Devil Reef, they call it. It's well
+above water a good part of the time, and never much below it, but at
+that you could hardly call it an island. The story is that there's a
+whole legion of devils seen sometimes on that reef--sprawled about,
+or darting in and out of some kind of caves near the top. It's a
+rugged, uneven thing, a good bit over a mile out, and toward the end of
+shipping days sailors used to make big detours just to avoid it.
+
+"That is, sailors that didn't hail from Innsmouth. One of the things
+they had against old Captain Marsh was that he was supposed to land on
+it sometimes at night when the tide was right. Maybe he did, for I dare
+say the rock formation was interesting, and it's just barely possible
+he was looking for pirate loot and maybe finding it; but there was talk
+of his dealing with demons there. Fact is, I guess on the whole it was
+really the captain that gave the bad reputation to the reef.
+
+"That was before the big epidemic of 1846, when over half the folks
+in Innsmouth was carried off. They never did quite figure out what
+the trouble was, but it was probably some foreign kind of disease
+brought from China or somewhere by the shipping. It surely was bad
+enough--there was riots over it, and all sorts of ghastly doings that I
+don't believe ever got outside of town--and it left the place in awful
+shape. Never came back--there can't be more'n 300 or 400 people living
+there now.
+
+"But the real thing behind the way folks feel is simply race
+prejudice--and I don't say I'm blaming those that hold it. I hate
+those Innsmouth folks myself, and I wouldn't care to go to their
+town. I s'pose you know--though I can see you're a Westerner by your
+talk--what a lot our New England ships used to have to do with queer
+ports in Africa, Asia, the South Seas, and everywhere else, and what
+queer kinds of people they sometimes brought back with 'em. You've
+probably heard about the Salem man that came home with a Chinese wife,
+and maybe you know there's still a bunch of Fiji Islanders somewhere
+around Cape Cod.
+
+"Well, there must be something like that back of the Innsmouth people.
+The place always was badly cut off from the rest of the country by
+marshes and creeks, and we can't be sure about the ins and outs of
+the matter; but it's pretty clear that old Captain Marsh must have
+brought home some odd specimens when he had all three of his ships in
+commission back in the twenties and thirties. There certainly is a
+strange kind of a streak in the Innsmouth folks today--I don't know how
+to explain it, but it sort of makes you crawl. You'll notice a little
+in Sargent if you take his bus. Some of 'em have queer narrow heads
+with flat noses and bulgy, starey eyes that never seem to shut, and
+their skin ain't quite right. Rough and scabby, and the sides of their
+necks are all shriveled or creased up. Get bald, too, very young. The
+older fellows look the worst--fact is, I don't believe I've ever seen
+a very old chap of that kind. Guess they must die of looking in the
+glass! Animals hate 'em--they used to have lots of horse trouble before
+autos came in.
+
+"Nobody can ever keep track of those people, and state school officials
+and census men have a devil of a time. You can bet that prying
+strangers ain't welcome around Innsmouth. I've heard personally of
+more'n one business or government man that's disappeared there, and
+there's loose talk of one who went crazy and is out at Danvers now.
+They must have fixed up some awful scare for that fellow.
+
+"That's why I wouldn't go at night if I was you. I've never been there
+and have no wish to go, but I guess a daytime trip couldn't hurt
+you--even though the people hereabouts will advise you not to make it.
+If you're just sightseeing, and looking for old-time stuff, Innsmouth
+ought to be quite a place for you."
+
+And so I spent part of that evening at the Newburyport Public Library
+looking up data about Innsmouth. The Essex County histories on the
+library shelves had very little to say, except that the town was
+founded in 1643, noted for shipbuilding before the Revolution, a seat
+of great marine prosperity in the early 19th century, and later a minor
+factory center using the Manuxet as power. The epidemic and riots of
+1846 were very sparsely treated, as if they formed a discredit to the
+country.
+
+References to decline were few, though the significance of the later
+record was unmistakable. After the Civil War all industrial life was
+confined to the Marsh Refining Company, and the marketing of gold
+ingots formed the only remaining bit of major commerce aside from the
+eternal fishing.
+
+Most interesting of all was a glancing reference to the strange jewelry
+vaguely associated with Innsmouth. It had evidently impressed the whole
+countryside more than a little, for mention was made of specimens in
+the museum of Miskatonic University at Arkham, and in the display room
+of the Newburyport Historical Society. I resolved to see the local
+sample--said to be a large, queerly-proportioned thing evidently meant
+for a tiara--if it could possibly be arranged.
+
+The librarian gave me a note of introduction to the curator of the
+Society, a Miss Anna Tilton, who lived nearby, and after a brief
+explanation that ancient gentlewoman was kind enough to pilot me into
+the closed building, since the hour was not outrageously late. The
+collection was a notable one indeed, but in my present mood I had eyes
+for nothing but the bizarre object which glistened in a corner cupboard
+under the electric lights.
+
+It took no excessive sensitiveness to beauty to make me literally gasp
+at the strange, unearthly splendor of the alien, opulent phantasy that
+rested there on a purple velvet cushion. The longer I looked, the more
+the thing fascinated me; and in this fascination there was a curiously
+disturbing element hardly to be classified or accounted for. I decided
+that it was the queer other-worldly quality of the art which made me
+uneasy. It was as if the workmanship were that of another planet.
+
+The patterns all hinted of remote secrets and unimaginable abysses in
+time and space, and the monotonously aquatic nature of the reliefs
+became almost sinister. Among these reliefs were fabulous monsters of
+abhorrent grotesqueness and malignity--wholly primal and awesomely
+ancestral.
+
+At times I fancied that every contour of these blasphemous fish-frogs
+was overflowing with the ultimate quintessence of unknown and inhuman
+evil.
+
+In odd contrast to the tiara's aspect was its brief and prosy history
+as related by Miss Tilton. It had been pawned for a ridiculous sum at
+a shop in State Street in 1873, by a drunken Innsmouth man shortly
+afterward killed in a brawl.
+
+Miss Tilton was inclined to believe that it formed part of some exotic
+pirate hoard discovered by old Captain Obed Marsh. This view was surely
+not weakened by the insistent offers of purchase at a high price
+which the Marshes began to make as soon as they knew of its presence,
+and which they repeated to this day despite the Society's unvarying
+determination not to sell.
+
+As the good lady showed me out of the building, she assured me that the
+rumors of devil-worship were partly justified by a peculiar secret cult
+which had gained force there and engulfed all the orthodox churches.
+
+It was called, she said, "The Esoteric Order of Dagon," and was
+undoubtedly a debased, quasi-pagan thing imported from the East a
+century before, at a time when Innsmouth fisheries seemed to be going
+barren. Its persistence among a simple people was quite natural in view
+of the sudden and permanent return of abundantly fine fishing, and it
+soon came to be the greatest influence on the town.
+
+All this, to the pious Miss Tilton, formed an excellent reason for
+shunning the ancient town of decay and desolation; but to me it was
+merely a fresh incentive; and I could scarcely sleep in my small room
+at the "Y" as the night wore away.
+
+
+
+
+                                  II
+
+
+Shortly before ten the next morning I stood with my one small valise
+in front of Hammond's Drug Store in old Market Square waiting for
+the Innsmouth bus. In a few moments a small motor-coach of extreme
+decrepitude and dirty gray color rattled down State Street, made a
+turn, and drew up at the curb beside me. I felt immediately that
+it was the right one; a guess which the half-illegible sign on the
+windshield--"_Arkham-Innsmouth-Newb'port_"--soon verified.
+
+There were only three passengers--dark, unkempt men of sullen visage
+and somewhat youthful cast--and when the vehicle stopped they clumsily
+shambled out and began walking up State Street in a silent, almost
+furtive fashion. The driver also alighted. This, I reflected, must be
+the Joe Sargent mentioned by the ticket-agent; and even before I had
+noticed any details there spread over me a wave of spontaneous aversion
+which could be neither checked nor explained.
+
+He was a thin, stoop-shouldered man not much under six feet tall,
+dressed in shabby blue civilian clothes and wearing a frayed gray golf
+cap. His age was perhaps thirty-five, but the odd, deep creases in the
+sides of his neck made him seem older when one did not study his dull,
+expressionless face. He had a narrow head, bulging, watery blue eyes
+that seemed never to wink, a flat nose, a receding forehead and chin,
+and singularly undeveloped ears. As he walked toward the bus I observed
+his peculiarly shambling gait and saw that his feet were inordinately
+immense. The more I studied them the more I wondered how he could buy
+any shoes to fit them.
+
+A certain greasiness about the fellow increased my dislike. He was
+evidently given to working or lounging around the fish docks, and
+carried with him much of their characteristic smell. Just what foreign
+blood was in him I could not even guess.
+
+I was sorry when I saw that there would be no other passengers on the
+bus. Somehow I did not like the idea of riding alone with this driver.
+But as the leaving time obviously approached I conquered my qualms and
+followed the man aboard, extending him a dollar bill and murmuring the
+single word "Innsmouth."
+
+At length the decrepit vehicle started with a jerk, and rattled noisily
+past the old brick buildings of State Street amidst a cloud of vapor
+from the exhaust.
+
+The day was warm and sunny, but the landscape of sand, sedge-grass,
+and stunted shrubbery became more and more desolate as we proceeded.
+Out the window I could see the blue water and the sandy line of Plum
+Island, and we presently drew very near the beach as our narrow road
+veered off from the main highway to Rowley and Ipswich.
+
+At last we lost sight of Plum Island and saw the vast expanse of the
+open Atlantic on our left. Our narrow course began to climb steeply,
+and I felt a singular sense of disquiet in looking at the lonely crest
+ahead where the rutted roadway met the sky. It was as if the bus were
+about to keep on its ascent leaving the sane earth altogether and
+merging with the unknown arcana of upper air and cryptical sky. The
+smell of the sea took on ominous implications, and the silent driver's
+bent, rigid back and narrow head became more and more hateful. As I
+looked at him I saw that the back of his head was almost as hairless
+as his face, having only a few straggling yellow strands upon a gray
+scabrous surface.
+
+Then we reached the crest and beheld the outspread valley beyond,
+where the Manuxet joins the sea just north of the long line of cliffs
+that culminate in Kingsport Head; all my attention was captured by the
+nearer panorama just below me. I had, I realized, come face to face
+with rumor-shadowed Innsmouth.
+
+It was a town of wide extent and dense construction, yet one with a
+portentous dearth of visible life. The vast huddle of sagging gambrel
+roofs and peaked gables conveyed with offensive clearness the idea
+of wormy decay, and as we approached along the now descending road I
+could see that many roofs had wholly caved in. Stretching inland I saw
+the rusted, grass-grown line of the abandoned railway, with leaning
+telegraph-poles now devoid of wires.
+
+Here and there the ruins of wharves jutted out from the shore to end
+in indeterminate rottenness, those farthest south seeming the most
+decayed. And far out at sea, despite a high tide, I glimpsed a long,
+black line scarcely rising above the water yet carrying a suggestion of
+odd latent malignancy. This, I knew, must be Devil Reef. As I looked,
+a subtle, curious sense of beckoning seemed superadded to the grim
+repulsion; and oddly enough, I found this overtone more disturbing than
+the primary impression.
+
+As the bus reached a lower level I began to catch the steady note of
+a waterfall through the unnatural stillness. The leaning, unpainted
+houses grew thicker, lined both sides of the road, and displayed more
+urban tendencies than did those we were leaving behind. The panorama
+ahead had contracted to a street scene, and in spots I could see
+where a cobblestone pavement and stretches of brick sidewalk had
+formerly existed. All the houses were apparently deserted, and there
+were occasional gaps where tumbledown chimneys and cellar walls told
+of buildings that had collapsed. Pervading everything was the most
+nauseous fishy odor imaginable.
+
+And I was not to reach my destination without one other very strong
+impression of poignantly disagreeable quality. The bus had come to a
+sort of open concourse or radial point with churches on two sides and
+the bedraggled remains of a circular green in the center, and I was
+looking at a large pillared hall on the right-hand junction ahead. The
+structure's once white paint was now gray and peeling, and the black
+and gold sign on the pediment was so faded that I could only with
+difficulty make out the words "Esoteric Order of Dagon."
+
+The door of the church basement was open, revealing a rectangle of
+blackness inside. And as I looked, a certain object crossed or seemed
+to cross that dark rectangle; burning into my brain a momentary
+conception of nightmare which was all the more maddening because
+analysis could not show a single nightmarish quality in it.
+
+It was a living object--the first except the driver that I had seen
+since entering the compact part of the town--and had I been in a
+steadier mood I would have found nothing whatever of terror in it.
+Clearly, as I realized a moment later, it was the pastor; clad in
+some peculiar vestments doubtless introduced since the Order of Dagon
+had modified the ritual of the local churches. The thing which had
+probably caught my first subconscious glance and supplied the touch of
+bizarre horror was the tall tiara he wore; an almost exact duplicate
+of the one Miss Tilton had shown me the previous evening. This, acting
+on my imagination, had supplied namelessly sinister qualities to the
+indeterminate face and robed, shambling form beneath it.
+
+A very thin sprinkling of repellent-looking youngish people now became
+visible on the sidewalks--lone individuals, and silent knots of two
+or three. The lower floors of the crumbling houses sometimes harbored
+small shops with dingy signs, and I noticed a parked truck or two as we
+rattled along. The sound of waterfalls became more and more distinct,
+and presently I saw a fairly deep river-gorge ahead, spanned by a wide,
+iron-railed highway bridge beyond which a large square opened out. Then
+we rolled into the large semicircular square across the river and drew
+up on the right-hand side in front of a tall, cupola-crowned building
+with remnants of yellow paint and with a half-effaced sign proclaiming
+it to be the Gilman House.
+
+I was glad to get out of that bus, and at once proceeded to check
+my valise in the shabby hotel lobby. There was only one person in
+sight--an elderly man without what I had come to call the "Innsmouth
+look"--and I decided not to ask him any of the questions which bothered
+me; remembering that odd things had been noticed in this hotel.
+Instead, I strolled out on the square, from which the bus had already
+gone, and studied the scene minutely and appraisingly.
+
+For some reason or other I chose to make my first inquiries at
+the chain grocery, whose personnel was not likely to be native to
+Innsmouth. I found a solitary boy of about seventeen in charge, and was
+pleased to note the brightness and affability which promised cheerful
+information. He seemed exceptionally eager to talk, and I soon gathered
+that he did not like the place, its fishy smell, or its furtive people.
+His family did not like him to work in Innsmouth, but the chain had
+transferred him there and he did not wish to give up his job.
+
+There was, he said, no public library or chamber of commerce in
+Innsmouth, but I could probably find my way about. The street I had
+come down was Federal. West of that were the fine old residence
+streets--Broad, Washington, Lafayette, and Adams--and east of it were
+the shoreward slums.
+
+Certain spots were almost forbidden territory, as he had learned at
+considerable cost. One must not, for example, linger much around the
+Marsh refinery, or around any of the still used churches, or around the
+pillared Order of Dagon Hall at New Church Green. Those churches were
+very odd--all violently disavowed by their respective denominations
+elsewhere, and apparently using the queerest kind of ceremonials and
+clerical vestments.
+
+As for the Innsmouth people--the youth hardly knew what to make of
+them. Their appearance--especially those staring, unwinking eyes which
+one never saw shut--was certainly shocking enough--and their voices
+were disgusting. It was awful to hear them chanting in their churches
+at night, and especially during their main festivals or revivals, which
+fell twice a year on April 30 and October 31.
+
+They were very fond of the water, and swam a great deal in both river
+and harbor. Swimming races out to Devil Reef were very common, and
+everyone in sight seemed well able to share in this arduous sport.
+
+It would be of no use, my informant said, to ask the natives anything
+about the place. The only one who would talk was a very aged but
+normal-looking man who lived at the poorhouse on the north rim of the
+town and spent his time walking about or lounging around the fire
+station. This hoary character, Zadok Allen, was 96 years old and
+somewhat touched in the head, besides being the town drunkard. He was a
+strange, furtive creature who constantly looked over his shoulder as
+if afraid of something, and when sober could not be persuaded to talk
+at all with strangers. He was, however, unable to resist any offer of
+his favorite poison; and once drunk would furnish the most astonishing
+fragments of whispered reminiscence.
+
+After all, though, little useful data could be gained from him; since
+his stories were all insane, incomplete hints of impossible marvels and
+horrors which could have no source save in his own distorted fancy.
+Nobody ever believed him, but the natives did not like him to drink
+and talk with any strangers; and it was not always safe to be seen
+questioning him. It was probably from him that some of the wildest
+popular whispers and delusions were derived.
+
+The Marshes, together with the other three gently bred families of the
+town--the Waites, the Gilmans, and the Eliots--were all very retiring.
+They lived in immense houses along Washington Street, and several were
+reputed to harbor in concealment certain kinsfolk whose personal aspect
+forbade public view, and whose deaths had been reported and recorded.
+
+Warning me that most of the street signs were down, the youth drew for
+my benefit a rough but ample and painstaking sketch map of the town's
+salient features. After a moment's study I felt sure that it would be
+of great help, and pocketed it with profuse thanks.
+
+Thus began my systematic though half-bewildered tour of Innsmouth's
+narrow, shadow-blighted ways. Crossing the bridge and turning toward
+the roar of the lower falls, I passed close to the Marsh refinery,
+which seemed oddly free from the noise of industry. This building
+stood on the steep river bluff near a bridge and an open confluence of
+streets which I took to be the earliest civic center, displaced after
+the Revolution by the present Town Square.
+
+Re-crossing the gorge on the Main Street bridge, I struck a region of
+utter desertion which somehow made me shudder. Collapsing huddles of
+gambrel roofs formed a jagged and fantastic skyline, above which rose
+the ghoulish, decapitated steeple of an ancient church.
+
+Fish Street was as deserted as Main, though it differed in having many
+brick and stone warehouses still in excellent shape. Water Street
+was almost its duplicate, save that there were great seaward gaps
+where wharves had been. Not a living thing did I see, except for the
+scattered fishermen on the distant breakwater, and not a sound did I
+hear save the lapping of the harbor tides and the roar of the falls in
+the Manuxet.
+
+I kept north along Main to Martin, then turning inland, crossing
+Federal Street safely north of the Green, and entering the decayed
+patrician neighborhood of northern Broad, Washington, Lafayette, and
+Adams Streets. Following Washington Street toward the river, I now
+faced a zone of former industry and commerce; noting the ruins of a
+factory ahead, and seeing others, with the traces of an old railway
+station and covered railway bridge beyond up the gorge on my right.
+
+The uncertain bridge now before me was posted with a warning sign,
+but I took the risk and crossed again to the south bank where traces
+of life reappeared. Furtive, shambling creatures stared cryptically
+in my direction, and more normal faces eyed me coldly and curiously.
+Innsmouth was rapidly becoming intolerable, and I turned down Paine
+Street toward the Square in the hope of getting some vehicle to take me
+to Arkham before the still-distant starting time of that sinister bus.
+
+It was then that I saw the tumbledown fire station on my left,
+and noticed the red-faced, bushy-bearded, watery-eyed old man in
+nondescript rags who sat on a bench in front of it talking with a pair
+of unkempt but not abnormal-looking firemen. This, of course, must be
+Zadok Allen, the half-crazed, liquorish non-agenarian whose tales of
+old Innsmouth and its shadow were so hideous and incredible.
+
+
+
+
+                                  III
+
+
+I had been assured that the old man could do nothing but hint at wild,
+disjointed, and incredible legends, and I had been warned that the
+natives made it unsafe to be seen talking with him; yet the thought
+of this aged witness to the town's decay, with memories going back to
+the early days of ships and factories, was a _lure_ that no amount
+of reason could make me resist. Curiosity flared up beyond sense and
+caution, and in my youthful egotism I fancied I might be able to sift
+a nucleus of real history from the confused, extravagant outpouring I
+would probably extract with the aid of whiskey.
+
+A quart bottle of such was easily, though not cheaply, obtained in the
+rear of a dingy variety-store just off the Square in Eliot Street.
+
+Re-entering the Square I saw that luck was with me; for--shuffling
+out of Paine Street around the corner of the Gilman House--I glimpsed
+nothing less than the tall, lean, tattered form of old Zadok Allen
+himself. In accordance with my plan, I attracted his attention by
+brandishing my newly-purchased bottle; and soon realized that he had
+begun to shuffle wistfully after me as I turned into Waite Street on my
+way to the most deserted region I could think of. Before I reached Main
+Street I could hear a faint and wheezy "Hey, Mister!" behind me, and I
+presently allowed the old man to catch up and take copious pulls from
+the quart bottle.
+
+I began putting out feelers as we walked along to Water Street and
+turned southward amidst the omnipresent desolation and crazily tilted
+ruins, but found that the aged tongue did not loosen as quickly
+as I had expected. At length I saw a grass-grown opening toward
+the sea between crumbling brick walls, with the weedy length of an
+earth-and-masonry wharf projecting beyond. Piles of moss-covered stones
+near the water promised tolerable seats, and the scene was sheltered
+from all possible view by a ruined warehouse on the north.
+
+About four hours remained for conversation if I were to catch the eight
+o'clock coach for Arkham, and I began to dole out more liquor to the
+ancient tippler; meanwhile eating my own frugal lunch. In my donations
+I was careful not to overshoot the mark, for I did not wish Zadok's
+vinous garrulousness to pass into a stupor. After an hour his furtive
+taciturnity showed signs of disappearing, and something or other had
+caused his wandering gaze to light on the low, distant line of Devil
+Reef, then showing plainly and almost fascinatingly above the waves. He
+bent toward me, took hold of my coat lapel, and hissed out some hints
+that could not be mistaken.
+
+"Thar's whar it all begun--that cursed place of all wickedness whar
+the deep water starts. Gate o' hell--sheer drop daown to a bottom no
+saoundin'-line kin tech. Ol' Cap'n Obed done it--him that faound aout
+more'n was good fer him in the Saouth Sea islands.
+
+"Never was nobody like Cap'n Obed--old limb o' Satan! Heh, heh! I kin
+mind him a-tellin' abaout furren parts, an' callin' all the folks
+stupid fer goin' to Christian meetin' an' bearin' their burdens meek
+an' lowly. Says they'd orter git better gods like some o' the folks
+in the Injies--gods as ud bring 'em good fishin' in return fer their
+sacrifices, an' ud reely answer folks's prayers.
+
+"Matt Eliot, his fust mate, talked a lot, too, only he was agin'
+folks's doin' any heathen things. Told abaout an island east of
+Othaheite whar they was a lot o' stone ruins older'n anybody knew
+anything abaout, kind o' like them on Ponape, in the Carolines, but
+with carvin's of faces that looked like the big statues on Easter
+Island. They was a little volcanic island near thar, too, whar they was
+other ruins with diff'rent carvin's--ruins all wore away like they'd
+ben under the sea onct, an' with picters of awful monsters all over 'em.
+
+"Wal, Sir, Matt he says the natives araound thar had all the fish they
+cud ketch, an' sported bracelets an' armlets an' head rigs made aout
+of a queer kind o' gold an' covered with picters o' monsters jest like
+the ones carved over the ruins on the little island--sorter fishlike
+frogs or froglike fishes that was drawed in all kinds o' positions
+like they was human bein's. Nobody cud git aout o' them whar they got
+all the stuff, an' all the other natives wondered haow they managed to
+find fish in plenty even when the very next islands had lean pickin's.
+Matt he got to wonderin' too, an' so did Cap'n Obed. Obed, he notices,
+besides, that lots of the han'some young folks ud drop aout o' sight
+fer good from year to year, an' that they wan't many old folk araound.
+Also, he thinks some of the folks looks durned queer even fer Kanakys.
+
+"It took Obed to git the truth aout o' them heathens. I dun't know haow
+he done it, but he begun by tradin' fer the gold-like things they wore.
+Ast 'em whar they come from, an' ef they cud git more, an' finally
+wormed the story aout o' the old chief--Walakea, they called him.
+Nobody but Obed ud ever a believed the old yeller devil, but the Cap'n
+cud read folks like they was books. Heh, heh! Nobody never believes me
+naow when I tell 'em, an I dun't s'pose you will, young feller--though
+come to look at ye, ye hev kind o' got them sharp-readin' eyes like
+Obed had."
+
+The old man's whisper grew fainter, and I found myself shuddering at
+the terrible and sincere portentousness of his intonation, even though
+I knew his tale could be nothing but drunken phantasy.
+
+"Wal, Sir, Obed he larnt that they's things on this arth as most folks
+never heard abaout--an' wouldn't believe ef they did hear. It seems
+these Kanakys was sacrificin' heaps o' their young men an' maidens to
+some kind o' god-things that lived under the sea, an' gittin' all kinds
+o' favors in return. They met the things on the little islet with the
+queer ruins, an' it seems them awful picters o' frog-fish monsters was
+supposed to be picters o' these things. Mebbe they was the kind o'
+critters as got all the mermaids stories an' sech started. They had all
+kinds o' cities on the sea-bottom, an' this island was heaved up from
+thar. Seems they was some of the things alive in the stone buildin's
+when the island come up sudden to the surface. That's haow the Kanakys
+got wind they was daown thar. Made sign-talk as soon as they got over
+bein' skeert, an' pieced up a bargain afore long.
+
+"Them things liked human sacrifices. Had had 'em ages afore, but
+lost track o' the upper world arter a time. What they done to the
+victims it ain't fer me to say, an' I guess Obed wa'n't none too
+sharp abaout askin'. But it was all right with the heathens, because
+they'd ben havin' a hard time an' was desp'rate abaout everything.
+They give a sarten number o' young folks to the sea-things twict every
+year--May-Eve an' Hallowe'en--reg'lar as cud be. Also give some o' the
+carved knick-knacks they made. What the things agreed to give in return
+was a plenty o' fish--they druv 'em in from all over the sea--an' a few
+gold-like things naow an' then.
+
+"When it come to matin' with them toad-lookin' fishes, the Kanakys
+kind o' balked, but finally they larnt something as put a new face
+on the matter. Seems that human folks has got a kind o' relation to
+sech water-beasts--that everything alive come aout o' the water onct,
+an' only needs a little change to go back agin. Them things told the
+Kanakys that ef they mixed bloods there'd be children as ud look human
+at fust, but later turn more'n more like the things, till finally
+they'd take to the water an' jine the main lot o' things daown thar.
+An' this is the important part, young feller--them as turned into fish
+things an' went into the water _wouldn't never die_. Them things never
+died excep' they was kilt violent.
+
+"Wal, Sir, it seems by the time Obed knowed them islanders they was all
+full o' fish blood from them deep-water things. When they got old an'
+begun to show it, they was kep' hid until they felt like takin' to the
+water an' quittin' the place. Some was more teched than others, an'
+some never did change quite enough to take to the water; but mostly
+they turned aout jest the way them things said. Them as was born more
+like the things changed arly, but them as was nearly human sometimes
+stayed on the island till they was past seventy, though they'd usually
+go daown under fer trial trips afore that. Folks as had took to the
+water, gen'rally come back a good deal to visit, so's a man ud often be
+a-talkin' to his own five-times-great-grandfather, who'd left the dry
+land a couple o' hundred years or so afore.
+
+"Everybody got aout o' the idee o' dyin'--excep' in canoe wars with
+the other islanders, or as sacrifices to the sea-gods daown below, or
+from snake-bite or plague or sharp gallopin' ailments or somethin'
+afore they cud take to the water--but simply looked forrad to a kind
+o' change that wa'n't a bit horrible arter a while. They thought what
+they'd got was well wuth all they'd had to give up--an' I guess Obed
+kind o' come to think the same hisself when he'd chewed over old
+Walakea's story a bit. Walakea, though, was one of the few as hadn't
+got none of the fish blood--bein' of a royal line that intermarried
+with royal lines on other islands.
+
+"Walakea give him a funny kind o' thingumajig made aout o' lead or
+something, that he said ud bring up the fish things from any place in
+the water whar they might be a nest of 'em. The idee was to drop it
+daown with the right kind o' prayers an' sech. Walakea allaowed as was
+the things was scattered all over the world, so's anybody that looked
+abaout cud find a nest an' bring 'em up ef they was wanted.
+
+"Matt he didn't like this business at all, an' wanted Obed shud keep
+away from the island; but the Cap'n was sharp fer gain, an' faound
+he cud git them gold-like things so cheap it ud pay him to make a
+specialty of 'em.
+
+"Things went on that way fer years, an' Obed got enough o' that
+gold-like stuff to make him start the refinery in Waite's old run-daown
+fullin' mill.
+
+"Wall, come abaout 'thutty-eight--when I was seven year' old--Obed he
+faound the island people all wiped aout between v'yages. Seems the
+other islanders had got wind o' what was goin' on, an' had took matters
+into their own hands. S'pose they must a had, arter all, them old magic
+signs as the sea things says was the only things they was afeard of. No
+tellin' what any o' them Kanakys will chance to git a holt of when the
+sea-bottom throws up some island with ruins older'n the deluge. Pious
+cusses, these was--they didn't leave nothin' standin' on either the
+main island or the little volcanic islet excep' what parts of the ruins
+was too big to knock daown.
+
+"That naturally hit Obed pretty hard, seein' as his normal trade
+was doin' very poor. It hit the whole of Innsmouth, too, because in
+seafarin' days what profited the master of a ship gen'lly profited the
+crew proportionate. Most o' the folks araound the taown took the hard
+times kind o' sheeplike an' resigned, but they was in bad shape because
+the fishin' was peterin' aout an' the mills wa'n't doin' none too well.
+
+"Then's the time Obed he begun a-cursin' at the folks fer bein' dull
+sheep an' prayin' to a Christian heaven as didn't help 'em none. He
+told 'em he'd knowed of folks as prayed to gods that give somethin' ye
+reely need, an' says ef a good bunch o' men ud stand by him, he cud
+mebbe git a holt o' sarten paowers as ud bring plenty o' fish an' quite
+a bit o' gold."
+
+Here the old man faltered, mumbled, and lapsed into a moody and
+apprehensive silence; glancing nervously over his shoulder and then
+turning back to stare fascinatedly at the distant black reef. When
+I spoke to him he did not answer, so I knew I would have to let him
+finish the bottle. He licked its nose and slipped it into his pocket,
+then beginning to nod and whisper softly to himself. I bent close to
+catch any articulate words he might utter, and thought I saw a sardonic
+smile behind the stained, bushy whiskers. Yes--he was really forming
+words, and I could grasp a fair proportion of them.
+
+"Poor Matt--Matt he allus was agin it--tried to line up the folks on
+his side, an' had long talks with the preachers--no use--they run
+the Congregational parson aout o' taown, an' the Methodist feller
+quit--never did see Resolved Babcock, the Baptist parson, agin--Wrath
+o' Jehovy--I was a mighty little critter, but I heerd what I heerd an'
+seen what I seen--Dagon an' Ashtoreth--Belial an' Beëlzebub--Golden
+Caff an' the idols o' Canaan an' the Philistines--Babylonish
+abominations--_Mene, mene, tekel, upharsin_--"
+
+He stopped again, and from the look in his watery blue eyes I feared he
+was close to a stupor after all. But when I gently shook his shoulder
+he turned on me with astonishing alertness and snapped out some more
+obscure phrases.
+
+"Dun't believe me, hey? Heh, heh, heh--then just tell me, young feller,
+why Cap'n Obed an' twenty odd other folks used to row aout to Devil
+Reef in the dead o' night an' chant things so laoud ye cud hear 'em
+all over taown when the wind was right? Tell me that, hey? An' tell
+me why Obed was allus droppin' heavy things daown into the deep water
+t'other side o' the reef whar the bottom shoots daown like a cliff
+lower'n ye kin saound? Tell me what he done with that funny-shaped lead
+thingumajig as Walakea give him? Hey, boy?"
+
+The watery blue eyes were almost savage and maniacal now, and the dirty
+white beard bristled electrically. Old Zadok probably saw me shrink
+back, for he began to cackle evilly.
+
+"Heh, heh, heh, heh! Beginnin' to see, hey? Haow abaout the night I
+took my pa's ship's glass up to a cupalo an' seed the reef a-bristlin'
+thick with shapes that dove off quick soon's the moon riz? Obed an' the
+folks was in a dory, but them shapes dove off the far side into the
+deep water an' never come up.... Haow'd ye like to be a little shaver
+alone up in a cupalo a-watchin' shapes _as wa'n't human shapes_?...
+Hey?... Heh, heh, heh, heh...."
+
+       *       *       *       *       *
+
+The old man was getting hysterical, and I began to shiver with a
+nameless alarm. He laid a gnarled claw on my shoulder, and it seemed to
+me that its shaking was not altogether that of mirth.
+
+"S'pose one night ye seed somethin' heavy heaved offen Obed's dory
+beyond the reef, an' then larned nex' day a young feller was missin'
+from home? Hey? Did anybody ever see hide or hair o' Hiram Gilman agin?
+Did they? An' Nick Pierce, an' Luelly Waite, an' Adoniram Saouthwick,
+an' Henry Garrison? Hey? Heh, heh....
+
+"Wal, Sir, that was the time Obed begun to git on his feet agin. Folks
+see his three darters a-wearin' gold-like things as nobody'd never see
+on 'em afore, an' smoke started comin' aout o' the refin'ry chimbly.
+Other folks was prosp'rin', too--fish began to swarm into the harbor
+fit to kill, an' heaven knows what sized cargoes we begun to ship aout
+to Newb'ryport, Arkham, an' Boston. 'Twas then Obed got the ol' branch
+railrud put through.
+
+"Remember, I ain't sayin' Obed was set on hevin' things jest like
+they was on that Kanaky isle. I dun't think he aimed at fust to do
+no mixin', nor raise no young-uns to take to the water an' turn into
+fishes with etarnal life. He wanted them gold things, an' was willin'
+to pay heavy, an' I guess the _others_ was satisfied fer a while....
+
+"Come in 'forty-six the taown done some lookin' an' thinkin' fer
+itself. Too many folks missin'--too much wild preachin' at meetin' of a
+Sunday--too much talk abaout that reef. I guess I done a bit by tellin'
+Selectman Mowry what I see from the cupalo. They was a party one night
+as follered Obed's craowd aout to the reef, an' I heerd shots betwixt
+the dories. Nex' day Obed an' thutty-two others was in jail, with
+everybody a-wonderin' jest what was afoot an' jest what charge agin
+'em cud be got to holt. God, ef anybody'd looked ahead ... a couple
+o' weeks later, when nothin' had ben throwed into the sea fer that
+long...."
+
+Zadok was showing signs of fright and exhaustion, and I let him keep
+silence for a while, though glancing apprehensively at my watch. The
+tide had turned and was coming in now, and the sound of the waves
+seemed to arouse him.
+
+"That awful night.... I seed 'em.... I was up in the cupalo ... hordes
+of 'em ... swarms of 'em ... all over the reef an' swimmin' up the
+harbor into the Manuxet.... God, what happened in the streets of
+Innsmouth that night ... they rattled our door, but pa wouldn't open
+... then he clumb aout the kitchen winder with his musket to find
+Selectman Mowry an' see what he cud do.... Maounds o' the dead an'
+the dyin' ... shots an' screams ... shaoutin' in Ol' Squar an' Taown
+Squar an' New Church Green ... jail throwed open ... proclamation ...
+treason ... called it the plague when folks come in an' faound haff our
+people missin' ... nobody left but them as ud jine in with Obed an'
+them things or else keep quiet ... never heerd o' my pa no more...."
+
+The old man was panting, and perspiring profusely. His grip on my
+shoulder tightened.
+
+"Everything cleaned up in the mornin'--but they was _traces_.... Obed
+he kinder takes charge an' says things is goin' to be changed ...
+_others'll_ worship with us at meetin'-time, an' sarten haouses hez got
+to entertain _guests_ ... _they_ wanted to mix like they done with the
+Kanakys, an' he fer one didn't feel baound to stop 'em. Far gone, was
+Obed ... jest like a crazy man on the subjeck. He says they brung us
+fish an' treasure, an' shud hev what they hankered arter....
+
+"Nothin' was to be diff'runt on the aoutside, only we was to keep shy
+o' strangers ef we knowed what was good fer us. We all hed to take the
+Oath o' Dagon, an' later on they was secon' an' third Oaths that some
+of us took. Them as ud help special, ud git special rewards--gold an'
+sech. No use balkin', fer they was millions of 'em daown thar. They'd
+ruther not start risin' an' wipin' aout humankind, but ef they was gave
+away an' forced to, they cud do a lot toward jest that.
+
+"Yield up enough sacrifices an' savage knick-knacks an' harborage in
+the taown when they wanted it, an' they'd let well enough alone. All in
+the band of the faithful--Order o' Dagon--an' the children shud never
+die, but go back to the Mother Hydra an' Father Dagon what we all come
+from onct--_Iä! Iä! Cthulhu fhtagn! Ph'nglui mglw'nafh Cthulhu R'lyeh
+wgahnagl fhtagn_--"
+
+Old Zadok began to moan now, and tears were coursing down his
+channelled cheeks into the depths of his beard.
+
+"God, what I seen senct I was fifteen year' old--_Mene, mene,
+tekel, upharsin!_--the folks as was missin', an' them as kilt
+theirselves--them as told things in Arkham or Ipswich or sech places
+was all called crazy, like you're a-callin' me right naow--but God,
+what I seen--they'd a kilt me long ago fer what I know, only I'd
+took the fust an' secon' Oaths o' Dagon offen Obed, so was pertected
+unlessen a jury of 'em proved I told things knowin' an' delib'rit ...
+but I wudn't take the third Oath--I'd a died ruther'n take that--
+
+"It got wuss araound Civil War time, _when children born senct
+'forty-six begun to grow up_--some of 'em, that is. I was
+afeard--never did no pryin' arter that awful night, an' never see one
+o'--_them_--clost to in all my life. That is, never no full-blooded
+one. Barnabas Marsh that runs the refin'ry naow is Obed's grandson by
+his fust wife--son of Onesiphorus, his eldest son, _but his mother was
+another o' them as wa'n't never seed aoutdoors_.
+
+"Right naow Barnabas is abaout changed. Can't shet his eyes no more,
+an' is all aout o' shape. They say he still wears clothes, but he'll
+take to the water soon." ...
+
+The sound of the incoming tide was now very insistent, and little by
+little it seemed to change the old man's mood from maudlin tearfulness
+to watchful fear. He would pause now and then to renew those nervous
+glances over his shoulder or out toward the reef, and despite the wild
+absurdity of his tale, I could not help beginning to share his vague
+apprehensiveness. Zadok now grew shriller, and seemed to be trying to
+whip up his courage with louder speech.
+
+"Hey, yew, why dun't ye say somethin'? Haow'd ye like to be livin' in a
+taown like this, with everything a-rottin' an' a-dyin', an' boarded-up
+monsters crawlin' an' bleatin' an' barkin' an' hoppin' araoun' black
+cellars an' attics every way ye turn? Hey? Wal, Sir, _let me tell ye
+that aint the wust_!"
+
+Zadok was really screaming now, and the mad frenzy of his voice
+disturbed me more than I care to own.
+
+"Curse ye, dun't set thar a-starin' at me with them eyes--I tell Obed
+Marsh he's in hell, an' hez got to stay thar! Heh, heh ... in hell, I
+says! Can't git me--I hain't done nothin' nor told nobody nothin'--
+
+"Oh, you, young feller? Wal, even ef I hain't told nobody nothin' yet,
+I'm a-goin' to naow! Yew jest set still an' listen to me, boy--this is
+what I ain't never told nobody.... I says I didn't get to do no pryin'
+arter that night--_but I found things aout jest the same_!
+
+"Yew want to know what the reel horror is, hey? Wal, it's this--it
+ain't what them fish devils _hez done, but what they're a-goin' to
+do_! They're a-bringin' things up aout o' whar they come from into the
+taown--ben doin' it fer years, an' slackenin' up lately. Them haouses
+north o' the river betwixt Water an' Main Streets is full of 'em--them
+devils _an' what they brung_--an' when they git ready ... I say, _when
+they git ready_ ... ever hear tell of a _shoggoth_?....
+
+"Hey, d'ye hear me? I tell ye I _know what them things be--I seen 'em
+one night when_.... EH-AHHHH--AH! E'YAAHHHH...."
+
+The hideous suddenness and inhuman frightfulness of the old man's
+shriek almost made me faint. His eyes, looking past me toward the
+malodorous sea, were positively starting from his head; while his
+face was a mask of fear worthy of Greek tragedy. His bony claw dug
+monstrously into my shoulder, and he made no motion as I turned my head
+to look at whatever he had glimpsed.
+
+There was nothing that I could see. Only the incoming tide, with
+perhaps one set of ripples more local than the long-flung line of
+breakers. But now Zadok was shaking me, and I turned back to watch the
+melting of that fear-frozen face into a chaos of twitching eyelids and
+mumbling gums. Presently his voice came back--albeit as a trembling
+whisper.
+
+"_Git aout o' here!_ Git aout o' here! _They seen us_--git aout
+fer your life! Dun't wait fer nothin'--_they know naow_--Run fer
+it--quick--_aout o' this taown_--"
+
+Another heavy wave dashed against the loosening masonry of the bygone
+wharf, and changed the mad ancient's whisper to another inhuman and
+blood-curdling scream.
+
+"E-YAAAHHHH!...
+
+"YHAAAAAAAA!..."
+
+Before I could recover my scattered wits he had relaxed his clutch
+on my shoulder and dashed wildly inland toward the street, reeling
+northward around the ruined warehouse wall.
+
+I glanced back at the sea, but there was nothing there. And when I
+reached Water Street and looked along it toward the north there was no
+remaining trace of Zadok Allen.
+
+
+
+
+                                  IV
+
+
+I can hardly describe the mood in which I was left by this harrowing
+episode--an episode at once mad and pitiful, grotesque and terrifying.
+The grocery boy had prepared me for it, yet the reality left me none
+the less bewildered and disturbed. Puerile though the story was, old
+Zadok's insane earnestness and horror had communicated to me a mounting
+unrest which joined with my earlier sense of loathing for the town and
+its blight of intangible shadow.
+
+The hour had grown perilously late--my watch said 7:15, and the Arkham
+bus left Town Square at eight--so I tried to give my thoughts as
+neutral and practical a cast as possible, meanwhile walking rapidly
+through the deserted streets of gaping roofs and leaning houses toward
+the hotel where I had checked my valise and would find my bus.
+
+Studying the grocery youth's map and seeking a route I had not
+traversed before, I chose Marsh Street instead of State for my approach
+to Town Square. Near the corner of Fall Street I began to see scattered
+groups of furtive whisperers, and when I finally reached the Square I
+saw that almost all the loiterers were congregated around the door of
+the Gilman House. It seemed as if many bulging, watery, unwinking eyes
+looked oddly at me as I claimed my valise in the lobby, and I hoped
+that none of these unpleasant creatures would be my fellow-passengers
+on the coach.
+
+The bus, rather early, rattled in with three passengers somewhat
+before eight, and an evil-looking fellow on the sidewalk muttered a
+few indistinguishable words to the driver. I was, it appeared, in very
+bad luck. There had been something wrong with the engine, despite the
+excellent time made from Newburyport, and the bus could not complete
+the journey to Arkham. No, it could not possibly be repaired that
+night, nor was there any other way of getting transportation out of
+Innsmouth, either to Arkham or elsewhere. Sargent was sorry, but I
+would have to stop over at the Gilman. Probably the clerk would make
+the price easy for me, but there was nothing else to do. Almost dazed
+by this sudden obstacle, and violently dreading the fall of night in
+this decaying and half-unlighted town, I left the bus and reentered
+the hotel lobby; where the sullen, queer-looking night clerk told me I
+could have Room 428 on next the top floor--large, but without running
+water--for a dollar.
+
+Despite what I had heard of this hotel in Newburyport, I signed the
+register, paid my dollar, let the clerk take my valise, and followed
+that sour, solitary attendant up three creaking flights of stairs past
+dusty corridors which seemed wholly devoid of life. My room, a dismal
+rear one with two windows and bare, cheap furnishings, over-looked
+a dingy courtyard otherwise hemmed in by low, deserted brick blocks,
+and commanded a view of decrepit westward-stretching roofs with a
+marshy countryside beyond. At the end of the corridor was a bathroom--a
+discouraging relique with ancient marble bowl, tin tub, faint electric
+light, and musty wooden panelling around all the plumbing fixtures.
+
+As twilight deepened I turned on the one feeble electric bulb over the
+cheap, iron-framed bed, and tried as best I could to read. I felt it
+advisable to keep my mind wholesomely occupied, for it would not do
+to brood over the abnormalities of this ancient, blight-shadowed town
+while I was still within its borders. The insane yarn I had heard from
+the aged drunkard did not promise very pleasant dreams, and I felt I
+must keep the image of his wild, watery eyes as far as possible from my
+imagination.
+
+Another thing that disturbed me was the absence of a bolt on the door
+of my room. One had been there, as marks clearly showed, but there
+were signs of recent removal. No doubt it had become out of order,
+like so many other things in this decrepit edifice. In my nervousness
+I looked around and discovered a bolt on the clothespress which seemed
+to be of the same size, judging from the marks, as the one formerly on
+the door. To gain a partial relief from the general tension I busied
+myself by transferring this hardware to the vacant place with the aid
+of a handy three-in-one device including a screw-driver which I kept
+on my keyring. The bolt fitted perfectly, and I was somewhat relieved
+when I knew that I could shoot it firmly upon retiring. There were
+adequate bolts on the two lateral doors to connecting rooms, and these
+I proceeded to fasten.
+
+I did not undress, but decided to read till I was sleepy and then
+lie down with only my coat, collar, and shoes off. Taking a pocket
+flashlight from my valise, I placed it in my trousers, so that I
+could read my watch if I woke up later in the dark. Drowsiness,
+however, did not come; and when I stopped to analyze my thoughts I
+found to my disquiet that I was really unconsciously listening for
+something--listening for something which I dreaded but could not name.
+
+At length, feeling a fatigue which had nothing of drowsiness in it, I
+bolted the newly outfitted hall door, turned off the light, and threw
+myself down on the hard, uneven bed--coat, collar, shoes, and all. In
+the darkness every faint noise of the night seemed magnified, and a
+flood of doubly unpleasant thoughts swept over me. I was sorry I had
+put out the light, yet was too tired to rise and turn it on again.
+Then, after a long, dreary interval, and prefaced by a fresh creaking
+of stairs and corridor, there came that soft, damnably unmistakable
+sound which seemed like a malign fulfilment of all my apprehensions.
+Without the least shadow of a doubt, the lock on my hall door was being
+tried--cautiously, furtively, tentatively--with a key.
+
+The change in the menace from vague premonition to immediate reality
+was a profound shock, and fell upon me with the force of a genuine
+blow. It never once occurred to me that the fumbling might be a mere
+mistake. Malign purpose was all I could think of, and I kept deathly
+quiet, awaiting the would-be intruder's next move.
+
+After a time the cautious rattling ceased, and I heard the room to the
+north entered with a pass key. Then the lock of the connecting door to
+my room was softly tried. The bolt held, of course, and I heard the
+floor creak as the prowler left the room. After a moment there came
+another soft rattling, and I knew that the room to the south of me was
+being entered. Again a furtive trying of a bolted connecting door,
+and again a receding creaking. This time the creaking went along the
+hall and down the stairs, so I knew that the prowler had realized the
+bolted condition of my doors and was giving up his attempt for a time.
+
+_The one thing to do was to get out of that hotel alive as quickly as I
+could, and through some channel other than the front stairs and lobby!_
+
+Rising softly and throwing my flashlight on the switch, I sought
+to light the bulb over my bed in order to choose and pocket some
+belongings for a swift, valiseless flight. Nothing, however, happened;
+and I saw that the power had been cut off. So, filling my pockets
+with the flashlight's aid, I put on my hat and tiptoed to the
+windows to consider chances of descent. Despite the state's safety
+regulations there was no fire escape on this side of the hotel, and
+I saw that my windows commanded only a sheer three-story drop to the
+cobbled courtyard. On the right and left, however, some ancient brick
+business blocks abutted on the hotel; their slant roofs coming up to a
+reasonable jumping distance from my fourth-story level. To reach either
+of these lines of buildings I would have to be in a room two doors
+from my own--in one case on the north and in the other case on the
+south--and my mind instantly set to work calculating what chances I had
+of making the transfer.
+
+First, I reinforced my own outer door by pushing the bureau against
+it--little by little, in order to make a minimum of sound. Then,
+gathering from the grocery boy's map that the best route out of town
+was southward, I glanced first at the connecting door on the south
+side of the room. It was designed to open in my direction, hence I
+saw--after drawing the bolt and finding other fastenings in place--it
+was not a favorable one for forcing. Accordingly abandoning it as a
+route, I cautiously moved the bedstead against it to hamper any attack
+which might be made on it later from the next room. The door on the
+north was hung to open away from me, and this--though a test proved
+it to be locked or bolted from the other side--I knew must be my
+route. If I could gain the roofs of the buildings in Paine Street and
+descend successfully to the ground level, I might perhaps dart through
+the courtyard and the adjacent or opposite buildings to Washington
+or Bates--or else emerge in Paine and edge around southward into
+Washington. In any case, I would aim to strike Washington somehow and
+get quickly out of the Town Square region. My preference would be to
+avoid Paine, since the fire station there might be open all night.
+
+I was irresolutely speculating on when I had better attack the
+northward door, and on how I could least audibly manage it, when I
+noticed that the vague noises underfoot had given place to a fresh and
+heavier creaking of the stairs. A wavering flicker of light showed
+through my transom, and the boards of the corridor began to groan with
+a ponderous load. Muffled sounds of possible vocal origin approached,
+and at length a firm knock came at my outer door.
+
+For a moment I simply held my breath and waited. Eternities
+seemed to elapse, and the nauseous fishy odor of my environment
+seemed to mount suddenly and spectacularly. Then the knocking was
+repeated--continuously, and with growing insistence. I knew that the
+time for action had come, and forthwith drew the bolt of the northward
+connecting door, bracing myself for the task of battering it open. The
+knocking waxed louder, and I hoped that its volume would cover the
+sound of my efforts. At last beginning my attempt, I lunged again and
+again at the thin panelling with my left shoulder, heedless of shock or
+pain.
+
+Finally the connecting door gave, but with such a crash that I knew
+those outside must have heard. Instantly the outside knocking became
+a violent battering, while keys sounded ominously in the hall doors
+of the rooms on both sides of me. Rushing through the newly opened
+connection, I succeeded in bolting the northerly hall door before the
+lock could be turned; but even as I did so I heard the hall door of the
+third room--the one from whose window I had hoped to reach the roof
+below--being tried with a pass key.
+
+For an instant I felt absolute despair, since my trapping in a chamber
+with no window egress seemed complete. Then, with a dazed automatism,
+I made for the next connecting door and performed the blind motion of
+pushing at it in an effort to get through!
+
+Sheer fortunate chance gave me my reprieve--for the connecting door
+before me was not only unlocked but actually ajar. In a second I was
+through, and had my right knee and shoulder against a hall door which
+was visibly opening inward. My pressure took the opener off guard, for
+the thing shut as I pushed, so that I could slip the well-conditioned
+bolt as I had done with the other door. As I gained this respite I
+heard the battering at the two other doors abate, while a confused
+clatter came from the connecting door I had shielded with the bedstead.
+Evidently the bulk of my assailants had entered the southerly room and
+were massing in a lateral attack. But at the same moment a pass key
+sounded in the next door to the north, and I knew that a nearer peril
+was at hand.
+
+The northward connecting door was wide open, but there was no time to
+think about checking the already turning lock in the hall. All I could
+do was to shut and bolt the open connecting door, as well as its mate
+on the opposite side--pushing a bedstead against the one and a bureau
+against the other, and moving a washstand in front of the hall door.
+I must, I saw, trust to such makeshift barriers to shield me till I
+could get out the window and on the roof of the Paine Street block. But
+even in this acute moment my chief horror was something apart from the
+immediate weakness of my defenses. I was shuddering because not one
+of my pursuers, despite some hideous pantings, gruntings, and subdued
+barkings at odd intervals, was uttering an intelligible vocal sound!
+
+As I moved the furniture and rushed toward the windows I heard a
+frightful scurrying along the corridor toward the room north of me, and
+perceived that the southward battering had ceased. Plainly, most of my
+opponents were about to concentrate against the feeble connecting door
+which they knew must open directly on me. Outside, the moon played on
+the ridge-pole of the block below, and I saw that the jump would be
+desperately hazardous because of the steep surface on which I must land.
+
+The clatter at the northerly connecting door was now terrific, and
+I saw that the weak panelling was beginning to splinter. Obviously,
+the besiegers had brought some ponderous object into play as a
+battering-ram. The bedstead, however, still held firm; so that I had at
+least a faint chance of making good my escape. As I opened the window
+I noticed that it was flanked by heavy velour draperies suspended from
+a pole by brass rings, and also that there was a large projecting
+catch for the shutters on the exterior. Seeing a possible means of
+avoiding the dangerous jump, I yanked at the hangings and brought
+them down, pole and all; then quickly hooking two of the rings in the
+shutter catch and flinging the drapery outside. The heavy folds reached
+fully to the abutting roof, and I saw that the rings and catch would
+be likely to bear my weight. So, climbing out of the window and down
+the improvised rope ladder, I left behind me forever the morbid and
+horror-infested fabric of the Gilman House.
+
+I landed safely on the loose slates of the steep roof, and succeeded in
+gaining the gaping black skylight without a slip. The place inside was
+ghoulish-looking, but I was past minding such impressions and made at
+once for the staircase revealed by my flashlight--after a hasty glance
+at my watch, which showed the hour to be 2 A.M. The steps creaked, but
+seemed tolerably sound; and I raced down past a barnlike second story
+to the ground floor. The desolation was complete, and only echoes
+answered my footfalls.
+
+The hallway inside was black, and when I reached the opposite end I saw
+that the street door was wedged immovably shut. Resolved to try another
+building, I groped my way toward the courtyard, but stopped short when
+close to the doorway.
+
+For out of an opened door in the Gilman House a large crowd of doubtful
+shapes was pouring--lanterns bobbing in the darkness, and horrible
+croaking voices exchanging low cries in what was certainly not English.
+Their features were indistinguishable, but their crouching, shambling
+gait was abominably repellent. And worst of all, I perceived that one
+figure was strangely robed, and unmistakably surmounted by a tall tiara
+of a design altogether too familiar. Again groping toward the street,
+I opened a door off the hall and came upon an empty room with closely
+shuttered but sashless windows. Fumbling in the rays of my flashlight,
+I found I could open the shutters; and in another moment had climbed
+outside and was carefully closing the aperture in its original manner.
+
+I walked rapidly, softly, and close to the ruined houses. At Bates
+Street I drew into a yawning vestibule while two shambling figures
+crossed in front of me, but was soon on my way again and approaching
+the open space where Eliot Street obliquely crosses Washington at the
+intersection of South. Though I had never seen this space, it had
+looked dangerous to me on the grocery youth's map; since the moonlight
+would have free play there. There was no use trying to evade it, for
+any alternative course would involve detours of possibly disastrous
+visibility and delaying effect. The only thing to do was to cross it
+boldly and openly; imitating the typical shamble of the Innsmouth folk
+as best I could, and trusting that no one--or at least no pursuer of
+mine--would be there.
+
+Just how fully the pursuit was organized--and indeed, just what its
+purpose might be--I could form no idea. There seemed to be unusual
+activity in the town, but I judged that the news of my escape from
+the Gilman had not yet spread. The open space was, as I had expected,
+strongly moonlit. But my progress was unimpeded, and no fresh sound
+arose to hint that I had been spied. Glancing about me, I involuntarily
+let my pace slacken for a second to take in the sight of the sea,
+gorgeous in the burning moonlight at the street's end. Far out beyond
+the breakwater was the dim, dark line of Devil Reef.
+
+Then, without warning, I saw the intermittent flashes of light on the
+distant reef. My muscles tightened for panic flight, held in only by a
+certain unconscious caution and half-hypnotic fascination. And to make
+matters worse, there now flashed forth from the lofty cupola of the
+Gilman House, which loomed up to the northeast behind me, a series of
+analogous though differently spaced gleams which could be nothing less
+than an answering signal.
+
+I now bent to the left around the ruinous green; still gazing toward
+the ocean as it blazed in the spectral summer moonlight, and watching
+the cryptical flashing of those nameless, unexplainable beacons.
+
+It was then that the most horrible impression of all was borne in upon
+me--the impression which destroyed my last vestige of self-control and
+sent me running frantically southward past the yawning black doorways
+and fishily staring windows of that deserted nightmare street. For at
+a closer glance I saw that the moonlit waters between the reef and
+the shore were far from empty. They were alive with a teeming horde of
+shapes swimming inward toward the town!
+
+My frantic running ceased before I had covered a block, for at my left
+I began to hear something like the hue and cry of organized pursuit.
+There were footsteps and guttural sounds, and a rattling motor wheezed
+south along Federal Street. In a second all my plans were utterly
+changed--for if the southward highway were blocked ahead of me, I must
+clearly find another egress from Innsmouth. I paused and drew into a
+gaping doorway, reflecting how lucky I was to have left the moonlit
+open space before these pursuers came down the parallel street.
+
+Then I thought of the abandoned railway to Rowley, whose solid line of
+ballasted, weed-grown earth still stretched off to the northwest from
+the crumbling station on the edge of the river gorge. There was just a
+chance that the townsfolk would not think of that!
+
+Drawing inside the hall of my deserted shelter, I once more consulted
+the grocery boy's map with the aid of the flashlight. The immediate
+problem was how to reach the ancient railway; and I now saw that the
+safest course was ahead to Babson Street, then west to Lafayette--there
+edging around but not crossing an open space homologous to the one
+I had traversed--and subsequently back northward and westward in
+zigzagging line through Lafayette, Bates, Adams, and Banks Streets--the
+latter skirting the river gorge--to the abandoned and dilapidated
+station I had seen from my window. My reason for going ahead to Babson
+was that I wished neither to re-cross the earlier open space nor to
+begin my westward course along a cross street as broad as South. I
+crossed the street to the right-hand side in order to edge around into
+Babson as inconspicuously as possible.
+
+In Babson Street I clung as closely as possible to the sagging,
+uneven buildings; twice pausing in a doorway as the noises behind me
+momentarily increased. The open space ahead shone wide and desolate
+under the moon, but my route would not force me to cross it. During
+my second pause I began to detect a fresh distribution of the vague
+sounds; and upon looking cautiously out from cover beheld a motor car
+darting across the open space, bound outward along Eliot Street.
+
+As I watched--choked by a sudden rise in the fishy odor after a short
+abatement--I saw a band of uncouth, crouching shapes loping and
+shambling in the same direction; and knew that this must be the party
+guarding the Ipswich road, since that highway forms an extension of
+Eliot Street. Two of the figures I glimpsed were in voluminous robes,
+and one wore a peaked diadem which glistened whitely in the moonlight.
+The gait of this figure was so odd that it sent a chill through me--for
+it seemed to me the creature was almost _hopping_.
+
+When the last of the band was out of sight I resumed my progress;
+darting around the corner into Lafayette Street, and crossing Eliot
+very hurriedly lest stragglers of the party be still advancing along
+that thoroughfare. I did hear some croaking and clattering sounds
+far off toward Town Square, but accomplished the passage without
+disaster. My greatest dread was in re-crossing broad and moonlit South
+Street--with its seaward view--and I had to nerve myself for the
+ordeal. Someone might easily be looking, and possible Eliot Street
+stragglers could not fail to glimpse me from either of two points. At
+the last moment I decided I had better slacken my trot and make the
+crossing as before in the shambling gait of an average Innsmouth native.
+
+I had not quite crossed the street when I heard a muttering band
+advancing along Washington from the north. As they reached the broad
+open space where I had had my first disquieting glimpse of the moonlit
+water I could see them plainly only a block away--and was horrified by
+the bestial abnormality of their faces and the dog-like sub-humanness
+of their crouching gait. One man moved in a positively simian way, with
+long arms frequently touching the ground; while another figure--robed
+and tiaraed--seemed to progress in an almost hopping fashion. I judged
+this party to be the one I had seen in the Gilman's courtyard--the one,
+therefore, most closely on my trail. As some of the figures turned
+to look in my direction I was transfixed with fright, yet managed to
+preserve the casual, shambling gait I had assumed. To this day I do
+not know whether they saw me or not. If they did, my stratagem must
+have deceived them, for they passed on across the moonlit space without
+varying their course--meanwhile croaking and jabbering in some hateful
+guttural patois I could not identify.
+
+Once more in shadow, I resumed my former dog-trot past the leaning and
+decrepit houses that stared blankly into the night. Having crossed to
+the western sidewalk I rounded the nearest corner into Bates Street,
+where I kept close to the buildings on the southern side. At last I saw
+the ancient arcaded station--or what was left of it--and made directly
+for the tracks that started from its farther end.
+
+The rails were rusty but mainly intact, and not more than half the
+ties had rotted away. Walking or running on such a surface was very
+difficult; but I did my best, and on the whole made very fair time. For
+some distance the line kept on along the gorge's brink, but at length I
+reached the long covered bridge where it crossed the chasm at a dizzy
+height. The condition of this bridge would determine my next step. If
+humanly possible, I would use it; if not, I would have to risk more
+street wandering and take the nearest intact highway bridge.
+
+The vast, barnlike length of the old bridge gleamed spectrally in the
+moonlight and I saw that the ties were safe for at least a few feet
+within. Entering, I began to use my flashlight, and was almost knocked
+down by the cloud of bats that flapped past me. About halfway across
+there was a perilous gap in the ties which I feared for a moment would
+halt me; but in the end I risked a desperate jump which fortunately
+succeeded.
+
+I was glad to see the moonlight again when I emerged from that macabre
+tunnel. The old tracks crossed River Street at a grade, and at once
+veered off into a region increasingly rural and with less and less of
+Innsmouth's abhorrent fishy odor. Here the dense growth of weeds and
+briers hindered me and cruelly tore my clothes, but I was none the less
+glad that they were there to give me concealment in case of peril. I
+knew that much of my route must be visible from the Rowley road.
+
+The marshy region began very shortly, with the single track on a low,
+grassy embankment. Then came a sort of island of higher ground, where
+the line passed through a shallow open cut choked with bushes and
+brambles. I was very glad of this partial shelter, since at this point
+the Rowley road was uncomfortably near according to my window view.
+
+Just before entering the cut I glanced behind me, but saw no pursuer.
+The ancient spires and roofs of decaying Innsmouth gleamed lovely and
+ethereal in the magic yellow moonlight, and I thought of how they must
+have looked in the old days before the shadow fell. Then, as my gaze
+circled inland from the town, something less tranquil arrested my
+notice and held me immobile for a second.
+
+What I saw--or fancied I saw--was a disturbing suggestion of undulant
+motion far to the south; a suggestion which made me conclude that
+a very large horde must be pouring out of the city along the level
+Ipswich road. The distance was great, and I could distinguish nothing
+in detail; but I did not at all like the look of that moving column.
+
+All sorts of unpleasant conjectures crossed my mind. I thought of those
+very extreme Innsmouth types said to be hidden in crumbling, centuried
+warrens near the waterfront. I thought, too, of those nameless swimmers
+I had seen. Counting the parties so far glimpsed, as well as those
+presumably covering other roads, the number of my pursuers must be
+strangely large for a town as depopulated as Innsmouth.
+
+Who were they? Why were they here? And if such a column of them was
+scouring the Ipswich road, would the patrols on the other roads be
+likewise augmented?
+
+I had entered the brush-grown cut and was struggling along at a very
+slow pace when that damnable fishy odor again waxed dominant. There
+were sounds, too--a kind of wholesale, colossal flopping or pattering
+which somehow called up images of the most detestable sort.
+
+And then both stench and sounds grew stronger, so that I paused
+shivering and grateful for the cut's protection. It was here, I
+recalled, that the Rowley road drew so close to the old railway before
+crossing westward and diverging. Something was coming along that road,
+and I must lie low till its passage and vanishment in the distance.
+Crouched in the bushes of that sandy cleft I felt reasonably safe, even
+though I knew the searchers would have to cross the track in front of
+me not much more than a hundred yards away. I would be able to see
+them, but they could not, except by a malign miracle, see me.
+
+All at once I began dreading to look at them as they passed. I saw the
+close moonlit space where they would surge by, and had curious thoughts
+about the irredeemable pollution of that space. They would perhaps
+be the worst of all Innsmouth types--something one would not care to
+remember.
+
+The stench waxed overpowering, and the noises swelled to a bestial
+babel of croaking, baying, and barking, without the least suggestion
+of human speech. Were these indeed the voices of my pursuers? That
+flopping or pattering was monstrous--I could not look upon the
+degenerate creatures responsible for it. I would keep my eyes shut till
+the sounds receded toward the west. The horde was very close now--the
+air foul with their hoarse snarlings, and the ground almost shaking
+with their alien-rhythmed footfalls. My breath nearly ceased to come,
+and I put every ounce of will-power into the task of holding my eyelids
+down.
+
+I am not even yet willing to say whether what followed was a hideous
+actuality or only a nightmare hallucination. The later action of the
+government, after my frantic appeals, would tend to confirm it as a
+monstrous truth; but could not an hallucination have been repeated
+under the quasi-hypnotic spell of that ancient, haunted, and shadowed
+town?
+
+But I must try to tell what I thought I saw that night under the
+mocking yellow moon--saw surging and hopping down the Rowley road in
+plain sight in front of me as I crouched among the wild brambles of
+that desolate railway cut. Of course my resolution to keep my eyes shut
+had failed. It was foredoomed to failure--for who could crouch blindly
+while a legion of croaking, baying entities of unknown source flopped
+noisomely past, scarcely more than a hundred yards away?
+
+For I knew that a long section of them must be plainly in sight where
+the sides of the cut flattened out and the road crossed the track--and
+I could no longer keep myself from sampling whatever horror that
+leering yellow moon might have to show.
+
+It was the end, for whatever remains to me of life on the surface of
+this earth, of every vestige of mental peace and confidence in the
+integrity of nature and of the human mind. Can it be possible that this
+planet has actually spawned such things; that human eyes have truly
+seen, as objective flesh, what man has hitherto known only in febrile
+phantasy and tenuous legend?
+
+And yet I saw them in a limitless stream--flopping, hopping, croaking,
+bleating--surging inhumanly through the spectral moonlight in a
+grotesque, malignant saraband of fantastic nightmare. And some of them
+had tall tiaras of that nameless whitish-gold metal ... and some were
+strangely robed ... and one, who led the way, was clad in a ghoulishly
+humped black coat and striped trousers, and had a man's felt hat
+perched on the shapeless thing that answered for a head....
+
+I think their predominant color was a grayish-green, though they had
+white bellies. They were mostly shiny and slippery, but the ridges of
+their backs were scaly. Their forms vaguely suggested the anthropoid,
+while their heads were the heads of fish, with prodigious bulging eyes
+that never closed. At the sides of their necks were palpitating gills,
+and their long paws were webbed. They hopped irregularly, sometimes on
+two legs and sometimes on four. I was somehow glad that they had no
+more than four limbs. Their croaking, baying voices, clearly used for
+articulate speech, held all the dark shades of expression which their
+staring faces lacked.
+
+But for all of their monstrousness they were not unfamiliar to me. I
+knew too well what they must be--for was not the memory of that evil
+tiara at Newburyport still fresh? They were the blasphemous fish-frogs
+of the nameless design--living and horrible--and as I saw them I knew
+also of what that humped, tiaraed priest in the black church basement
+had so fearsomely reminded me. Their number was past guessing. It
+seemed to me that there were limitless swarms of them--and certainly my
+momentary glimpse could have shown only the least fraction. In another
+instant everything was blotted out by a merciful fit of fainting; the
+first I had ever had.
+
+
+
+
+                                   V
+
+
+It was a gentle daylight rain that awaked me from my stupor in the
+brush-grown railway cut, and when I staggered out to the roadway ahead
+I saw no trace of any prints in the fresh mud. Innsmouth's ruined roofs
+and toppling steeples loomed up grayly toward the southeast, but not a
+living creature did I spy in all the desolate salt marshes around. My
+watch was still going, and told me that the hour was past noon.
+
+The reality of what I had been through was highly uncertain in my mind,
+but I felt that something hideous lay in the background. I must get
+away from evil-shadowed Innsmouth--and accordingly I began to test
+my cramped, wearied powers of locomotion. Despite weakness, hunger,
+horror, and bewilderment I found myself after a time able to walk; so
+started slowly along the muddy road to Rowley. Before evening I was
+in the village, getting a meal and providing myself with presentable
+clothes. I caught the night train to Arkham, and the next day talked
+long and earnestly with government officials there; a process I later
+repeated in Boston. With the main result of these colloquies the public
+is now familiar--and I wish, for normality's sake, there were nothing
+more to tell. Perhaps it is madness that is overtaking me--yet perhaps
+a greater horror--or a greater marvel--is reaching out.
+
+I dared not look for that piece of strange jewelry said to be in the
+Miskatonic University Museum. I did, however, improve my stay in Arkham
+by collecting some genealogical notes I had long wished to possess;
+very rough and hasty data, it is true, but capable of good use later
+on when I might have time to collate and codify them. The curator of
+the historical society there--Mr. E. Lapham Peabody--was very courteous
+about assisting me, and expressed unusual interest when I told him I
+was a grandson of Eliza Orne of Arkham, who was born in 1867 and had
+married James Williamson of Ohio at the age of seventeen.
+
+It seemed that a maternal uncle of mine had been there many years
+before on a quest much like my own; and that my grandmother's family
+was a topic of some local curiosity. There had, Mr. Peabody said, been
+considerable discussion about the marriage of her father, Benjamin
+Orne, just after the Civil War; since the ancestry of the bride was
+peculiarly puzzling. That bride was understood to have been an orphaned
+Marsh of New Hampshire--a cousin of the Essex County Marshes--but her
+education had been in France and she knew very little of her family. A
+guardian had deposited funds in a Boston bank to maintain her and her
+French governess; but that guardian's name was unfamiliar to Arkham
+people, and in time he dropped out of sight, so that the governess
+assumed his role by court appointment. The French-woman--now long
+dead--was very taciturn, and there were those who said she could have
+told more than she did.
+
+But the most baffling thing was the inability of anyone to place
+the recorded parents of the young woman--Enoch and Lydia (Meserve)
+Marsh--among the known families of New Hampshire. Possibly,
+many suggested, she was the natural daughter of some Marsh of
+prominence--she certainly had the true Marsh eyes. Most of the
+puzzling was done after her early death, which took place at the birth
+of my grandmother--her only child. Having formed some disagreeable
+impressions connected with the name of Marsh, I did not welcome the
+news that it belonged on my own ancestral tree; nor was I pleased
+by Mr. Peabody's suggestion that I had the true Marsh eyes myself.
+However, I was grateful for data which I knew would prove valuable;
+and took copious notes and lists of book references regarding the
+well-documented Orne family.
+
+I went directly home to Toledo from Boston, and later spent a month
+at Maumee recuperating from my ordeal. In September I entered Oberlin
+for my final year, and from then till the next June was busy with
+studies and other wholesome activities--reminded of the bygone terror
+only by occasional official visits from government men in connection
+with the campaign which my pleas and evidence had started. Around the
+middle of July--just a year after the Innsmouth experience--I spent a
+week with my late mother's family in Cleveland; checking some of my
+new genealogical data with the various notes, traditions, and bits
+of heirloom material in existence there, and seeing what kind of a
+connected chart I could construct.
+
+I did not exactly relish this task, for the atmosphere of the
+Williamson home had always depressed me. There was a strain of
+morbidity there, and my mother had never encouraged my visiting her
+parents as a child, although she always welcomed her father when
+he came to Toledo. My Arkham-born grandmother had seemed strange
+and almost terrifying to me, and I do not think I grieved when she
+disappeared. I was eight years old then, and it was said that she had
+wandered off in grief after the suicide of my uncle Douglas, her eldest
+son. He had shot himself after a trip to New England--the same trip,
+no doubt, which had caused him to be recalled at the Arkham Historical
+Society.
+
+This uncle had resembled her, and I had never liked him either.
+Something about the staring, unwinking expression of both of them
+had given me a vague, unaccountable uneasiness. My mother and uncle
+Walter had not looked like that. They were like their father, though
+poor little cousin Lawrence--Walter's son--had been an almost perfect
+duplicate of his grandmother before his condition took him to the
+permanent seclusion of a sanitarium at Canton. I had not seen him in
+four years, but my uncle once implied that his state, both mental and
+physical, was very bad. This worry had probably been a major cause of
+his mother's death two years before.
+
+My grandfather and his widowered son Walter now comprised the Cleveland
+household, but the memory of older times hung thickly over it. I still
+disliked the place, and tried to get my researches done as quickly as
+possible. Williamson records and traditions were supplied in abundance
+by my grandfather; though for Orne material I had to depend on my uncle
+Walter, who put at my disposal the contents of all his files, including
+notes, letters, cuttings, heirlooms, photographs, and miniatures.
+
+It was in going over the letters and pictures on the Orne side that I
+began to acquire a kind of terror of my own ancestry. As I have said,
+my grandmother and uncle Douglas had always disturbed me. Now, years
+after their passing, I gazed at their pictured faces with a measurably
+heightened feeling of repulsion and alienation. I could not at first
+understand the change, but gradually a horrible sort of _comparison_
+began to obtrude itself on my unconscious mind despite the steady
+refusal of my consciousness to admit even the least suspicion of it.
+It was clear that the typical expression of these faces now suggested
+something it had not suggested before--something which would bring
+stark panic if too openly thought of.
+
+But the worst shock came when my uncle showed me the Orne jewelry in
+a downtown safe-deposit vault. Some of the items were delicate and
+inspiring enough, but there was one box of strange old pieces descended
+from my mysterious great-grandmother which my uncle was almost
+reluctant to produce. They were, he said, of very grotesque and almost
+repulsive design.
+
+As my uncle began slowly and grudgingly to unwrap the things, he urged
+me not to be shocked by the strangeness and frequent hideousness of
+the designs. There were two armlets, a tiara, and a kind of pectoral;
+the latter having in high relief certain figures of almost unbearable
+extravagance.
+
+He seemed to expect some demonstration when the first piece--the
+tiara--became visible, but I doubt if he expected quite what actually
+happened. I did not expect it, either, for I thought I was thoroughly
+forewarned regarding what the jewelry would turn out to be. What I did
+was to faint silently away just as I had done in that brier-choked
+railway cut a year before.
+
+From that day on my life has been a nightmare of brooding and
+apprehension, nor do I know how much is hideous truth and how much
+madness. My great-grandmother had been a Marsh of unknown source whose
+husband lived in Arkham--and did not old Zadok say that the daughter of
+Obed Marsh by a monstrous mother was married to an Arkham man through
+a trick? What was it the ancient toper had muttered about the likeness
+of my eyes to Captain Obed's? In Arkham, too, the curator had told me I
+had the true Marsh eyes. Was Obed Marsh my own great-great-grandfather?
+Who--or _what_--then, was my great-great-grandmother? But perhaps
+this was all madness. Those whitish-gold ornaments might easily
+have been bought from some Innsmouth sailor by the father of my
+great-grandmother, whoever he was. And that look in the staring-eyed
+faces of my grandmother and self-slain uncle might be sheer fancy,
+bolstered up by the Innsmouth shadow which had so darkly colored my
+imagination. But why had my uncle killed himself after an ancestral
+quest in New England?
+
+For more than two years I fought off these reflections with partial
+success. My father secured me a place in an insurance office, and
+I buried myself in routine as deeply as possible. In the winter of
+1930-31, however, the dreams began. They were very sparse and insidious
+at first, but increased in frequency and vividness as the weeks went
+by. Great watery spaces opened out before me, and I seemed to wander
+through titanic sunken porticos and labyrinths of weedy cyclopean walls
+and grotesque fishes as my companions. Then the _other shapes_ began to
+appear, filling me with nameless horror the moment I awoke. But during
+the dreams they did not horrify me at all--I was one with them; wearing
+their unhuman trappings, treading their aqueous ways, and praying
+monstrously at their evil sea-bottom temples.
+
+There was much more than I could remember, but even what I did remember
+each morning would be enough to stamp me as a madman or a genius if
+ever I dared write it down. Some frightful influence, I felt, was
+seeking gradually to drag me out of the sane world of wholesome life
+into unnameable abysses of blackness and alienage; and the process
+told heavily on me. My health and appearance grew steadily worse, till
+finally I was forced to give up my position and adopt the static,
+secluded life of an invalid. Some odd nervous affliction had me in its
+grip, and I found myself at times almost unable to shut my eyes.
+
+It was then that I began to study the mirror with mounting alarm. The
+slow ravages of disease are not pleasant to watch, but in my case there
+was something subtler and more puzzling in the background. My father
+seemed to notice it, too, for he began looking at me curiously and
+almost affrightedly. What was taking place in me? Could it be that I
+was coming to resemble my grandmother and uncle Douglas?
+
+One night I had a frightful dream in which I met my grandmother
+under the sea. She lived in a phosphorescent palace of many
+terraces, with gardens of strange leprous corals and grotesque
+brachiate efflorescences, and welcomed me with a warmth that may
+have been sardonic. She had changed--as those who take to the water
+change--and told me she had never died. Instead, she had gone to a
+spot her dead son had learned about, and had leaped to a realm whose
+wonders--destined for him as well--he had spurned with a smoking
+pistol. This was to be my realm, too--I could not escape it. I would
+never die, but would live with those who had lived since before man
+ever walked the earth.
+
+[Illustration: "One night, in a frightful dream, I met two Ancient Ones
+under the sea in a phosphorescent, many terraced palace surrounded by
+gardens of strange, leprous corals."]
+
+I met also that which had been her grandmother. For eighty thousand
+years Pth'thya-l'yi had lived in Y'ha-nthlei, and thither she had gone
+back after Obed Marsh was dead. Y'ha-nthlei was not destroyed when
+the upper-earth men shot death into the sea. It was hurt, but not
+destroyed. The Deep Ones could never be destroyed, even though the
+palaeogean magic of the forgotten Old Ones might sometimes check them.
+For the present they would rest; but some day, if they remembered, they
+would rise again for the tribute Great Cthulhu craved. It would be a
+city greater than Innsmouth next time. They had planned to spread, and
+had brought up that which would help them, but now they must wait once
+more. For bringing the upper-earth men's death I must do a penance,
+but that would not be heavy. This was the dream in which I saw a
+_shoggoth_ for the first time, and the sight set me awake in a frenzy
+of screaming. That morning the mirror definitely told me I had acquired
+_the Innsmouth look_.
+
+So far I have not shot myself as my uncle Douglas did. I bought an
+automatic and almost took the step, but certain dreams deterred me. The
+tense extremes of horror are lessening, and I feel queerly drawn toward
+the unknown sea-deeps instead of fearing them. I hear and do strange
+things in sleep, and awake with a kind of exaltation instead of terror.
+I do not believe I need to wait for the full change as most have
+waited. If I did, my father would probably shut me up in a sanitarium
+as my poor little cousin is shut up. Stupendous and unheard-of
+splendors await me below, and I shall seek them soon. _Iā-R'lyeh!
+Cthulhu fhtagn! Iā! Iā!_ No, I shall not shoot myself--I cannot
+be made to shoot myself!
+
+I shall plan my cousin's escape from that Canton madhouse, and together
+we shall go to marvel-shadowed Innsmouth. We shall swim out to that
+brooding reef in the sea and dive down through black abysses to
+cyclopean and many-columned Y'ha-nthlei, and in that lair of the Deep
+Ones we shall dwell amidst wonder and glory forever.
+
+
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK THE SHADOW OVER INNSMOUTH ***
+
+
+    
+
+Updated editions will replace the previous one—the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg™ electronic works to protect the PROJECT GUTENBERG™
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away—you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg™ mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg™ License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg™
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg™
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg™ electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg™ electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the person
+or entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg™ electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg™ electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg™
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the
+Foundation” or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg™ electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg™ mission of promoting
+free access to electronic works by freely sharing Project Gutenberg™
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg™ name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg™ License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg™ work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg™ License must appear
+prominently whenever any copy of a Project Gutenberg™ work (any work
+on which the phrase “Project Gutenberg” appears, or with which the
+phrase “Project Gutenberg” is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+    This eBook is for the use of anyone anywhere in the United States and most
+    other parts of the world at no cost and with almost no restrictions
+    whatsoever. You may copy it, give it away or re-use it under the terms
+    of the Project Gutenberg License included with this eBook or online
+    at www.gutenberg.org. If you
+    are not located in the United States, you will have to check the laws
+    of the country where you are located before using this eBook.
+  
+1.E.2. If an individual Project Gutenberg™ electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase “Project
+Gutenberg” associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg™
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg™ electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg™ License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg™
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg™.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg™ License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg™ work in a format
+other than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg™ website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the
+full Project Gutenberg™ License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg™ works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg™ electronic works
+provided that:
+
+    • You pay a royalty fee of 20% of the gross profits you derive from
+        the use of Project Gutenberg™ works calculated using the method
+        you already use to calculate your applicable taxes. The fee is owed
+        to the owner of the Project Gutenberg™ trademark, but he has
+        agreed to donate royalties under this paragraph to the Project
+        Gutenberg Literary Archive Foundation. Royalty payments must be paid
+        within 60 days following each date on which you prepare (or are
+        legally required to prepare) your periodic tax returns. Royalty
+        payments should be clearly marked as such and sent to the Project
+        Gutenberg Literary Archive Foundation at the address specified in
+        Section 4, “Information about donations to the Project Gutenberg
+        Literary Archive Foundation.”
+    
+    • You provide a full refund of any money paid by a user who notifies
+        you in writing (or by e-mail) within 30 days of receipt that s/he
+        does not agree to the terms of the full Project Gutenberg™
+        License. You must require such a user to return or destroy all
+        copies of the works possessed in a physical medium and discontinue
+        all use of and all access to other copies of Project Gutenberg™
+        works.
+    
+    • You provide, in accordance with paragraph 1.F.3, a full refund of
+        any money paid for a work or a replacement copy, if a defect in the
+        electronic work is discovered and reported to you within 90 days of
+        receipt of the work.
+    
+    • You comply with all other terms of this agreement for free
+        distribution of Project Gutenberg™ works.
+    
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg™ electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg™ trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg™ collection. Despite these efforts, Project Gutenberg™
+electronic works, and the medium on which they may be stored, may
+contain “Defects,” such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg™ trademark, and any other party distributing a Project
+Gutenberg™ electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’, WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg™ electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg™
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg™ work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg™ work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg™
+
+Project Gutenberg™ is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg™’s
+goals and ensuring that the Project Gutenberg™ collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg™ and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at www.gutenberg.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation’s EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state’s laws.
+
+The Foundation’s business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation’s website
+and official page at www.gutenberg.org/contact
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg™ depends upon and cannot survive without widespread
+public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit www.gutenberg.org/donate.
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate.
+
+Section 5. General Information About Project Gutenberg™ electronic works
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg™ concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg™ eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg™ eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org.
+
+This website includes information about Project Gutenberg™,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/corpora/originals/madnessOG.txt
+++ b/corpora/originals/madnessOG.txt
@@ -1,0 +1,5023 @@
+﻿The Project Gutenberg eBook of At the mountains of madness
+    
+This ebook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this ebook or online
+at www.gutenberg.org. If you are not located in the United States,
+you will have to check the laws of the country where you are located
+before using this eBook.
+
+Title: At the mountains of madness
+
+Author: H. P. Lovecraft
+
+Illustrator: Howard V. Brown
+
+Release date: April 27, 2023 [eBook #70652]
+
+Language: English
+
+Original publication: United States: Street & Smith Publications, Inc, 1936
+
+Credits: Greg Weeks, Mary Meehan and the Online Distributed Proofreading Team at http://www.pgdp.net
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK AT THE MOUNTAINS OF MADNESS ***
+
+
+
+
+
+                      At the MOUNTAINS of MADNESS
+
+                          By H. P. LOVECRAFT
+
+           [Transcriber's Note: This etext was produced from
+            Astounding Stories February, March, April 1936.
+         Extensive research did not uncover any evidence that
+         the U.S. copyright on this publication was renewed.]
+
+
+I am forced into speech because men of science have refused to follow
+my advice without knowing why. It is altogether against my will that
+I tell my reasons for opposing this contemplated invasion of the
+antarctic--with its vast fossil hunt and its wholesale boring and
+melting of the ancient ice caps. And I am the more reluctant because my
+warning may be in vain.
+
+Doubt of the real facts, as I must reveal them, is inevitable; yet,
+if I suppressed what will seem extravagant and incredible there would
+be nothing left. The hitherto withheld photographs, both ordinary
+and aërial, will count in my favor, for they are damnably vivid and
+graphic. Still, they will be doubted because of the great lengths to
+which clever fakery can be carried. The ink drawings, of course, will
+be jeered at as obvious impostures; notwithstanding a strangeness and
+technique which art experts ought to remark and puzzle over.
+
+In the end I must rely on the judgment and standing of the few
+scientific leaders who have, on the one hand, sufficient independence
+of thought to weigh my data on its own hideously convincing merits or
+in the light of certain primordial and highly baffling myth cycles;
+and on the other hand, sufficient influence to deter the exploring
+world in general from any rash and over-ambitious program in the region
+of those mountains of madness.
+
+It is an unfortunate fact that relatively obscure men like myself and
+my associates, connected only with a small university, have little
+chance of making an impression where matters of a wildly bizarre or
+highly controversial natures are concerned.
+
+It is further against us that we are not, in the strictest sense,
+specialists in the fields which came primarily to be concerned. As a
+geologist, my object in leading the Miskatonic University Expedition
+was wholly that of securing deep-level specimens of rock and soil from
+various parts of the antarctic continent, aided by the remarkable drill
+devised by Professor Frank H. Pabodie of our engineering department.
+
+I had no wish to be a pioneer in any other field than this, but I did
+hope that the use of this new mechanical appliance at different points
+along previously explored paths would bring to light materials of a
+sort hitherto unreached by the ordinary methods of collection.
+
+Pabodie's drilling apparatus, as the public already knows from our
+reports, was unique and radical in its lightness, portability, and
+capacity to combine the ordinary Artesian drill principle with the
+principle of the small circular rock drill in such a way as to cope
+quickly with strata of varying hardness.
+
+Steel head, jointed rods, gasoline motor, collapsible wooden derrick,
+dynamiting paraphernalia, cording, rubbish-removal auger, and sectional
+piping for bores five inches wide and up to one thousand feet deep all
+formed, with needed accessories, no greater load than three seven-dog
+sledges could carry. This was made possible by the clever aluminum
+alloy of which most of the metal objects were fashioned.
+
+Four large Dornier aëroplanes, designed especially for the tremendous
+altitude flying necessary on the antarctic plateau and with added
+fuel-warming and quick-starting devices worked out by Pabodie, could
+transport our entire expedition from a base at the edge of the great
+ice barrier to various suitable inland points, and from these points a
+sufficient quota of dogs would serve us.
+
+We planned to cover as great an area as one antarctic season--or
+longer, if absolutely necessary--would permit, operating mostly in the
+mountain ranges and on the plateau south of Ross Sea; regions explored
+in varying degree by Shackleton, Amundsen, Scott, and Byrd. With
+frequent changes of camp, made by aëroplane and involving distances
+great enough to be of geological significance, we expected to unearth a
+quite unprecedented amount of material--especially in the pre-Cambrian
+strata of which so narrow a range of antarctic specimens had previously
+been secured.
+
+We wished also to obtain as great as possible a variety of the upper
+fossiliferous rocks, since the primal life history of this bleak realm
+of ice and death is of the highest importance to our knowledge of the
+earth's past. That the antarctic continent was once temperate and
+even tropical, with a teeming vegetable and animal life of which the
+lichens, marine fauna, arachnida, and penguins of the northern edge are
+the only survivors, is a matter of common information; and we hoped to
+expand that information in variety, accuracy, and detail. When a simple
+boring revealed fossiliferous signs, we would enlarge the aperture by
+blasting, in order to get specimens of suitable size and condition.
+
+Our borings, of varying depth according to the promise held out by the
+upper soil or rock, were to be confined to exposed, or nearly exposed,
+land surfaces--these inevitably being slopes and ridges because of the
+mile or two-mile thickness of solid ice overlying the lower levels.
+
+We could not afford to waste drilling depth on any considerable amount
+of more glaciation, though Pabodie had worked out a plan for sinking
+copper electrodes in thick clusters of borings and melting off limited
+areas of ice with current from a gasoline-driven dynamo.
+
+It is this plan--which we could not put into effect except
+experimentally on an expedition such as ours--that the coming
+Starkweather-Moore Expedition proposes to follow, despite the warnings
+I have issued since our return from the antarctic.
+
+       *       *       *       *       *
+
+The public knows of the Miskatonic Expedition through our frequent
+wireless reports to the _Arkham Advertiser_ and Associated Press, and
+through the later articles by Pabodie and myself. We consisted of four
+men from the University--Pabodie, Lake of the biology department,
+Atwood of the physics department--also a meteorologist--and myself,
+representing geology and having nominal command, also sixteen
+assistants: seven graduate students from Miskatonic and nine skilled
+mechanics.
+
+Of these sixteen, twelve were qualified aëroplane pilots, all but two
+of whom were competent wireless operators. Eight of them understood
+navigation with compass and sextant, as did Pabodie, Atwood and I. In
+addition, of course, our two ships--wooden exwhalers, reinforced for
+ice conditions and having auxiliary steam--were fully manned.
+
+The Nathaniel Derby Pickman Foundation, aided by a few special
+contributions, financed the expedition; hence our preparations were
+extremely thorough, despite the absence of great publicity.
+
+The dogs, sledges, machines, camp materials, and unassembled parts of
+our five planes were delivered in Boston, and there our ships were
+loaded.
+
+We were marvelously well-equipped for our specific purposes, and in
+all matters pertaining to supplies, regimen, transportation, and camp
+construction we profited by the excellent example of our many recent
+and exceptionally brilliant predecessors. It was the unusual number and
+fame of these predecessors which made our own expedition--ample though
+it was--so little noticed by the world at large.
+
+As the newspapers told, we sailed from Boston Harbor on September 2nd,
+1930, taking a leisurely course down the coast and through the Panama
+Canal, and stopping at Samoa and Hobart, Tasmania, at which latter
+place we took on final supplies.
+
+None of our exploring party had ever been in the polar regions before,
+hence we all relied greatly on our ship captains--J. B. Douglas,
+commanding the brig _Arkham_, and serving as commander of the sea
+party, and Georg Thorfinnssen, commanding the barque _Miskatonic_--both
+veteran whalers in antarctic waters.
+
+As we left the inhabited world behind the sun sank lower and lower in
+the north, and stayed longer and longer above the horizon each day.
+At about 62° South Latitude we sighted our first icebergs--tablelike
+objects with vertical sides--and just before reaching the antarctic
+circle, which we crossed on October 20th with appropriately quaint
+ceremonies, we were considerably troubled with field ice.
+
+The falling temperature bothered me considerably after our long voyage
+through the tropics, but I tried to brace up for the worse rigors to
+come. On many occasions the curious atmospheric effects enchanted me
+vastly; these included a strikingly vivid mirage--the first I had ever
+seen--in which distant bergs became the battlements of unimaginable
+cosmic castles.
+
+Pushing through the ice, which was fortunately neither extensive
+nor thickly packed, we regained open water at South Latitude 67°,
+East Longitude 175°. On the morning of October 26th a strong land
+blink appeared on the south, and before noon we all felt a thrill of
+excitement at beholding a vast, lofty, and snow-clad mountain chain
+which opened out and covered the whole vista ahead. At last we had
+encountered an outpost of the great unknown continent and its cryptic
+world of frozen death.
+
+These peaks were obviously the Admiralty Range discovered by Ross, and
+it would now be our task to round Cape Adare and sail down the east
+coast of Victoria Land to our contemplated base on the shore of McMurdo
+Sound, at the foot of the volcano Erebus in South Latitude 77° 9´.
+
+       *       *       *       *       *
+
+The last lap of the voyage was vivid and fancy-stirring. Great barren
+peaks of mystery loomed up constantly against the west as the low
+northern sun of noon or the still lower horizon-grazing southern sun of
+midnight poured its hazy reddish rays over the white snow, bluish ice
+and water lanes, and black bits of exposed granite slope.
+
+Through the desolate summits swept raging, intermittent gusts of
+the terrible antarctic wind, whose cadences sometimes held vague
+suggestions of a wild and half-sentient musical piping, with notes
+extending over a wide range, and which for some subconscious mnemonic
+reason seemed to me disquieting and even dimly terrible.
+
+Something about the scene reminded me of the strange and disturbing
+Asian paintings of Nicholas Roerich, and of the still stranger and more
+disturbing descriptions of the evilly fabled plateau of Leng which
+occur in the dreaded _Necronomicon_ of the mad Arab Abdul Alhazred. I
+was rather sorry, later on, that I had ever looked into that monstrous
+book at the college library.
+
+On the 7th of November, sight of the westward range having been
+temporarily lost, we passed Franklin Island; and the next day descried
+the cones of Mts. Erebus and Terror on Ross Island ahead, with the long
+line of the Parry Mountains beyond. There now stretched off to the east
+the low, white line of the great ice barrier, rising perpendicularly
+to a height of two hundred feet like the rocky cliffs of Quebec, and
+marking the end of southward navigation.
+
+In the afternoon we entered McMurdo Sound and stood off the coast in
+the lee of smoking Mt. Erebus. The scoriaceous peak towered up some
+twelve thousand seven hundred feet against the eastern sky, like a
+Japanese print of the sacred Fujiyama, while beyond it rose the white,
+ghostlike height of Mt. Terror, ten thousand nine hundred feet in
+altitude, and now extinct as a volcano.
+
+Puffs of smoke from Erebus came intermittently, and one of the graduate
+assistants--a brilliant young fellow named Danforth--pointed out what
+looked like lava on the snowy slope, remarking that this mountain,
+discovered in 1840, had undoubtedly been the source of Poe's image
+when he wrote seven years later:
+
+      "--the lavas that restlessly roll
+    Their sulphurous currents down Yaanek
+      In the ultimate climes of the pole--
+    That groan as they roll down Mount Yaanek
+      In the realms of the boreal pole."
+
+Danforth was a great reader of bizarre material, and had talked a
+good deal of Poe. I was interested myself because of the antarctic
+scene of Poe's only long story--the disturbing and enigmatical _Arthur
+Gordon Pym_. On the barren shore, and on the lofty ice barrier in the
+background, myriad of grotesque penguins squawked and flapped their
+fins, while many fat seals were visible on the water, swimming or
+sprawling across large cakes of slowly drifting ice.
+
+Using small boats, we effected a difficult landing on Ross Island
+shortly after midnight, on the morning of the 9th, carrying a line of
+cable from each of the ships and preparing to unload supplies by means
+of a breeches-buoy arrangement.
+
+Our sensations on first treading antarctic soil were poignant and
+complex, even though at this particular point the Scott and Shackleton
+expeditions had preceded us.
+
+Our camp on the frozen shore below the volcano's slope was only a
+provisional one, headquarters being kept aboard the _Arkham_. We landed
+all our drilling apparatus, dogs, sledges, tents, provisions, gasoline
+tanks, experimental ice-melting outfit, cameras, both ordinary and
+aërial, aëroplane parts, and other accessories, including three small
+portable wireless outfits--besides those in the planes--capable of
+communicating with the _Arkham's_ large outfit from any part of the
+antarctic continent that we would be likely to visit.
+
+The ship's outfit, communicating with the outside world, was to convey
+press reports to the _Arkham Advertiser's_ powerful wireless station
+on Kingsport Head, Mass. We hoped to complete our work during a single
+antarctic summer; but if this proved impossible we would winter on the
+_Arkham_, sending the _Miskatonic_ north before the freezing of the ice
+for another summer's supplies.
+
+       *       *       *       *       *
+
+I need not repeat what the newspapers have already published about our
+early work: of our ascent of Mt. Erebus; our successful mineral borings
+at several points on Ross Island and the singular speed with which
+Pabodie's apparatus accomplished them, even through solid rock layers;
+our provisional test of the small ice-melting equipment; our perilous
+ascent of the great barrier with sledges and supplies; and our final
+assembling of five huge aëroplanes at the camp atop the barrier.
+
+The health of our land party--twenty men and fifty-five Alaskan sledge
+dogs--was remarkable, though of course we had so far encountered no
+really destructive temperatures or windstorms.
+
+For the most part, the thermometer varied between zero and 20° or 25°
+above, and our experience with New England winters had accustomed us to
+rigors of this sort. The barrier camp was semipermanent, and destined
+to be a storage cache for gasoline, provisions, dynamite, and other
+supplies.
+
+Only four of our planes were needed to carry the actual exploring
+material, the fifth being left with a pilot and two men, from the
+ships, at the storage cache to form a means of reaching us from the
+_Arkham_ in case all our exploring planes were lost.
+
+Later, when not using all the other planes for moving apparatus, we
+would employ one or two in a shuttle transportation service between
+this cache and another permanent base on the great plateau from six
+hundred to seven hundred miles southward, beyond Beardmore Glacier.
+
+Despite the almost unanimous accounts of appalling winds and tempests
+that pour down from the plateau, we determined to dispense with
+intermediate bases, taking our chances in the interest of economy and
+probable efficiency.
+
+Wireless reports have spoken of the breathtaking, four-hour, nonstop
+flight of our squadron on November 21st over the lofty shelf ice, with
+vast peaks rising on the west, and the unfathomed silences echoing to
+the sound of our engines.
+
+Wind troubled us only moderately, and our radio compasses helped us
+through the one opaque fog we encountered. When the vast rise loomed
+ahead, between Latitudes 83° and 84°, we knew we had reached Beardmore
+Glacier, the largest valley glacier in the world, and that the frozen
+sea was now giving place to a frowning and mountainous coast line.
+
+At last we were truly entering the white, æon-dead world of the
+ultimate south. Even as we realized it we saw the peak of Mt. Nansen
+in the eastern distance, towering up to its height of almost fifteen
+thousand feet.
+
+The successful establishment of the southern base above the glacier in
+Latitude 86° 7´, East Longitude 174° 23´, and the phenomenally rapid
+and effective borings and blastings made at various points reached by
+our sledge trips and short aëroplane flights, are matters of history;
+as is the arduous and triumphant ascent of Mt. Nansen by Pabodie and
+two of the graduate students--Gedney and Carroll--on December 13th to
+15th.
+
+We were some eight thousand five hundred feet above sea-level. When
+experimental drillings revealed solid ground only twelve feet down
+through the snow and ice at certain points, we made considerable use of
+the small melting apparatus and sunk bores and performed dynamiting at
+many places, where no previous explorer had ever thought of securing
+mineral specimens.
+
+The pre-Cambrian granites and beacon sandstones thus obtained confirmed
+our belief that this plateau was homogeneous, with the great bulk of
+the continent to the west, but somewhat different from the parts lying
+eastward below South America--which we then thought to form a separate
+and smaller continent divided from the larger one by a frozen junction
+of Ross and Weddell Seas, though Byrd has since disproved the report.
+
+In certain of the sandstones, dynamited and chiseled after boring
+revealed their nature, we found some highly interesting fossil markings
+and fragments; notably ferns, seaweeds, trilobites, crinoids, and such
+mollusks as linguellæ and gastropods--all of which seemed of real
+significance in connection with the region's primordial history. There
+was also a queer triangular, striated marking, about a foot in greatest
+diameter, which Lake pieced together from three fragments of slate
+brought up from a deep-blasted aperture.
+
+These fragments came from a point to the westward, near the Queen
+Alexandra Range; and Lake, as a biologist, seemed to find their curious
+marking unusually puzzling and provocative, though to my geological eye
+it looked not unlike some of the ripple effects reasonably common in
+the sedimentary rocks.
+
+Since slate is no more than a metamorphic formation into which a
+sedimentary stratum is pressed, and since the pressure itself produces
+odd distorting effects on any markings which may exist, I saw no reason
+for extreme wonder over the striated depression.
+
+       *       *       *       *       *
+
+On January 6, 1931, Lake, Pabodie, Daniels, all six of the students,
+four mechanics, and myself flew directly over the south pole in two
+of the great planes, being forced down once by a sudden high wind,
+which, fortunately, did not develop into a typical storm. This was,
+as the papers have stated, one of several observation flights, during
+others of which we tried to discern new topographical features in areas
+unreached by previous explorers.
+
+Our early flights were disappointing in this latter respect, though
+they afforded us some magnificent examples of the richly fantastic and
+deceptive mirages of the polar regions, of which our sea voyage had
+given us some brief foretastes.
+
+Distant mountains floated in the sky as enchanted cities, and often the
+whole white world would dissolve into a gold, silver, and scarlet land
+of Dunsanian dreams and adventurous expectancy under the magic of the
+low midnight sun.
+
+On cloudy days we had considerable trouble in flying, owing to the
+tendency of snowy earth and sky to merge into one mystical opalescent
+void with no visible horizon to mark the junction of the two.
+
+At length we resolved to carry out our original plan of flying five
+hundred miles eastward with all four exploring planes and establishing
+a fresh sub-base at a point which would probably be on the smaller
+continental division, as we mistakenly conceived it. Geological
+specimens obtained there would be desirable for purposes of comparison.
+
+Our health so far had remained excellent--lime juice well offsetting
+the steady diet of tinned and salted food, and temperatures generally
+above zero enabling us to do without our thickest furs.
+
+It was now midsummer, and with haste and care we might be able to
+conclude work by March and avoid a tedious wintering through the long
+antarctic night. Several savage windstorms had burst upon us from the
+west, but we had escaped damage through the skill of Atwood in devising
+rudimentary aëroplane shelters and windbreaks of heavy snow blocks, and
+in reinforcing the principal camp buildings with snow. Our good luck
+and efficiency had indeed been almost uncanny.
+
+The outside world knew, of course, of our program, and was told also
+of Lake's strange and dogged insistence on a westward--or rather,
+northwestward--prospecting trip before our radical shift to the new
+base.
+
+It seems that he had pondered a great deal and with alarmingly radical
+daring over that triangular striated marking in the slate; reading into
+it certain contradictions in nature and geological period which whetted
+his curiosity to the utmost, and made him avid to sink more borings
+and blastings in the west-stretching formation to which the exhumed
+fragments evidently belonged.
+
+He was strangely convinced that the marking was the print of some
+bulky, unknown, and radically unclassifiable organism of considerably
+advanced evolution, notwithstanding that the rock which bore it was of
+so vastly ancient a date--Cambrian if not actually pre-Cambrian--as to
+preclude the probable existence not only of all highly evolved life,
+but of any life at all above the unicellular or at most the trilobite
+stage. These fragments, with their odd marking, must have been five
+hundred million to a thousand million years old.
+
+
+
+
+                                  II.
+
+
+Popular imagination, I judge, responded actively to our wireless
+bulletins of Lake's start northwestward into regions never trodden
+by human foot or penetrated by human imagination, though we did not
+mention his wild hopes of revolutionizing the entire sciences of
+biology and geology.
+
+His preliminary sledging and boring journey of January 11th to 18th
+with Pabodie and five others--marred by the loss of two dogs in an
+upset when crossing one of the great pressure ridges in the ice--had
+brought up more and more of the Archæan slate; and even I was
+interested by the singular profusion of evident fossil markings in that
+unbelievably ancient stratum.
+
+These markings, however, were of very primitive life forms involving
+no great paradox except that any life forms should occur in rock as
+definitely pre-Cambrian as this seemed to be; hence I still failed to
+see the good sense of Lake's demand for an interlude in our time-saving
+program--an interlude requiring the use of all four planes, many men,
+and the whole of the expedition's mechanical apparatus.
+
+I did not, in the end, veto the plan, though I decided not to accompany
+the northwestward party despite Lake's plea for my geological advice.
+While they were gone, I would remain at the base with Pabodie and five
+men and work out final plans for the eastward shift. In preparation for
+this transfer, one of the planes had begun to move up a good gasoline
+supply from McMurdo Sound; but this could wait temporarily. I kept
+with me one sledge and nine dogs, since it is unwise to be at any time
+without possible transportation in an utterly tenantless world of
+æon-long death.
+
+Lake's subexpedition into the unknown, as every one will recall, sent
+out its own reports from the short-wave transmitters on the planes;
+these being simultaneously picked up by our apparatus at the southern
+base and by the _Arkham_ at McMurdo Sound, whence they were relayed to
+the outside world on wave lengths up to fifty meters.
+
+The start was made January 22nd at 4 a.m.; and the first wireless
+message we received came only two hours later, when Lake spoke of
+descending and starting a small-scale ice-melting and bore at a point
+some three hundred miles away from us. Six hours after that a second
+and very excited message told of the frantic, beaverlike work whereby a
+shallow shaft had been sunk and blasted, culminating in the discovery
+of slate fragments with several markings approximately like the one
+which had caused the original puzzlement.
+
+Three hours later a brief bulletin announced the resumption of the
+flight in the teeth of a raw and piercing gale; and when I dispatched
+a message of protest against further hazards, Lake replied curtly that
+his new specimens made any hazard worth taking.
+
+I saw that his excitement had reached the point of mutiny, and that I
+could do nothing to check this headlong risk of the whole expedition's
+success; but it was appalling to think of his plunging deeper and
+deeper into that treacherous and sinister white immensity of tempests
+and unfathomed mysteries which stretched off for some fifteen hundred
+miles to the half-known, half-suspected coast line of Queen Mary and
+Knox Lands.
+
+       *       *       *       *       *
+
+Then, in about an hour and a half more, came that doubly excited
+message from Lake's moving plane, which almost reversed my sentiments
+and made me wish I had accompanied the party:
+
+    "10:05 p.m. On the wing. After snowstorm, have spied mountain range
+    ahead higher than any hitherto seen. May equal Himalayas, allowing
+    for height of plateau. Probable Latitude 76° 15´, Longitude 113° 10´
+    E. Reaches far as can see to right and left. Suspicion of two
+    smoking cones. All peaks black and bare of snow. Gale blowing off
+    them impedes navigation."
+
+After that Pabodie, the men, and I hung breathlessly over the receiver.
+Thought of this titanic mountain rampart seven hundred miles away
+inflamed our deepest sense of adventure; and we rejoiced that our
+expedition, if not ourselves personally, had been its discoverers. In
+half an hour Lake called us again:
+
+    "Moulton's plane forced down on plateau in foothills, but nobody
+    hurt and perhaps can repair. Shall transfer essentials to other
+    three for return or further moves if necessary, but no more heavy
+    plane travel needed just now. Mountains surpass anything in
+    imagination. Am going up scouting in Carroll's plane, with all
+    weight out.
+
+    "You can't imagine anything like this. Highest peaks must go over
+    thirty-five thousand feet. Everest out of the running, Atwood to
+    work out height with theodolite while Carroll and I go up. Probably
+    wrong about cones, for formations look stratified. Possibly
+    pre-Cambrian slate with other strata mixed in. Queer sky line
+    effects--regular sections of cubes clinging to highest peaks. Whole
+    thing marvelous in red-gold light of low sun. Like land of mystery
+    in a dream or gateway to forbidden world of untrodden wonder. Wish
+    you were here to study."
+
+Though it was technically sleeping time, not one of us listeners
+thought for a moment of retiring. It must have been a good deal
+the same at McMurdo Sound, where the supply cache and the _Arkham_
+were also getting the messages; for Captain Douglas gave out a call
+congratulating everybody on the important find, and Sherman, the cache
+operator, seconded his sentiments. We were sorry, of course, about the
+damaged aëroplane, but hoped it could be easily mended. Then, at eleven
+p.m., came another call from Lake:
+
+    "Up with Carroll over highest foothills. Don't dare try really tall
+    peaks in present weather, but shall later. Frightful work climbing,
+    and hard going at this altitude, but worth it. Great range fairly
+    solid, hence can't get any glimpses beyond. Main summits exceed
+    Himalayas, and very queer. Range looks like pre-Cambrian slate,
+    with plain signs of many other upheaved strata. Was wrong about
+    volcanism. Goes farther in either direction than we can see. Swept
+    clear of snow above about twenty-one thousand feet.
+
+    "Odd formations on slopes of highest mountains. Great low square
+    blocks with exactly vertical sides, and rectangular lines of low,
+    vertical ramparts, like the old Asian castles clinging to steep
+    mountains in Roerich's paintings. Impressive from distance. Flew
+    close to some, and Carroll thought they were formed of smaller
+    separate pieces, but that is probably weathering. Most edges
+    crumbled and rounded off as if exposed to storms and climate
+    changes for millions of years.
+
+    "Parts, especially upper parts, seem to be of lighter-colored
+    rock than any visible strata on slopes proper, hence an evidently
+    crystalline origin. Close flying shows many cave mouths, some
+    unusually regular in outline, square or semicircular. You must come
+    and investigate. Think I saw rampart squarely on top of one peak.
+    Height seems about thirty thousand to thirty-five thousand feet. Am
+    up twenty-one thousand five hundred myself, in devilish, gnawing
+    cold. Wind whistles and pipes through passes and in and out of
+    caves, but no flying danger so far."
+
+From then on for another half hour Lake kept up a running fire of
+comment, and expressed his intention of climbing some of the peaks on
+foot. I replied that I would join him as soon as he could send a plane,
+and that Pabodie and I would work out the best gasoline plan--just
+where and how to concentrate our supply in view of the expedition's
+altered character.
+
+Obviously, Lake's boring operations, as well as his aëroplane
+activities, would need a great deal delivered at the new base which
+he was to establish at the foot of the mountains; and it was possible
+that the eastward flight might not be made, after all, this season. In
+connection with this business I called Captain Douglas and asked him to
+get as much as possible out of the ships and up the barrier with the
+single dog team we had left there. A direct route across the unknown
+region between Lake and McMurdo Sound was what we really ought to
+establish.
+
+Lake called me later to say that he had decided to let the camp stay
+where Moulton's plane had been forced down, and where repairs had
+already progressed somewhat. The ice sheet was very thin, with dark
+ground here and there visible, and he would sink some borings and
+blasts at that very point before making any sledge trips or climbing
+expeditions.
+
+He spoke of the ineffable majesty of the whole scene, and the queer
+state of his sensations at being in the lee of vast, silent pinnacles,
+whose ranks shot up like a wall reaching the sky at the world's rim.
+
+[Illustration: _It was a queer state of sensations--being in the lee of
+vast, silent pinnacles, where ranks shot up like a wall reaching the
+sky at the world's rim._]
+
+Atwood's theodolite observations had placed the height of the five
+tallest peaks at from thirty thousand to thirty-four thousand feet.
+
+The windswept nature of the terrain clearly disturbed Lake, for it
+argued the occasional existence of prodigious gales, violent beyond
+anything we had so far encountered. His camp lay a little more than
+five miles from where the higher foothills rose abruptly.
+
+I could almost trace a note of subconscious alarm in his words--flashed
+across a glacial void of seven hundred miles--as he urged that we all
+hasten with the matter and get the strange, new region disposed of as
+soon as possible. He was about to rest now, after a continuous day's
+work of almost unparalleled speed, strenuousness, and results.
+
+       *       *       *       *       *
+
+In the morning I had a three-cornered wireless talk with Lake and
+Captain Douglas at their widely separated bases. It was agreed that one
+of Lake's planes would come to my base for Pabodie, the five men, and
+myself, as well as for all the fuel it could carry. The rest of the
+fuel question, depending on our decision about an easterly trip, could
+wait for a few days, since Lake had enough for immediate camp heat and
+borings.
+
+Eventually the old southern base ought to be restocked, but if we
+postponed the easterly trip we would not use it till the next summer,
+and, meanwhile, Lake must send a plane to explore a direct route
+between his new mountains and McMurdo Sound.
+
+Pabodie and I prepared to close our base for a short or long period, as
+the case might be. If we wintered in the antarctic we would probably
+fly straight from Lake's base to the _Arkham_ without returning to
+this spot. Some of our conical tents had already been reinforced by
+blocks of hard snow, and now we decided to complete the job of making a
+permanent village. Owing to a very liberal tent supply, Lake had with
+him all that his base would need, even after our arrival. I wirelessed
+that Pabodie and I would be ready for the northwestward move after one
+day's work and one night's rest.
+
+Our labors, however, were not very steady after four p.m., for about
+that time Lake began sending in the most extraordinary and excited
+messages. His working day had started unpropitiously, since an
+aëroplane survey of the nearly exposed rock surfaces showed an entire
+absence of those Archæan and primordial strata for which he was
+looking, and which formed so great a part of the colossal peaks that
+loomed up at a tantalizing distance from the camp.
+
+Most of the rocks glimpsed were apparently Jurassic and Comanchean
+sandstones and Permian and Triassic schists, with now and then a glossy
+black outcropping suggesting a hard and slaty coal.
+
+This rather discouraged Lake, whose plans all hinged on unearthing
+specimens more than five hundred million years older. It was clear
+to him that in order to recover the Archæan slate vein in which he
+had found the odd markings, he would have to make a long sledge trip
+from these foothills to the steep slopes of the gigantic mountains
+themselves.
+
+He had resolved, nevertheless, to do some local boring as part of the
+expedition's general program; hence, he set up the drill and put five
+men to work with it while the rest finished settling the camp and
+repairing the damaged aëroplane. The softest visible rock--a sandstone
+about a quarter of a mile from the camp--had been chosen for the
+first sampling; and the drill made excellent progress without much
+supplementary blasting.
+
+It was about three hours afterward, following the first really heavy
+blast of the operation, that the shouting of the drill crew was heard;
+and that young Gedney--the acting foreman--rushed into the camp with
+the startling news.
+
+       *       *       *       *       *
+
+They had struck a cave. Early in the boring the sandstone had given
+place to a vein of Comanchean limestone, full of minute fossil
+cephalopods, corals, echini, and spirifera, and with occasional
+suggestions of siliceous sponges and marine vertebrate bones--the
+latter probably of teliosts, sharks, and ganoids.
+
+This, in itself, was important enough, as affording the first
+vertebrate fossils the expedition had yet secured; but when shortly
+afterward the drill head dropped through the stratum into apparent
+vacancy, a wholly new and doubly intense wave of excitement spread
+among the excavators.
+
+A good-sized blast had laid open the subterrane secret; and now,
+through a jagged aperture perhaps five feet across and three feet
+thick, there yawned before the avid searchers a section of shallow
+limestone hollowing worn more than fifty million years ago by the
+trickling ground waters of a bygone tropic world.
+
+The hollowed layer was not more than seven or eight feet deep, but
+extended off indefinitely in all directions and had a fresh, slightly
+moving air which suggested its membership in an extensive subterranean
+system. Its roof and floor were abundantly equipped with large
+stalactites and stalagmites, some of which met in columnar form.
+
+But important above all else was the vast deposit of shells and bones,
+which in places nearly choked the passage. Washed down from unknown
+jungles of Mesozoic tree ferns and fungi, and forests of Tertiary
+cycads, fan palms, and primitive angiosperms, this osseous medley
+contained representatives of more Cretaceous, Eocene, and other
+animal species than the greatest palæontologist could have counted or
+classified in a year. Mollusks, crustacean armor, fishes, amphibians,
+reptiles, birds, and early mammals--great and small, known and unknown.
+
+No wonder Gedney ran back to the camp shouting, and no wonder every one
+else dropped work and rushed headlong through the biting cold to where
+the tall derrick marked a new-found gateway to secrets of inner earth
+and vanished æons.
+
+When Lake had satisfied the first keen edge of his curiosity he
+scribbled a message in his notebook and had young Moulton run back to
+the camp to dispatch it by wireless.
+
+This was my first word of the discovery, and it told of the
+identification of early shells, bones of ganoids and placoderms,
+remnants of labyrinthodonta and thecoiidea, great mosasaur skull
+fragments, dinosaur vertebræ and armor plates, pterodactyl teeth and
+wing bones, Archaeopteryx débris, Miocene sharks' teeth, primitive
+bird skulls, and other bones of archaic mammals such as Palæotheres,
+Xiphodons, Eohippi, Oreodons, and Titanotheriidæ.
+
+There was nothing as recent as a mastodon, elephant, true camel, deer,
+or bovine animal; hence Lake concluded that the last deposits had
+occurred during the Oligocene Age, and that the hollowed stratum had
+lain in its present dried, dead, and inaccessible state for at least
+thirty million years.
+
+On the other hand, the prevalence of very early life forms was singular
+in the highest degree. Though the limestone formation was, on the
+evidence of such typical imbedded fossils as ventriculites, positively
+and unmistakably Comanchean and not a particle earlier; the free
+fragments in the hollow space included a surprising proportion from
+organisms hitherto considered as peculiar to far older periods--even
+rudimentary fishes, mollusks, and corals as remote as the Silurian or
+Ordovician.
+
+The inevitable inference was that in this part of the world there had
+been a remarkable and unique degree of continuity between the life of
+over three hundred million years ago and that of only thirty million
+years ago. How far this continuity had extended beyond the Oligocene
+Age when the cavern was closed was of course past all speculation.
+
+In any event, the coming of the frightful ice in the Pleistocene some
+five hundred thousand years ago--a mere yesterday as compared with the
+age of this cavity--must have put an end to any of the primal forms
+which had locally managed to outlive their common terms.
+
+       *       *       *       *       *
+
+Lake was not content to let his first message stand, but had another
+bulletin written and dispatched across the snow to the camp before
+Moulton could get back. After that Moulton stayed at the wireless in
+one of the planes, transmitting to me--and to the _Arkham_ for relaying
+to the outside world--the frequent postscripts which Lake sent him by a
+succession of messengers.
+
+Those who followed the newspapers will remember the excitement created
+among men of science by that afternoon's reports--reports which have
+finally led, after all these years, to the organization of that very
+Starkweather-Moore Expedition which I am so anxious to dissuade from
+its purposes. I had better give the messages literally as Lake sent
+them, and as our base operator McTighe translated them from his pencil
+shorthand:
+
+    Fowler makes discovery of highest importance in sandstone and
+    limestone fragments from blasts. Several distinct triangular
+    striated prints like those in archæan slate, proving that source
+    survived from over six hundred million years ago to Comanchean
+    times without more than moderate morphological changes and decrease
+    in average size. Comanchean prints apparently more primitive or
+    decadent, if anything, than older ones. Emphasize importance of
+    discovery in press. Will mean to biology what Einstein has meant
+    to mathematics and physics. Joins up with my previous work and
+    amplifies conclusions.
+
+    Appears to indicate, as I suspected, that earth has seen whole cycle
+    or cycles of organic life before known one that begins with
+    Archæozoic cells. Was evolved and specialized not later than a
+    thousand million years ago, when planet was young and recently
+    uninhabitable for any life forms of normal protoplasmic structure.
+    Question arises when, where, and how development took place.
+
+        *       *       *       *       *
+
+    Later. Examining certain skeletal fragments of large land and marine
+    saurians and primitive mammals, find singular local wounds or
+    injuries to bony structure not attributable to any known predatory
+    or carnivorous animal of any period. Of two sorts--straight,
+    penetrant bores, and apparently hacking incisions. One or two
+    cases of cleanly severed bones. Not many specimens affected. Am
+    sending to camp for electric torches. Will extend search area
+    underground by hacking away stalactites.
+
+        *       *       *       *       *
+
+    Still later. Have found peculiar soapstone fragment about six inches
+    across and an inch and a half thick, wholly unlike any visible local
+    formation--greenish, but no evidences to place its period. Has
+    curious smoothness and regularity. Shaped like five-pointed star
+    with tips broken off, and signs of other cleavage at inward angles
+    and in center of surface. Small, smooth depression in center of
+    unbroken surface. Arouses much curiosity as to source and
+    weathering. Probably some freak of water action. Carroll, with
+    magnifier, thinks he can make out additional markings of geologic
+    significance. Groups of tiny dots in regular patterns. Dogs growing
+    uneasy as we work, and seem to hate this soapstone. Must see if it
+    has any peculiar odor. Will report again when Mills gets back with
+    light and we start on underground area.
+
+        *       *       *       *       *
+
+    10:15 p.m. Important discovery. Orrendorf and Watkins, working
+    underground at 9:45 with light, found monstrous barrel-shaped fossil
+    of wholly unknown nature; probably vegetable unless overgrown
+    specimen of unknown marine radiata. Tissue evidently preserved by
+    mineral salts. Tough as leather, but astonishing flexibility
+    retained in places. Marks of broken-off parts at ends and around
+    sides. Six feet end to end, three and five tenths feet central
+    diameter, tapering to one foot at each end. Like a barrel with five
+    bulging ridges in place of staves. Lateral breakages, as of
+    thinnish stalks, are at equator in middle of these ridges. In
+    furrows between ridges are curious growths--combs or wings that
+    fold up and spread out like fans. All greatly damaged but one,
+    which gives almost seven-foot wing spread. Arrangement reminds one
+    of certain monsters of primal myth, especially fabled Elder Things
+    in _Necronomicon_.
+
+    These wings seem to be membranous, stretched on framework of
+    glandular tubing. Apparent minute orifices in frame tubing at wing
+    tips. Ends of body shriveled, giving no clue to interior or to what
+    has been broken off there. Must dissect when we get back to camp.
+    Can't decide whether vegetable or animal. Many features obviously
+    of almost incredible primitiveness. Have set all hands cutting
+    stalactites and looking for further specimens. Additional scarred
+    bones found, but these must wait. Having trouble with dogs. They
+    can't endure the new specimen, and would probably tear it to pieces
+    if we didn't keep it at a distance from them.
+
+        *       *       *       *       *
+
+    11:30 p.m. Attention, Dyer, Pabodie, Douglas. Matter of highest--I
+    might say transcendent--importance. _Arkham_ must relay to Kingsport
+    Head Station at once. Strange barrel growth is the archæan thing
+    that left prints in rocks. Mills, Boudreau, and Fowler discover
+    cluster of thirteen more at underground point forty feet from
+    aperture. Mixed with curiously rounded and configured soapstone
+    fragments smaller than one previously found--star-shaped, but no
+    marks of breakage except at some of the points.
+
+    Of organic specimens, eight apparently perfect, with all appendages.
+    Have brought all to surface, leading off dogs to distance. They
+    cannot stand the things. Give close attention to description and
+    repeat back for accuracy. Papers must get this right.
+
+    Objects are eight feet long all over. Six-foot, five-ridged barrel
+    torso three and five tenths feet central diameter, one foot end
+    diameters. Dark gray, flexible, and infinitely tough. Seven-foot
+    membranous wings of same color, found folded, spread out of furrows
+    between ridges. Wing framework tubular or glandular, or lighter
+    gray, with orifices at wing tips. Spread wings have serrated edge.
+    Around equator, one at central apex of each of the five vertical,
+    stavelike ridges, are five systems of light-gray flexible arms or
+    tentacles found tightly folded to torso but expansible to maximum
+    length of over three feet. Like arms of primitive crinoid. Single
+    stalks three inches diameter branch after six inches into five
+    substalks, each of which branches after eight inches into five
+    small, tapering tentacles or tendrils, giving each stalk a total
+    of twenty-five tentacles.
+
+    At top of torso blunt, bulbous neck of lighter gray, with gill-like
+    suggestions, holds yellowish five-pointed starfish-shaped apparent
+    head covered with three-inch wiry cilia of various prismatic colors.
+
+    Head thick and puffy, about two feet point to point, with three-inch
+    flexible yellowish tubes projecting from each point. Slit in exact
+    center of top probably breathing aperture. At end of each tube is
+    spherical expansion where yellowish membrane rolls back on handling
+    to reveal glassy, red-irised globe, evidently an eye.
+
+    Five slightly longer reddish tubes start from inner angles of
+    starfish-shaped head and end in saclike swellings of same color
+    which, upon pressure, open to bell-shaped orifices two inches
+    maximum  diameter and lined with sharp, white tooth-like
+    projections--probable mouths. All these tubes, cilia, and points
+    of starfish head, found folded tightly down; tubes and points
+    clinging to bulbous neck and  torso. Flexibility surprising despite
+    vast toughness.
+
+    At bottom of torso, rough but dissimilarly functioning counterparts
+    of head arrangements exist. Bulbous light-gray pseudoneck, without
+    gill suggestions, holds greenish five-pointed starfish arrangement.
+
+    Tough, muscular arms four feet long and tapering from seven inches
+    diameter at base to about two and five tenths at point. To each
+    point is attached small end of a greenish five-veined membranous
+    triangle eight inches long and six wide at farther end. This is the
+    paddle, fin, or pseudofoot which had made prints in rocks from a
+    thousand million to fifty or sixty million years old.
+
+    From inner angles of starfish arrangement project two-foot reddish
+    tubes tapering from three inches diameter at base to one at tip.
+    Orifices at tips. All these parts infinitely tough and leathery,
+    but extremely flexible. Four-foot arms with paddles undoubtedly
+    used for locomotion of some sort, marine or otherwise. When moved,
+    display suggestions of exaggerated muscularity. As found, all
+    these projections tightly folded over pseudoneck and end of torso,
+    corresponding to projections at other end.
+
+    Cannot yet assign positively to animal or vegetable kingdom, but
+    odds now favor animal. Probably represents incredibly advanced
+    evolution of radiata without loss of certain primitive features.
+    Echinoderm resemblances unmistakable despite local contradictory
+    evidences.
+
+    Wing structure puzzles in view of probable marine habitat, but may
+    have use in water navigation. Symmetry is curiously vegetablelike,
+    suggesting vegetable's essential up-and-down structure rather than
+    animal's fore-and-aft structure. Fabulously early date of evolution,
+    preceding even simplest archæan Protozoa hitherto known, baffles all
+    conjecture as to origin.
+
+    Complete specimens have such uncanny resemblance to certain
+    creatures of primal myth that suggestion of ancient existence
+    outside antarctic becomes inevitable. Dyer and Pabodie have read
+    _Necronomicon_ and seen Clark Ashton Smith's nightmare paintings
+    based on text, and will understand when I speak of Elder Things
+    supposed to have created all earth life as jest or mistake. Students
+    have always thought conception formed from morbid imaginative
+    treatment of very ancient tropical radiata. Also like prehistoric
+    folklore things Wilmarth has spoken of--Cthulhu cult appendages,
+    etc.
+
+    Vast field of study opened. Deposits probably of late Cretaceous
+    or early Eocene period, judging from associated specimens. Massive
+    stalagmites deposited above them. Hard work hewing out, but
+    toughness prevented damage. State of preservation miraculous,
+    evidently owing to limestone action. No more found so far, but
+    will resume search later. Job now to get fourteen huge specimens
+    to camp without dogs, which bark furiously and can't be trusted
+    near them.
+
+    With nine men--three left to guard the dogs--we ought to manage the
+    three sledges fairly well, though wind is bad. Must establish plane
+    communication with McMurdo Sound and begin shipping material. But
+    I've got to dissect one of these things before we take any rest.
+    Wish I had a real laboratory here. Dyer better kick himself for
+    having tried to stop my westward trip. First the world's greatest
+    mountains, and then this. If this last isn't the high spot of the
+    expedition, I don't know what is. We're made scientifically.
+    Congrats, Pabodie, on the drill that opened up the cave. Now will
+    _Arkham_ please repeat description?
+
+[Illustration: "_I've got to dissect one of these things before_----"
+
+"_First the world's greatest mountains--then this!_"]
+
+The sensations of Pabodie and myself at receipt of this report were
+almost beyond description, nor were our companions much behind us in
+enthusiasm. McTighe, who had hastily translated a few high spots as
+they came from the droning receiving set, wrote out the entire message
+from his shorthand version, as soon as Lake's operator signed off.
+
+All appreciated the epoch-making significance of the discovery, and
+I sent Lake congratulations as soon as the _Arkham's_ operator had
+repeated back the descriptive parts as requested; and my example was
+followed by Sherman from his station at the McMurdo Sound supply cache,
+as well as by Captain Douglas of the _Arkham_.
+
+Later, as head of the expedition, I added some remarks to be relayed
+through the _Arkham_ to the outside world. Of course, rest was an
+absurd thought amidst this excitement; and my only wish was to get to
+Lake's camp as quickly as I could. It disappointed me when he sent word
+that a rising mountain gale made early aërial travel impossible.
+
+But within an hour and a half interest again rose to banish
+disappointment. Lake, sending more messages, told of the completely
+successful transportation of the fourteen great specimens to the camp.
+It had been a hard pull, for the things were surprisingly heavy; but
+nine men had accomplished it very neatly. Now some of the party were
+hurriedly building a snow corral at a safe distance from the camp, to
+which the dogs could be brought for greater convenience in feeding. The
+specimens were laid out on the hard snow near the camp, save for one on
+which Lake was making crude attempts at dissection.
+
+This dissection seemed to be a greater task than had been expected,
+for, despite the heat of a gasoline stove in the newly raised
+laboratory tent, the deceptively flexible tissues of the chosen
+specimen--a powerful and intact one--lost nothing of their more than
+leathery toughness. Lake was puzzled as to how he might make the
+requisite incisions without violence destructive enough to upset all
+the structural niceties he was looking for.
+
+He had, it is true, seven more perfect specimens; but these were too
+few to use up recklessly unless the cave might later yield an unlimited
+supply. Accordingly, he removed the specimen and dragged in one which,
+though having remnants of the starfish arrangements at both ends, was
+badly crushed and partly disrupted along one of the great torso furrows.
+
+Results, quickly reported over the wireless, were baffling and
+provocative indeed. Nothing like delicacy or accuracy was possible with
+instruments hardly able to cut the anomalous tissue, but the little
+that was achieved left us all awed and bewildered.
+
+Existing biology would have to be wholly revised, for this thing was no
+product of any cell growth science knows about. There had been scarcely
+any mineral replacement, and despite an age of perhaps forty million
+years the internal organs were wholly intact.
+
+The leathery, undeteriorative, and almost indestructible quality was an
+inherent attribute of the thing's form of organization, and pertained
+to some paleocene cycle of invertebrate evolution utterly beyond our
+powers of speculation.
+
+At first all that Lake found was dry, but as the heated tent produced
+its thawing effect, organic moisture of pungent and offensive odor
+was encountered toward the thing's uninjured side. It was not blood,
+but a thick, dark-green fluid apparently answering the same purpose.
+By the time Lake reached this stage all thirty-seven dogs had been
+brought to the still uncompleted corral near the camp, and even at that
+distance set up a savage barking and show of restlessness at the acrid,
+diffusive smell.
+
+       *       *       *       *       *
+
+Far from helping to place the strange entity, this provisional
+dissection merely deepened its mystery. All guesses about its external
+members had been correct, and on the evidence of these one could hardly
+hesitate to call the thing animal, but internal inspection brought up
+so many vegetable evidences that Lake was left hopelessly at sea. It
+had digestion and circulation, and eliminated waste matter through the
+reddish tubes of its starfish-shaped base.
+
+Cursorily, one would say that its respiratory apparatus handled oxygen
+rather than carbon dioxide; and there were odd evidences of air-storage
+chambers and methods of shifting respiration from the external orifice
+to at least two other fully developed breathing systems--gills and
+pores.
+
+Clearly, it was amphibian and probably adapted to long airless
+hibernation periods as well. Vocal organs seemed present in connection
+with the main respiratory system, but they presented anomalies beyond
+immediate solution. Articulate speech, in the sense of syllable
+utterance, seemed barely conceivable, but musical piping notes covering
+a wide range were highly probable. The muscular system was almost
+pre-naturally developed.
+
+The nervous system was so complex and highly developed as to leave Lake
+aghast. Though excessively primitive and archaic in some respects, the
+thing had a set of gangliar centers and connectives arguing the very
+extremes of specialized development.
+
+Its five-lobed brain was surprisingly advanced, and there were signs of
+a sensory equipment, served in part through the wiry cilia of the head,
+involving factors alien to any other terrestrial organism. Probably it
+had more than five senses, so that its habits could not be predicted
+from any existing analogy.
+
+It must, Lake thought, have been a creature of keen sensitiveness and
+delicately differentiated functions in its primal world--much like the
+ants and bees of to-day. It reproduced like the vegetable cryptogams,
+especially the pteridophyta; having spore cases at the tips of the
+wings and evidently developing from a thallus or prothallus.
+
+But to give it a name at this stage was mere folly. It looked like a
+radiate, but was clearly something more. It was partly vegetable, but
+had three fourths of the essentials of animal structure. That it was
+marine in origin, its symmetrical contour and certain other attributes
+clearly indicated; yet one could not be exact as to the limit of its
+later adaptations.
+
+The wings, after all, held a persistent suggestion of the aërial.
+How it could have undergone its tremendously complex evolution on a
+new-born earth in time to leave prints in archæan rocks was so far
+beyond conception as to make Lake whimsically recall the primal myths
+about Great Old Ones who filtered down from the stars and concocted
+earth life as a joke or mistake; and the wild tales of cosmic hill
+things from outside told by a folklorist colleague in Miskatonic's
+English department.
+
+       *       *       *       *       *
+
+Naturally, he considered the possibility of the pre-Cambrian prints
+having been made by a less evolved ancestor of the present specimens,
+but quickly rejected this too-facile theory upon considering the
+advanced structural qualities of the older fossils. If anything, the
+later contours showed decadence rather than higher evolution.
+
+The size of the pseudofeet had decreased, and the whole morphology
+seemed coarsened and simplified. Moreover, the nerves and organs,
+just examined, held singular suggestions of retrogression from forms
+still more complex. Atrophied and vestigial parts were surprisingly
+prevalent. Altogether, little could be said to have been solved; and
+Lake fell back on mythology for a provisional name--jocosely dubbing
+his finds "The Elder Ones."
+
+At about two-thirty a.m., having decided to postpone further work and
+get a little rest, he covered the dissected organism with a tarpaulin,
+emerged from the laboratory tent, and studied the intact specimens with
+renewed interest.
+
+The ceaseless antarctic sun had begun to limber up their tissues a
+trifle, so that the head points and tubes of two or three showed
+signs of unfolding; but Lake did not believe there was any danger of
+immediate decomposition in the almost subzero air. He did, however,
+move all the undissected specimens closer together and throw a spare
+tent over them in order to keep off the direct solar rays. That
+would also help to keep their possible scent away from the dogs,
+whose hostile unrest was really becoming a problem, even at their
+substantial distance and behind the higher and higher snow walls, which
+an increased quota of the men were hastening to raise around their
+quarters.
+
+He had to weight down the corners of the tent cloth with heavy blocks
+of snow to hold it in place amidst the rising gale, for the titan
+mountains seemed about to deliver some gravely severe blasts. Early
+apprehensions about sudden antarctic winds were revived, and under
+Atwood's supervision precautions were taken to bank the tents, new dog
+corral, and crude aëroplane shelters with snow, on the mountainward
+side. These latter shelters, begun with hard snow blocks during odd
+moments, were by no means as high as they should have been; and Lake
+finally detached all hands from other tasks to work on them.
+
+It was after four when Lake at last prepared to sign off and advised
+us all to share the rest period his outfit would take when the shelter
+walls were a little higher. He held some friendly chat with Pabodie
+over the ether, and repeated his praise of the really marvelous drills
+that had helped him make his discovery. Atwood also sent greetings and
+praises.
+
+I gave Lake a warm word of congratulation, owning up that he was right
+about the western trip, and we all agreed to get in touch by wireless
+at ten in the morning. If the gale was then over, Lake would send a
+plane for the party at my base. Just before retiring I dispatched a
+final message to the _Arkham_, with instructions about toning down the
+day's news for the outside world, since the full details seemed radical
+enough to rouse a wave of incredulity until further substantiated.
+
+
+
+
+                                 III.
+
+
+None of us, I imagine, slept very heavily or continuously that morning.
+Both the excitement of Lake's discovery and the mounting fury of the
+wind were against such a thing. So savage was the blast even where we
+were, that we could not help wondering how much worse it was at Lake's
+camp, directly under the vast unknown peaks that bred and delivered it.
+
+McTighe was awake at ten o'clock and tried to get Lake on the wireless,
+as agreed, but some electrical condition in the disturbed air to the
+westward seemed to prevent communication. We did, however, get the
+_Arkham_, and Douglas told me that he had likewise been vainly trying
+to reach Lake. He had not known about the wind, for very little was
+blowing at McMurdo Sound, despite its persistent rage where we were.
+
+Throughout the day we all listened anxiously and tried to get Lake at
+intervals, but invariably without results. About noon a positive frenzy
+of wind stampeded out of the west, causing us to fear for the safety of
+our camp; but it eventually died down, with only a moderate relapse at
+two p.m.
+
+After three o'clock it was very quiet, and we redoubled our efforts to
+get Lake. Reflecting that he had four planes, each provided with an
+excellent short-wave outfit, we could not imagine any ordinary accident
+capable of crippling all his wireless equipment at once. Nevertheless,
+the stony silence continued, and when we thought of the delirious force
+the wind must have had in his locality we could not help making the
+most direful conjectures.
+
+By six o'clock our fears had become intense and definite, and after a
+wireless consultation with Douglas and Thorfinnssen I resolved to take
+steps toward investigation. The fifth aëroplane, which we had left
+at the McMurdo Sound supply cache with Sherman and two sailors, was
+in good shape and ready for instant use, and it seemed that the very
+emergency for which it had been saved was now upon us.
+
+I got Sherman by wireless and ordered him to join me with the plane
+and the two sailors at the southern base as quickly as possible, the
+air conditions being apparently highly favorable. We then talked over
+the personnel of the coming investigation party, and decided that we
+would include all hands, together with the sledge and dogs which I
+had kept with me. Even so great a load would not be too much for one
+of the huge planes built to our special orders for heavy machinery
+transportation. At intervals I still tried to reach Lake with the
+wireless, but all to no purpose.
+
+Sherman, with the sailors Gunnarsson and Larsen, took off at seven
+thirty; and reported a quiet flight from several points on the wing.
+They arrived at our base at midnight, and all hands at once discussed
+the next move. It was risky business sailing over the antarctic in a
+single aëroplane without any line of bases, but no one drew back from
+what seemed like the plainest necessity. We turned in at two o'clock
+for a brief rest after some preliminary loading of the plane, but were
+up again in four hours to finish the loading and packing.
+
+At seven fifteen a.m., January 25th, we started northwestward under
+McTighe's pilotage with ten men, seven dogs, a sledge, a fuel and food
+supply, and other items including the plane's wireless outfit. The
+atmosphere was clear, fairly quiet, and relatively mild in temperature,
+and we anticipated very little trouble in reaching the latitude and
+longitude designated by Lake as the site of his camp. Our apprehensions
+were over what we might find, or fail to find, at the end of our
+journey, for silence continued to answer all calls dispatched to the
+camp.
+
+       *       *       *       *       *
+
+Every incident of that four-and-a-half-hour flight is burned into my
+recollection because of its crucial position in my life. It marked my
+loss, at the age of fifty-four, of all that peace and balance which the
+normal mind possesses through its accustomed conception of external
+nature and nature's laws.
+
+Thenceforward the ten of us--but the student Danforth and myself
+above all others--were to face a hideously amplified world of lurking
+horrors which nothing can erase from our emotions, and which we
+would refrain from sharing with mankind in general if we could. The
+newspapers have printed the bulletins we sent from the moving plane,
+telling of our nonstop course, our two battles with treacherous
+upper-air gales, our glimpse of the broken surface where Lake had sunk
+his mid-journey shaft three days before, and our sight of a group of
+those strange fluffy snow cylinders noted by Amundsen and Byrd as
+rolling in the wind across the endless leagues of frozen plateau.
+
+There came a point, though, when our sensations could not be conveyed
+in any words the press would understand, and a later point when we had
+to adopt an actual rule of strict censorship.
+
+The sailor Larsen was first to spy the jagged line of witchlike cones
+and pinnacles ahead, and his shouts sent every one to the windows of
+the great cabined plane. Despite our speed, they were very slow in
+gaining prominence; hence we knew that they must be infinitely far off,
+and visible only because of their abnormal height.
+
+Little by little, however, they rose grimly into the western sky,
+allowing us to distinguish various bare, bleak, blackish summits, and
+to catch the curious sense of phantasy which they inspired as seen
+in the reddish antarctic light against the provocative background of
+iridescent ice-dust clouds.
+
+In the whole spectacle there was a persistent, pervasive hint of
+stupendous secrecy and potential revelation. It was as if these
+stark, nightmare spires marked the pylons of a frightful gateway into
+forbidden spheres of dream, and complex gulfs of remote time, space,
+and ultradimensionality. I could not help feeling that they were evil
+things--mountains of madness whose farther slopes looked out over some
+accursed ultimate abyss.
+
+That seething, half-luminous cloud background held ineffable
+suggestions of a vague, ethereal beyondness far more than terrestrially
+spatial, and gave appalling reminders of the utter remoteness,
+separateness, desolation, and æon-long death of this untrodden and
+unfathomed austral world.
+
+       *       *       *       *       *
+
+It was young Danforth who drew our notice to the curious regularities
+of the higher mountain sky line--regularities like clinging fragments
+of perfect cubes, which Lake had mentioned in his messages, and which
+indeed justified his comparison with the dreamlike suggestions of
+primordial temple ruins, on cloudy Asian mountaintops so subtly and
+strangely painted by Roerich.
+
+There was indeed something hauntingly Roerichlike about this whole
+unearthly continent of mountainous mystery. I had felt it in October
+when we first caught sight of Victoria Land, and I felt it afresh now.
+I felt, too, another wave of uneasy consciousness of archæan mythical
+resemblances, of how disturbingly this lethal realm corresponded to the
+evilly famed plateau of Leng in the primal writings.
+
+Mythologists have placed Leng in Central Asia, but the racial memory of
+man--or of his predecessors--is long, and it may well be that certain
+tales have come down from lands and mountains and temples of horror
+earlier than Asia and earlier than any human world we know.
+
+A few daring mystics have hinted at a pre-Pleistocene origin for the
+fragmentary Pnakotic Manuscripts, and have suggested that the devotees
+of Tsathoggua were as alien to mankind as Tsathoggua itself.
+
+Leng, wherever in space or time it might brood, was not a region I
+would care to be in or near, nor did I relish the proximity of a
+world that had ever bred such ambiguous and archæan monstrosities as
+those Lake had just mentioned. At the moment I felt sorry that I had
+ever read the abhorred _Necronomicon_, or talked so much with that
+unpleasantly erudite folklorist Wilmarth at the university.
+
+       *       *       *       *       *
+
+This mood undoubtedly served to aggravate my reaction to the bizarre
+mirage which burst upon us from the increasingly opalescent zenith
+as we drew near the mountains and began to make out the cumulative
+undulations of the foothills. I had seen dozens of polar mirages during
+the preceding weeks, some of them quite as uncanny and fantastically
+vivid as the present sample, but this one had a wholly novel and
+obscure quality of menacing symbolism, and I shuddered as the seething
+labyrinth of fabulous walls and towers and minarets loomed out of the
+troubled ice vapors above our heads.
+
+The effect was that of a Cyclopean city of no architecture known to
+man or to human imagination, with vast aggregations of night-black
+masonry embodying monstrous perversions of geometrical laws. There
+were truncated cones, sometimes terraced or fluted, surmounted by
+tall cylindrical shafts here and there bulbously enlarged and often
+capped with tiers of thinnish scalloped disks, and strange, beetling,
+tablelike constructions suggesting piles of multitudinous rectangular
+slabs or circular plates or five-pointed stars with each one
+overlapping the one beneath.
+
+There were composite cones and pyramids either alone or surmounting
+cylinders or cubes or flatter truncated cones and pyramids, and
+occasional needlelike spires in curious clusters of five.
+
+All of these febrile structures seemed knit together by tubular bridges
+crossing from one to the other at various dizzy heights, and the
+implied scale of the whole was terrifying and oppressive in its sheer
+giganticism.
+
+The general type of mirage was not unlike some of the wilder forms
+observed and drawn by the arctic whaler Scoresby in 1820, but at
+this time and place, with those dark, unknown mountain peaks soaring
+stupendously ahead, that anomalous elder-world discovery in our minds,
+and the pall of probable disaster enveloping the greater part of our
+expedition, we all seemed to find in it a taint of latent malignity and
+infinitely evil portent.
+
+I was glad when the mirage began to break up, though in the process
+the various nightmare turrets and cones assumed distorted, temporary
+forms of even vaster hideousness. As the whole illusion dissolved to
+churning opalescence, we began to look earthward again, and saw that
+our journey's end was not far off.
+
+The unknown mountains ahead rose dizzily up like a fearsome rampart of
+giants, their curious regularities showing with startling clearness
+even without a field glass. We were over the lowest foothills now, and
+could see amidst the snow, ice, and bare patches of their main plateau
+a couple of darkish spots which we took to be Lake's camp and boring.
+
+The higher foothills shot up between five and six miles away, forming a
+range almost distinct from the terrifying line of more than Himalayan
+peaks beyond them. At length Ropes--the student who had relieved
+McTighe at the controls--began to head downward toward the left-hand
+dark spot whose size marked it as the camp. As he did so, McTighe sent
+out the last uncensored wireless message the world was to receive from
+our expedition.
+
+Every one, of course, has read the brief and unsatisfying bulletins of
+the rest of our antarctic sojourn.
+
+Some hours after our landing we sent a guarded report of the tragedy we
+found, and reluctantly announced the wiping out of the whole Lake party
+by the frightful wind of the preceding day, or of the night before
+that. There were eleven known dead, young Gedney was missing.
+
+People pardoned our hazy lack of details through realization of the
+shock the sad event must have caused us, and believed us when we
+explained that the mangling action of the wind had rendered all eleven
+bodies unsuitable for transportation outside.
+
+Indeed, I flatter myself that even in the midst of our distress, utter
+bewilderment, and soul-clutching horror, we scarcely went beyond the
+truth in any specific instance. The tremendous significance lies in
+what we dared not tell; what I would not tell now but for the need of
+warning others off from nameless terrors.
+
+       *       *       *       *       *
+
+It is a fact that the wind had wrought dreadful havoc. Whether all
+could have lived through it, even without the other thing, is gravely
+open to doubt. The storm, with its fury of madly driven ice particles,
+must have been beyond anything our expedition had encountered before.
+
+One aëroplane shelter--all, it seems, had been left in a far too flimsy
+and inadequate state--was nearly pulverized; and the derrick at the
+distant boring was entirely shaken to pieces.
+
+The exposed metal of the grounded planes and drilling machinery was
+bruised into a high polish, and two of the small tents were flattened
+despite their snow banking. Wooden surfaces left out in the blast were
+pitted and denuded of paint, and all signs of tracks in the snow were
+completely obliterated.
+
+It is also true that we found none of the archæan biological objects in
+a condition to take outside as a whole. We did gather some minerals
+from a vast, tumbled pile, including several of the greenish soapstone
+fragments whose odd five-pointed rounding and faint patterns of grouped
+dots caused so many doubtful comparisons, and some fossil bones, among
+which were the most typical of the curiously injured specimens.
+
+None of the dogs survived, their hurriedly built snow inclosure near
+the camp being almost wholly destroyed. The wind may have done that,
+though the greater breakage, on the side next to the camp, which was
+not the windward one, suggests an outward leap or break of the frantic
+beasts themselves.
+
+All three sledges were gone, and we have tried to explain that the wind
+may have blown them off into the unknown. The drill and ice-melting
+machinery at the boring were too badly damaged to warrant salvage, so
+we used them to choke up that subtly disturbing gateway to the past
+which Lake had blasted.
+
+We likewise left at the camp the two most shaken up of the planes;
+since our surviving party had only four real pilots--Sherman, Danforth,
+McTighe, and Ropes--in all, with Danforth in a poor nervous shape to
+navigate. We brought back all the books, scientific equipment, and
+other incidentals we could find, though much was rather unaccountably
+blown away. Spare tents and furs were either missing or badly out of
+condition.
+
+It was approximately four p.m., after wide plane cruising had forced
+us to give Gedney up for lost, that we sent our guarded message to the
+_Arkham_ for relaying; and I think we did well to keep it as calm and
+noncommittal as we succeeded in doing.
+
+The most we said about agitation concerned our dogs, whose frantic
+uneasiness near the biological specimens was to be expected from poor
+Lake's accounts. We did not mention, I think, their display of the
+same uneasiness when sniffing around the queer greenish soapstones
+and certain other objects in the disordered region--objects including
+scientific instruments, aëroplanes, and machinery, both at the camp
+and at the boring, whose parts had been loosened, moved, or otherwise
+tampered with by winds that must have harbored singular curiosity and
+investigativeness.
+
+About the fourteen biological specimens we were pardonably indefinite.
+We said that the only ones we discovered were damaged, but that enough
+was left of them to prove Lake's description wholly and impressively
+accurate. It was hard work keeping our personal emotions out of this
+matter--and we did not mention numbers or say exactly how we had found
+those which we did find. We had by that time agreed not to transmit
+anything suggesting madness on the part of Lake's men, and it surely
+looked like madness to find six imperfect monstrosities carefully
+buried upright in nine-foot snow graves under five-pointed mounds
+punched over with groups of dots in patterns exactly like those on
+the queer greenish soapstones dug up from Mesozoic or Tertiary times.
+The eight perfect specimens mentioned by Lake seemed to have been
+completely blown away.
+
+       *       *       *       *       *
+
+We were careful, too, about the public's general peace of mind; hence
+Danforth and I said little about that frightful trip over the mountains
+the next day. It was the fact that only a radically lightened plane
+could possibly cross a range of such height which mercifully limited
+that scouting tour to the two of us.
+
+On our return at one a.m., Danforth was close to hysterics, but kept an
+admirably stiff upper lip. It took no persuasion to make him promise
+not to show our sketches and the other things we brought away in our
+pockets, not to say anything more to the others than what we had agreed
+to relay outside, and to hide our camera films for private development
+later on; so that part of my present story will be as new to Pabodie,
+McTighe, Ropes, Sherman, and the rest as it will be to that world in
+general. Indeed--Danforth is closer mouthed than I: for he saw, or
+thinks he saw, one thing he will not tell even me.
+
+As all know, our report included a tale of a hard ascent--a
+confirmation of Lake's opinion that the great peaks are of archæan
+slate and other very primal crumpled strata unchanged since at least
+middle Comanchean time, a conventional comment on the regularity of the
+clinging cube and rampart formations, a decision that the cave mouths
+indicate dissolved calcareous veins, a conjecture that certain slopes
+and passes would permit of the scaling and crossing of the entire range
+by seasoned mountaineers, and a remark that the mysterious other side
+holds a lofty and immense superplateau as ancient and unchanging as the
+mountains themselves--twenty thousand feet in elevation, with grotesque
+rock formations protruding through a thin glacial layer and with low
+gradual foothills between the general plateau surface and the sheer
+precipices of the highest peaks.
+
+This body of data is in every respect true so far as it goes, and
+it completely satisfied the men at the camp. We laid our absence of
+sixteen hours--a longer time than our announced flying, landing,
+reconnoitering, and rock-collecting program called for--to a long
+mythical spell of adverse wind conditions, and told truly of our
+landing on the farther foothills.
+
+Fortunately our tale sounded realistic and prosaic enough not to tempt
+any of the others into emulating our flight. Had any tried to do that,
+I would have used every ounce of my persuasion to stop them--and I do
+not know what Danforth would have done.
+
+While we were gone, Pabodie, Sherman, Ropes, McTighe, and Williamson
+had worked like beavers over Lake's two best planes, fitting them
+again for use, despite the altogether unaccountable juggling of their
+operative mechanism.
+
+We decided to load all the planes the next morning and start back for
+our old base as soon as possible. Even though indirect, that was the
+safest way to work toward McMurdo Sound; for a straight-line flight
+across the most utterly unknown stretches of the æon-dead continent
+would involve many additional hazards.
+
+Further exploration was hardly feasible in view of our tragic
+decimation and the ruin of our drilling machinery. The doubts and
+horrors around us--which we did not reveal--made us wish only to escape
+from this austral world of desolation and brooding madness as swiftly
+as we could.
+
+       *       *       *       *       *
+
+As the public knows, our return to the world was accomplished without
+further disasters. All planes reached the old base on the evening of
+the next day--January 27th--after a swift nonstop flight; and on the
+28th we made McMurdo Sound in two laps, the one pause being very brief,
+and occasioned by a faulty rudder, in the furious wind over the ice
+shelf after we had cleared the great plateau.
+
+In five days more, the _Arkham_ and _Miskatonic_, with all hands and
+equipment on board, were shaking clear of the thickening field ice
+and working up Ross Sea, with the mocking mountains of Victoria Land
+looming westward against a troubled antarctic sky and twisting the
+wind's wails into a wide-ranged musical piping which chilled my soul to
+the quick.
+
+Less than a fortnight later we left the last hint of polar land behind
+us and thanked heaven that we were clear of a haunted, accursed realm
+where life and death, space and time, have made black and blasphemous
+alliances in the unknown epochs since matter first writhed and swam on
+the planet's scarce-cooled crust.
+
+Since our return we have all constantly worked to discourage antarctic
+exploration, and have kept certain doubts and guesses to ourselves with
+splendid unity and faithfulness. Even young Danforth, with his nervous
+breakdown, has not flinched or babbled to his doctors.
+
+Indeed, as I have said, there is one thing he thinks he alone saw
+which he will not tell even me, though I think it would help his
+psychological state if he would consent to do so. It might explain and
+relieve much, though perhaps the thing was no more than the delusive
+aftermath of an earlier shock. That is the impression I gather after
+those rare, irresponsible moments when he whispers disjointed things to
+me--things which he repudiates vehemently as soon as he gets a grip on
+himself again.
+
+It will be hard work deterring others from the great white south, and
+some of our efforts may directly harm our cause by drawing inquiring
+notice. We might have known from the first that human curiosity is
+undying, and that the results we announced would be enough to spur
+others ahead on the same age-long pursuit of the unknown.
+
+Lake's reports of those biological monstrosities had aroused
+naturalists and palæontologists to the highest pitch, though we were
+sensible enough not to show the detached parts we had taken from the
+actual buried specimens, or our photographs of those specimens as
+they were found. We also refrained from showing the more puzzling of
+the scarred bones and greenish soapstones; while Danforth and I have
+closely guarded the pictures we took or drew on the superplateau across
+the range, and the crumpled things we smoothed, studied in terror, and
+brought away in our pockets.
+
+But now that Starkweather-Moore party is organizing, and with a
+thoroughness far beyond anything our outfit attempted--if not
+dissuaded, they will get to the innermost nucleus of the antarctic
+and melt and bore till they bring up that which we know may end the
+world. So I must break through all reticences at last--even about that
+ultimate, nameless thing beyond the mountains of madness.
+
+
+
+
+                                  IV.
+
+
+It is only with vast hesitancy and repugnance that I let my mind go
+back to Lake's camp and what we really found there--and to that other
+thing beyond the awful mountain wall.
+
+I have told of the wind-ravaged terrain, the damaged shelters, the
+disarranged machinery, the varied uneasiness of our dogs, the missing
+sledges and other items, the deaths of men and dogs, the absence of
+Gedney, and the six insanely buried biological specimens, strangely
+sound in texture for all their structural injuries, from a world forty
+million years dead. I do not recall whether I mentioned that upon
+checking up the canine bodies we found one dog missing. We did not
+think much about that till later--indeed, only Danforth and I have
+thought of it at all.
+
+The principal things I have been keeping back relate to the bodies,
+and to certain subtle points which may or may not lend a hideous and
+incredible kind of rationale to the apparent chaos.
+
+At the time, I tried to keep the men's minds off those points; for
+it was so much simpler--so much more normal--to lay everything to an
+outbreak of madness on the part of some of Lake's party. From the look
+of things, that demon mountain wind must have been enough to drive
+any man mad in the midst of this center of all earthly mystery and
+desolation.
+
+The crowning abnormality, of course, was the condition of the
+bodies--men and dogs alike. They had all been in some terrible kind
+of conflict, and were torn and mangled in fiendish and altogether
+inexplicable ways. Death, so far as we could judge, had in each case
+come from strangulation or laceration.
+
+The dogs had evidently started the trouble, for the state of their
+ill-built corral bore witness to its forcible breakage from within.
+It had been set some distance from the camp because of the hatred of
+the animals for those hellish archæan organisms, but the precaution
+seemed to have been taken in vain. When left alone in that monstrous
+wind, behind flimsy walls of insufficient height, they must have
+stampeded--whether from the wind itself, or from some subtle,
+increasing odor emitted by the nightmare specimens, one could not say.
+
+       *       *       *       *       *
+
+But whatever had happened, it was hideous and revolting enough.
+Perhaps I had better put squeamishness aside and tell the worst at
+last--though with a categorical statement of opinion, based on the
+first-hand observations and most rigid deductions of both Danforth and
+myself, that the then missing Gedney was in no way responsible for the
+loathsome horrors we found.
+
+I have said that the bodies were frightfully mangled. Now I must
+add that some were incised and subtracted from in the most curious,
+cold-blooded, and inhuman fashion. It was the same with dogs and men.
+All the healthier, fatter bodies, quadrupedal or bipedal, had had
+their most solid masses of tissue cut out and removed, as by a careful
+butcher; and around them was a strange sprinkling of salt--taken from
+the ravaged provision chests on the planes--which conjured up the most
+horrible associations.
+
+The thing had occurred in one of the crude aëroplane shelters from
+which the plane had been dragged out, and subsequent winds had effaced
+all tracks which could have supplied any plausible theory. Scattered
+bits of clothing, roughly slashed from the human incision subjects,
+hinted no clues.
+
+It is useless to bring up the half impression of certain faint snow
+prints in one shielded corner of the ruined inclosure--because that
+impression did not concern human prints at all, but was clearly
+mixed up with all the talk of fossil prints which poor Lake had been
+giving throughout the preceding weeks. One had to be careful of one's
+imagination in the lee of those overshadowing mountains of madness.
+
+As I have indicated, Gedney and one dog turned out to be missing in
+the end. When we came on that terrible shelter we had missed two dogs
+and two men; but the fairly unharmed dissecting tent, which we entered
+after investigating the monstrous graves, had something to reveal.
+
+It was not as Lake had left it, for the covered parts of the primal
+monstrosity had been removed from the improvised table. Indeed, we had
+already realized that one of the six imperfect and insanely buried
+things we had found--the one with the trace of a peculiarly hateful
+odor--must represent the collected sections of the entity which Lake
+had tried to analyze.
+
+On and around that laboratory table were strewn other things, and it
+did not take long for us to guess that those things were the carefully,
+though oddly and inexpertly dissected parts of one man and one dog. I
+shall spare the feelings of survivors by omitting mention of the man's
+identity.
+
+Lake's anatomical instruments were missing, but there were evidences
+of their careful cleansing. The gasoline stove was also gone, though
+around it we found a curious litter of matches. We buried the human
+parts beside the other ten men, and the canine parts with the other
+thirty-five dogs. Concerning the bizarre smudges on the laboratory
+table, and on the jumble of roughly handled illustrated books scattered
+near it, we were much too bewildered to speculate.
+
+This formed the worst of the camp horror, but other things were
+equally perplexing. The disappearance of Gedney, the one dog, the
+eight uninjured biological specimens, the three sledges, and certain
+instruments, illustrated technical and scientific books, writing
+materials, electric torches and batteries, food and fuel, heating
+apparatus, spare tents, fur suits, and the like, was utterly beyond
+sane conjecture; as were likewise the spatter-fringed ink blots on
+certain pieces of paper, and the evidences of curious alien fumbling
+and experimentation around the planes and all other mechanical devices
+both at the camp and at the boring. The dogs seemed to abhor this oddly
+disordered machinery.
+
+Then, too, there was the upsetting of the larder, the disappearance
+of certain staples, and the jarringly comical heap of tin cans pried
+open in the most unlikely ways and at the most unlikely places. The
+profusion of scattered matches, intact, broken, or spent, formed
+another minor enigma--as did the two or three tent cloths and fur suits
+which we found lying about with peculiar and unorthodox slashings
+conceivably due to clumsy efforts at unimaginable adaptations.
+
+The maltreatment of the human and canine bodies, and the crazy burial
+of the damaged archæan specimens, were all of a piece with this
+apparent disintegrative madness. In view of just such an eventuality
+as the present one, we carefully photographed all the main evidences
+of insane disorder at the camp; and shall use the prints to buttress
+our pleas against the departure of the proposed Starkweather-Moore
+Expedition.
+
+       *       *       *       *       *
+
+Our first act after finding the bodies in the shelter was to photograph
+and open the row of insane graves with the five-pointed snow mounds.
+We could not help noticing the resemblance of these monstrous mounds,
+with their clusters of grouped dots, to poor Lake's descriptions of the
+strange greenish soapstones; and when we came on some of the soapstones
+themselves in the great mineral pile we found the likeness very close
+indeed.
+
+The whole general formation, it must be made clear, seemed abominably
+suggestive of the starfish head of the archæan entities; and we agreed
+that the suggestion must have worked potently upon the sensitized minds
+of Lake's overwrought party.
+
+For madness--centering in Gedney as the only possible surviving
+agent--was the explanation spontaneously adopted by everybody so far
+as spoken utterance was concerned; though I will not be so naïve as
+to deny that each of us may have harbored wild guesses which sanity
+forbade him to formulate completely.
+
+Sherman, Pabodie, and McTighe made an exhaustive aëroplane cruise over
+all the surrounding territory in the afternoon, sweeping the horizon
+with field glasses in quest of Gedney and of the various missing
+things; but nothing came to light.
+
+The party reported that the titan-barrier range extended endlessly to
+right and left alike, without any diminution in height or essential
+structure. On some of the peaks, though, the regular cube and rampart
+formations were bolder and plainer, having doubly fantastic similitudes
+to Roerich-painted Asian hill ruins. The distribution of cryptical cave
+mouths on the black snow-denuded summits seemed roughly even as far as
+the range could be traced.
+
+In spite of all the prevailing horrors we were left with enough sheer
+scientific zeal and adventurousness to wonder about the unknown realm
+beyond those mysterious mountains.
+
+As our guarded messages stated, we rested at midnight after our day of
+terror and bafflement--but not without a tentative plan for one or more
+range-crossing altitude flights in a lightened plane with aërial camera
+and geologist's outfit, beginning the following morning.
+
+It was decided that Danforth and I try it first, and we awaked at seven
+a.m. intending an early trip; though heavy winds--mentioned in our
+brief bulletin to the outside world--delayed our start till nearly nine
+o'clock.
+
+I have already repeated the noncommittal story we told the men at
+camp--and relayed outside--after our return sixteen hours later.
+It is now my terrible duty to amplify this account by filling in
+the merciful blanks with hints of what we really saw in that hidden
+transmontane world--hints of the revelations which have finally driven
+Danforth to a nervous collapse.
+
+I wish he would add a really frank word about the thing which he thinks
+he alone saw--even though it was probably a nervous delusion--and which
+was perhaps the last straw that put him where he is; but he is firm
+against that. All I can do is to repeat his later disjointed whispers
+about what set him shrieking as the plane soared back through the
+wind-tortured mountain pass after that real and tangible shock which I
+shared.
+
+This will form my last word. If the plain signs of surviving elder
+horrors in what I disclose be not enough to keep others from meddling
+with the inner antarctic--or at least from prying too deeply beneath
+the surface of that ultimate waste of forbidden secrets and unhuman,
+æon-cursed desolation--the responsibility for unnamable and perhaps
+immeasurable evils will not be mine.
+
+       *       *       *       *       *
+
+Danforth and I, studying the notes made by Pabodie in his afternoon
+flight and checking up with a sextant, had calculated that the lowest
+available pass in the range lay somewhat to the right of us, within
+sight of camp, and about twenty-three thousand or twenty-four thousand
+feet above sea-level. For this point, then, we first headed in the
+lightened plane as we embarked on our flight of discovery.
+
+The camp itself, on foothills which sprang from a high continental
+plateau, was some twelve thousand feet in altitude; hence the
+actual height increase necessary was not so vast as it might seem.
+Nevertheless we were acutely conscious of the rarefied air and intense
+cold as we rose; for, on account of visibility conditions, we had
+to leave the cabin windows open. We were dressed, of course, in our
+heaviest furs.
+
+As we drew near the forbidding peaks, dark and sinister above the
+line of crevasse-riven snow and interstitial glaciers, we noticed more
+and more the curiously regular formations clinging to the slopes; and
+thought again of the strange Asian paintings of Nicholas Roerich.
+
+The ancient and wind-weathered rock strata fully verified all of
+Lake's bulletins, and proved that these pinnacles had been towering
+up in exactly the same way since a surprisingly early time in earth's
+history--perhaps over fifty million years. How much higher they had
+once been, it was futile to guess; but everything about this strange
+region pointed to obscure atmospheric influences unfavorable to
+change, and calculated to retard the usual climatic processes of rock
+disintegration.
+
+But it was the mountainside tangle of regular cubes, ramparts, and cave
+mouths which fascinated and disturbed us most. I studied them with a
+field glass and took aërial photographs while Danforth drove; and at
+times I relieved him at the controls--though my aviation knowledge was
+purely an amateur's--in order to let him use the binoculars.
+
+We could easily see that much of the material of the things was a
+lightish archæan quartzite, unlike any formation visible over broad
+areas of the general surface; and that their regularity was extreme and
+uncanny to an extent which poor Lake had scarcely hinted.
+
+As he had said, their edges were crumbled and rounded from untold
+æons of savage weathering; but their preternatural solidity and tough
+material had saved them from obliteration. Many parts, especially
+those closest to the slopes, seemed identical in substance with the
+surrounding rock surface.
+
+The whole arrangement looked like the ruins of Macchu Picchu in
+the Andes, or the primal foundation walls of Kish as dug up by the
+Oxford-Field Museum Expedition in 1929; and both Danforth and I
+obtained that occasional impression of separate Cyclopean blocks which
+Lake had attributed to his flight-companion Carroll.
+
+How to account for such things in this place was frankly beyond me, and
+I felt queerly humbled as a geologist. Igneous formations often have
+strange regularities--like the famous Giants' Causeway in Ireland--but
+this stupendous range, despite Lake's original suspicion of smoking
+cones, was above all else nonvolcanic in evident structure.
+
+The curious cave mouths, near which the odd formation seemed most
+abundant, presented another, albeit a lesser puzzle because of their
+regularity of outline. They were, as Lake's bulletin had said, often
+approximately square or semicircular; as if the natural orifices had
+been shaped to greater symmetry by some magic hand. Their numerousness
+and wide distribution were remarkable, and suggested that the whole
+region was honeycombed with tunnels dissolved out of limestone strata.
+
+Such glimpses as we secured did not extend far within the caverns, but
+we saw that they were apparently clear of stalactites and stalagmites.
+Outside, those parts of the mountain slopes adjoining the apertures
+seemed invariably smooth and regular; and Danforth thought that the
+slight cracks and pittings of the weathering tended toward unusual
+patterns.
+
+Filled as he was with the horrors and strangenesses discovered at the
+camp, he hinted that the pittings vaguely resembled those baffling
+groups of dots sprinkled over the primeval greenish soapstones, so
+hideously duplicated on the madly conceived snow mounds above those six
+buried monstrosities.
+
+       *       *       *       *       *
+
+We had risen gradually in flying over the higher foothills and along
+toward the relatively low pass we had selected. As we advanced we
+occasionally looked down at the snow and ice of the land route,
+wondering whether we could have attempted the trip with the simpler
+equipment of earlier days.
+
+Somewhat to our surprise we saw that the terrain was far from difficult
+as such things go; and that despite the crevasses and other bad spots
+it would not have been likely to deter the sledges of a Scott, a
+Shackleton, or an Amundsen. Some of the glaciers appeared to lead up to
+wind-bared passes with unusual continuity, and upon reaching our chosen
+pass we found that its case formed no exception.
+
+Our sensations of tense expectancy as we prepared to round the crest
+and peer out over an untrodden world can hardly be described on paper;
+even though we had no cause to think the regions beyond the range
+essentially different from those already seen and traversed. The touch
+of evil mystery in these barrier mountains, and in the beckoning sea of
+opalescent sky glimpsed betwixt their summits, was a highly subtle and
+attenuated matter not to be explained in literal words. Rather was it
+an affair of vague psychological symbolism and æsthetic association--a
+thing mixed up with exotic poetry and paintings, and with archaic myths
+lurking in shunned and forbidden volumes.
+
+Even the wind's burden held a peculiar strain of conscious malignity;
+and for a second it seemed that the composite sound included a bizarre
+musical whistling, or piping over a wide range as the blast swept in
+and out of the omnipresent and resonant cave mouths. There was a cloudy
+note of reminiscent repulsion in this sound, as complex and unplaceable
+as any of the other dark impressions.
+
+We were now, after a slow ascent, at a height of twenty-three thousand
+five hundred and seventy feet according to the aneroid; and had left
+the region of clinging snow definitely below us. Up here were only
+dark, bare rock slopes and the start of rough-ribbed glaciers--but with
+those provocative cubes, ramparts, and echoing cave mouths to add a
+portent of the unnatural, the fantastic, and the dreamlike.
+
+Looking along the line of high peaks, I thought I could see the one
+mentioned by poor Lake, with a rampart exactly on top. It seemed to be
+half lost in a queer antarctic haze--such a haze, perhaps, as had been
+responsible for Lake's early notion of volcanism.
+
+The pass loomed directly before us, smooth and windswept between its
+jagged and malignly frowning pylons. Beyond it was a sky fretted with
+swirling vapors and lighted by the low polar sun--the sky of that
+mysterious farther realm upon which we felt no human eye had ever gazed.
+
+A few more feet of altitude and we would behold that realm. Danforth
+and I, unable to speak except in shouts amidst the howling, piping wind
+that raced through the pass and added to the noise of the unmuffled
+engines, exchanged eloquent glances. And then, having gained those last
+few feet, we did indeed stare across the momentous divide and over the
+unsampled secrets of an elder and utterly alien earth.
+
+
+
+
+                                  V.
+
+
+I think that both of us simultaneously cried out in mixed awe, wonder,
+terror, and disbelief in our own senses as we finally cleared the pass
+and saw what lay beyond. Of course, we must have had some natural
+theory in the back of our heads to steady our faculties for the moment.
+Probably we thought of such things as the grotesquely weathered stones
+of the Garden of the Gods in Colorado, or the fantastically symmetrical
+wind-carved rocks of the Arizona desert. Perhaps we even half thought
+the sight a mirage like that we had seen the morning before on first
+approaching those mountains of madness.
+
+We must have had some such normal notions to fall back upon as our
+eyes swept that limitless, tempest-scarred plateau and grasped the
+almost endless labyrinth of colossal, regular, and geometrically
+eurythmic stone masses which reared their crumbled and pitted crests
+above a glacial sheet not more than forty or fifty feet deep at its
+thickest, and in places obviously thinner.
+
+The effect of the monstrous sight was indescribable, for some fiendish
+violation of known natural law seemed certain at the outset. Here,
+on a hellishly ancient table-land fully twenty thousand feet high,
+and in a climate deadly to habitation since a prehuman age not less
+than five hundred thousand years ago, there stretched nearly to the
+vision's limit a tangle of orderly stone which only the desperation of
+mental self-defense could possibly attribute to any but a conscious and
+artificial cause.
+
+[Illustration: _The effect of the monstrous sight was indescribable!
+Some fiendish violation of natural law!_]
+
+We had previously dismissed, so far as serious thought was concerned,
+any theory that the cubes and ramparts of the mountainsides were other
+than natural in origin. How could they be otherwise, when man himself
+could scarcely have been differentiated from the great apes at the time
+when this region succumbed to the present unbroken reign of glacial
+death?
+
+Yet now the sway of reason seemed irrefutably shaken, for this
+Cyclopean maze of squared, curved, and angled blocks had features which
+cut off all comfortable refuge. It was, very clearly, the blasphemous
+city of the mirage in stark, objective, and ineluctable reality. That
+damnable portent had had a material basis after all--there had been
+some horizontal stratum of ice dust in the upper air, and this shocking
+stone survival had projected its image across the mountains according
+to the simple laws of reflection. Of course, the phantom had been
+twisted and exaggerated, and had contained things which the real source
+did not contain; yet now, as we saw that real source, we thought it
+even more hideous and menacing than its distant image.
+
+[Illustration: _It was, very clearly, the blasphemous city of the
+mirage--in stark, objective reality!_]
+
+Only the incredible, unhuman massiveness of these vast stone towers
+and ramparts had saved the frightful thing from utter annihilation in
+the hundreds of thousands--perhaps millions--of years it had brooded
+there amidst the blasts of a bleak upland. "Corona Mundi--Roof of the
+World----" All sorts of fantastic phrases sprang to our lips as we
+looked dizzily down at the unbelievable spectacle.
+
+I thought again of the eldritch primal myths that had so persistently
+haunted me since my first sight of this dead antarctic world--of
+the demonic plateau of Leng, of the Mi-Go, or Abominable Snow Men
+of the Himalayas, of the Pnakotic Manuscripts with their prehuman
+implications, of the Cthulhu cult, of the _Necronomicon_, and of the
+Hyperborean legends of formless Tsathoggua and the worse than formless
+star spawn associated with that semientity.
+
+       *       *       *       *       *
+
+For boundless miles in every direction the thing stretched off with
+very little thinning; indeed, as our eyes followed it to the right and
+left along the base of the low, gradual foothills which separated it
+from the actual mountain rim, we decided that we could see no thinning
+at all except for an interruption at the left of the pass through
+which we had come. We had merely struck, at random, a limited part of
+something of incalculable extent.
+
+The foothills were more sparsely sprinkled with grotesque stone
+structures, linking the terrible city to the already familiar cubes and
+ramparts which evidently formed its mountain outposts. These latter,
+as well as the queer cave mouths, were as thick on the inner as on the
+outer sides of the mountains.
+
+The nameless stone labyrinth consisted, for the most part, of
+walls from ten to one hundred and fifty feet in ice-clear height,
+and of a thickness varying from five to ten feet. It was composed
+mostly of prodigious blocks of dark primordial slate, schist, and
+sandstone--blocks in many cases as large as 4 × 6 × 8 feet--though in
+several places it seemed to be carved out of a solid, uneven bed rock
+of pre-Cambrian slate.
+
+The buildings were far from equal in size, there being innumerable
+honeycomb arrangements of enormous extent as well as smaller separate
+structures.
+
+The general shape of these things tended to be conical, pyramidal, or
+terraced; though there were many perfect cylinders, perfect cubes,
+clusters of cubes, and other rectangular forms, and a peculiar
+sprinkling of angled edifices whose five-pointed ground plan roughly
+suggested modern fortifications. The builders had made constant and
+expert use of the principle of the arch, and domes had probably existed
+in the city's heyday.
+
+The whole tangle was monstrously weathered, and the glacial surface
+from where the towers projected was strewn with fallen blocks and
+immemorial débris. Where the glaciation was transparent we could see
+the lower parts of the gigantic piles, and we noticed the ice-preserved
+stone bridges which connected the different towers at varying distances
+above the ground. On the exposed walls we could detect the scarred
+places where other and higher bridges of the same sort had existed.
+
+Closer inspection revealed countless largish windows; some of which
+were closed with shutters of a petrified material originally wood,
+though most gaped open in a sinister and menacing fashion.
+
+Many of the ruins, of course, were roofless, and with uneven though
+wind-rounded upper edges; whilst others, of a more sharply conical or
+pyramidal model or else protected by higher surrounding structures,
+preserved intact outlines despite the omnipresent crumbling and
+pitting. With the field glass we could barely make out what seemed to
+be sculptural decorations in horizontal bands--decorations including
+those curious groups of dots whose presence on the ancient soapstones
+now assumed a vastly larger significance.
+
+In many places the buildings were totally ruined and the ice sheet
+deeply riven from various geologic causes. In other places the
+stonework was worn down to the very level of the glaciation. One
+broad swath, extending from the plateau's interior to a cleft in the
+foothills about a mile to the left of the pass we had traversed, was
+wholly free from buildings. It probably represented, we concluded,
+the course of some great river which in Tertiary times--millions
+of years ago--had poured through the city and into some prodigious
+subterranean abyss of the great barrier range. Certainly, this was
+above all a region of caves, gulfs, and underground secrets beyond
+human penetration.
+
+       *       *       *       *       *
+
+Looking back to our sensations, and recalling our dazedness at viewing
+this monstrous survival from æons we had thought prehuman, I can only
+wonder that we preserved the semblance of equilibrium which we did.
+Of course, we knew that something--chronology, scientific theory, or
+our own consciousness--was woefully awry; yet we kept enough poise to
+guide the plane, observe many things quite minutely, and take a careful
+series of photographs which may yet serve both us and the world in good
+stead.
+
+In my case, ingrained scientific habit may have helped; for above all
+my bewilderment and sense of menace there burned a dominant curiosity
+to fathom more of this age-old secret--to know what sort of beings
+had built and lived in this incalculably gigantic place, and what
+relation to the general world of its time or of other times so unique a
+concentration of life could have had.
+
+For this place could be no ordinary city. It must have formed the
+primary nucleus and center of some archaic and unbelievable chapter of
+earth's history whose outward ramifications, recalled only dimly in the
+most obscure and distorted myths, had vanished utterly amidst the chaos
+of terrene convulsions long before any human race we know had shambled
+out of apedom.
+
+Here sprawled a Palæogæan megalopolis compared with which the fabled
+Atlantis and Lemuria, Commoriom and Uzuldaroum, and Olathoë in the
+land of Lomar are recent things of to-day--not even of yesterday;
+a megalopolis ranking with such whispered prehuman blasphemies as
+Valusia, R'lyeh, Ib in the land of Mnar, and the Nameless City of
+Arabia Deserta.
+
+As we flew above that tangle of stark Titan towers my imagination
+sometimes escaped all bounds and roved aimlessly in realms of fantastic
+associations--even weaving links betwixt this lost world and some of my
+own wildest dreams concerning the mad horror at the camp.
+
+The plane's fuel tank, in the interest of greater lightness, had
+been only partly filled; hence we now had to exert caution in our
+explorations. Even so, however, we covered an enormous extent of
+ground--or rather, air--after swooping down to a level where the wind
+became virtually negligible.
+
+There seemed to be no limit to the mountain range, or to the length
+of the frightful stone city which bordered its inner foothills. Fifty
+miles of flight in each direction showed no major change in the
+labyrinth of rock and masonry that clawed up corpselike through the
+eternal ice.
+
+There were, though, some highly absorbing diversifications; such as
+the carvings on the canyon where that broad river had once pierced the
+foothills and approached its sinking place in the great range.
+
+The headlands at the stream's entrance had been boldly carved into
+Cyclopean pylons; and something about the ridgy, barrel-shaped designs
+stirred up oddly vague, hateful, and confusing semiremembrances in both
+Danforth and me.
+
+We also came upon several star-shaped open spaces, evidently public
+squares, and noted various undulations in the terrain. Where a sharp
+hill rose, it was generally hollowed out into some sort of rambling
+stone edifice; but there were at least two exceptions. Of these latter,
+one was too badly weathered to disclose what had been on the jutting
+eminence, while the other still bore a fantastic conical monument
+carved out of the solid rock and roughly resembling such things as the
+well-known Snake Tomb in the ancient valley of Petra.
+
+Flying inland from the mountains, we discovered that the city was
+not of infinite width, even though its length along the foothills
+seemed endless. After about thirty miles the grotesque stone buildings
+began to thin out, and in ten more miles we came to an unbroken waste
+virtually without signs of sentient artifice. The course of the river
+beyond the city seemed marked by a broad, depressed line, while the
+land assumed a somewhat greater ruggedness, seeming to slope slightly
+upward as it receded in the mist-hazed west.
+
+So far we had made no landing, yet to leave the plateau without an
+attempt at entering some of the monstrous structures would have been
+inconceivable. Accordingly, we decided to find a smooth place on the
+foothills near our navigable pass, there grounding the plane and
+preparing to do some exploration on foot.
+
+Though these gradual slopes were partly covered with a scattering of
+ruins, low flying soon disclosed an ample number of possible landing
+places. Selecting that nearest to the pass, since our next flight would
+be across the great range and back to camp, we succeeded about twelve
+thirty p.m. in coming down on a smooth, hard snow field wholly devoid
+of obstacles and well adapted to a swift and favorable take-off later
+on.
+
+       *       *       *       *       *
+
+It did not seem necessary to protect the plane with a snow banking for
+so brief a time and in so comfortable an absence of high winds at this
+level; hence we merely saw that the landing skis were safely lodged,
+and that the vital parts of the mechanism were guarded against the cold.
+
+For our foot journey we discarded the heaviest of our flying furs, and
+took with us a small outfit consisting of pocket compass, hand camera,
+light provisions, voluminous notebooks and paper, geologist's hammer
+and chisel, specimen bags, coil of climbing rope, and powerful electric
+torches with extra batteries; this equipment having been carried in the
+plane on the chance that we might be able to effect a landing, take
+ground pictures, make drawings and topographical sketches, and obtain
+rock specimens from some bare slope, outcropping, or mountain cave.
+
+Fortunately, we had a supply of extra paper to tear up, place in a
+spare specimen bag, and use on the ancient principle of hare and hounds
+for marking our course in any interior mazes we might be able to
+penetrate. This had been brought in case we found some cave system with
+air quiet enough to allow such a rapid and easy method in place of the
+usual rock-chipping method of trail blazing.
+
+Walking cautiously downhill over the crusted snow, toward the
+stupendous stone labyrinth that loomed against the opalescent west,
+we felt almost as keen a sense of imminent marvels as we had felt on
+approaching the unfathomed mountain pass four hours previously.
+
+True, we had become visually familiar with the incredible secret
+concealed by the barrier peaks; yet the prospect of actually entering
+primordial walls reared by conscious beings perhaps millions of years
+ago--before any known race of men could have existed--was none the
+less awesome and potentially terrible in its implications of cosmic
+abnormality.
+
+Though the thinness of the air at this prodigious altitude made
+exertion somewhat more difficult than usual, both Danforth and I found
+ourselves bearing up very well, and felt equal to almost any task which
+might fall to our lot.
+
+It took only a few steps to bring us to a shapeless ruin worn level
+with the snow, while ten or fifteen rods farther on there was a huge,
+roofless rampart still complete in its gigantic five-pointed outline,
+and rising to an irregular height of ten or eleven feet. For this
+latter we headed; and when at last we were actually able to touch
+its weathered Cyclopean blocks, we felt that we had established an
+unprecedented and almost blasphemous link with forgotten æons normally
+closed to our species.
+
+This rampart, shaped like a star and perhaps three hundred feet from
+point to point, was built of Jurassic sandstone blocks of irregular
+size, averaging 6 x 8 feet in surface. There was a row of arched
+loopholes or windows about four feet wide and five feet high, spaced
+quite symmetrically along the points of the star and at its inner
+angles, and with the bottoms about four feet from the glaciated surface.
+
+Looking through these, we could see that the masonry was fully five
+feet thick, that there were no partitions remaining within, and that
+there were traces of banded carvings or bas-reliefs on the interior
+walls--facts we had indeed guessed before, when flying low over this
+rampart and others like it. Though lower parts must have originally
+existed, all traces of such things were now wholly obscured by the deep
+layer of ice and snow at this point.
+
+We crawled through one of the windows and vainly tried to decipher
+the nearly effaced mural designs, but did not attempt to disturb
+the glaciated floor. Our orientation flights had indicated that many
+buildings in the city proper were less ice-choked, and that we might
+perhaps find wholly clear interiors leading down to the true ground
+level if we entered those structures still roofed at the top.
+
+Before we left the rampart we photographed it carefully, and studied
+its mortarless Cyclopean masonry with complete bewilderment. We wished
+that Pabodie were present, for his engineering knowledge might have
+helped us guess how such titanic blocks could have been handled in that
+unbelievably remote age when the city and its outskirts were built up.
+
+       *       *       *       *       *
+
+The half-mile walk downhill to the actual city, with the upper wind
+shrieking vainly and savagely through the skyward peaks in the
+background, was something of which the smallest details will always
+remain engraved on my mind. Only in fantastic nightmares could any
+human beings but Danforth and me conceive such optical effects.
+
+Between us and the churning vapors of the west lay that monstrous
+tangle of dark stone towers, its outré and incredible forms impressing
+us afresh at every new angle of vision. It was a mirage in solid stone,
+and were it not for the photographs I would still doubt that such a
+thing could be. The general type of masonry was identical with that
+of the rampart we had examined; but the extravagant shapes which this
+masonry took in its urban manifestations were past all description.
+
+Even the pictures illustrate only one or two phases of its endless
+variety, preternatural massiveness, and utterly alien exoticism. There
+were geometrical forms for which an Euclid could scarcely find a
+name--cones of all degrees of irregularity and truncation, terraces
+of every sort of provocative disproportion, shafts with odd bulbous
+enlargements, broken columns in curious groups, and five-pointed or
+five-ridged arrangements of mad grotesqueness.
+
+As we drew nearer we could see beneath certain transparent parts of the
+ice sheet, and detect some of the tubular stone bridges that connected
+the crazily sprinkled structures at various heights. Of orderly streets
+there seemed to be none, the only broad open swath being a mile to the
+left, where the ancient river had doubtless flowed through the town
+into the mountains.
+
+Our field glasses showed the external, horizontal bands of nearly
+effaced sculptures and dot groups to be very prevalent, and we could
+half imagine what the city must once have looked like--even though most
+of the roofs and tower tops had necessarily perished.
+
+As a whole, it had been a complex tangle of twisted lanes and alleys,
+all of them deep canyons, and some little better than tunnels because
+of the overhanging masonry or overarching bridges.
+
+Now, outspread below us, it loomed like a dream phantasy against a
+westward mist through whose northern end the low, reddish antarctic sun
+of early afternoon was struggling to shine; and when, for a moment,
+that sun encountered a denser obstruction and plunged the scene into
+temporary shadow, the effect was subtly menacing in a way I can never
+hope to depict. Even the faint howling and piping of the unfelt wind in
+the great mountain passes behind us took on a wilder note of purposeful
+malignity.
+
+The last stage of our descent to the town was unusually steep and
+abrupt, and a rock outcropping at the edge where the grade changed led
+us to think that an artificial terrace had once existed there. Under
+the glaciation, we believed, there must be a flight of steps or its
+equivalent.
+
+When at last we plunged into the town itself, clambering over fallen
+masonry and shrinking from the oppressive nearness and dwarfing height
+of omnipresent crumbling and pitted walls, our sensations again became
+such that I marvel at the amount of self-control we retained.
+
+Danforth was frankly jumpy, and began making some offensively
+irrelevant speculations about the horror at the camp--which I resented
+all the more because I could not help sharing certain conclusions
+forced upon us by many features of this morbid survival from nightmare
+antiquity.
+
+The speculations worked on his imagination, too; for in one
+place--where a débris-littered alley turned a sharp corner--he insisted
+that he saw faint traces of ground markings which he did not like;
+whilst elsewhere he stopped to listen to a subtle, imaginary sound
+from some undefined point--a muffled musical piping, he said, not
+unlike that of the wind in the mountain caves, yet somehow disturbingly
+different.
+
+The ceaseless five-pointedness of the surrounding architecture and
+of the few distinguishable mural arabesques had a dimly sinister
+suggestiveness we could not escape, and gave us a touch of terrible
+subconscious certainty concerning the primal entities which had reared
+and dwelt in this unhallowed place.
+
+Nevertheless, our scientific and adventurous souls were not wholly
+dead, and we mechanically carried out our program of chipping specimens
+from all the different rock types represented in the masonry. We wished
+a rather full set in order to draw better conclusions regarding the age
+of the place.
+
+Nothing in the great outer walls seemed to date from later than the
+Jurassic and Comanchean periods, nor was any piece of stone in the
+entire place of a greater recency than the Pliocene age. In stark
+certainty, we were wandering amidst a death which had reigned at least
+five hundred thousand years, and in all probability even longer.
+
+       *       *       *       *       *
+
+As we proceeded through this maze of stone-shadowed twilight we stopped
+at all available apertures to study interiors and investigate entrance
+possibilities. Some were above our reach, whilst others led only into
+ice-choked ruins as unroofed and barren as the rampart on the hill.
+
+One, though spacious and inviting, opened on a seemingly bottomless
+abyss without visible means of descent. Now and then we had a chance to
+study the petrified wood of a surviving shutter, and were impressed by
+the fabulous antiquity implied in the still discernible grain. These
+things had come from Mesozoic gymnosperms and conifers--especially
+Cretaceous cycads--and from fan palms and early angiosperms of plainly
+Tertiary date. Nothing definitely later than the Pliocene could be
+discovered.
+
+In the placing of these shutters--whose edges showed the former
+presence of queer and long-vanished hinges--usage seemed to be
+varied--some being on the outer and some on the inner side of the
+deep embrasures. They seemed to have become wedged in place, thus
+surviving the rusting of their former and probably metallic fixtures
+and fastenings.
+
+After a time we came across a row of windows--in the bulges of a
+colossal five-edged cone of undamaged apex--which led into a vast,
+well-preserved room with stone flooring; but these were too high in
+the room to permit descent without a rope. We had a rope with us,
+but did not wish to bother with this twenty-foot drop unless obliged
+to--especially in this thin plateau air where great demands were made
+upon the heart action.
+
+This enormous room was probably a hall or concourse of some sort, and
+our electric torches showed bold, distinct, and potentially startling
+sculptures arranged round the walls in broad, horizontal bands
+separated by equally broad strips of conventional arabesques. We took
+careful note of this spot, planning to enter here unless a more easily
+gained interior was encountered.
+
+Finally, though, we did encounter exactly the opening we wished; an
+archway about six feet wide and ten feet high, marking the former end
+of an aërial bridge which had spanned an alley about five feet above
+the present level of glaciation. These archways, of course, were flush
+with upper-story floors, and in this case one of the floors still
+existed.
+
+The building thus accessible was a series of rectangular terraces
+on our left facing westward. That across the alley, where the other
+archway yawned, was a decrepit cylinder with no windows and with
+a curious bulge about ten feet above the aperture. It was totally
+dark inside, and the archway seemed to open on a well of illimitable
+emptiness.
+
+Heaped débris made the entrance to the vast left-hand building doubly
+easy, yet for a moment we hesitated before taking advantage of the
+long-wished chance. For though we had penetrated into this tangle of
+archaic mystery, it required fresh resolution to carry us actually
+inside a complete and surviving building of a fabulous elder world
+whose nature was becoming more and more hideously plain to us.
+
+In the end, however, we made the plunge, and scrambled up over the
+rubble into the gaping embrasure. The floor beyond was of great slate
+slabs, and seemed to form the outlet of a long, high corridor with
+sculptured walls.
+
+Observing the many inner archways which led off from it, and realizing
+the probable complexity of the nest of apartments within, we decided
+that we must begin our system of hare-and-hound trail blazing. Hitherto
+our compasses, together with frequent glimpses of the vast mountain
+range between the towers in our rear, had been enough to prevent our
+losing our way; but from now on, the artificial substitute would be
+necessary.
+
+Accordingly we reduced our extra paper to shreds of suitable size,
+placed these in a bag to be carried by Danforth, and prepared to use
+them as economically as safety would allow. This method would probably
+gain us immunity from straying, since there did not appear to be any
+strong air currents inside the primordial masonry. If such should
+develop, or if our paper supply should give out, we could of course
+fall back on the more secure though more tedious and retarding method
+of rock chipping.
+
+Just how extensive a territory we had opened up, it was impossible
+to guess without a trial. The close and frequent connection of the
+different buildings made it likely that we might cross from one to
+another on bridges underneath the ice, except where impeded by local
+collapses and geologic rifts, for very little glaciation seemed to have
+entered the massive constructions.
+
+Almost all the areas of transparent ice had revealed the submerged
+windows as tightly shuttered, as if the town had been left in that
+uniform state until the glacial sheet came to crystallize the lower
+part for all succeeding time. Indeed, one gained a curious impression
+that this place had been deliberately closed and deserted in some dim,
+bygone æon, rather than overwhelmed by any sudden calamity or even
+gradual decay. Had the coming of the ice been foreseen, and had a
+nameless population left _en masse_ to seek a less doomed abode?
+
+The precise physiographic conditions attending the formation of the
+ice sheet at this point would have to wait for later solution. It had
+not, very plainly, been a grinding drive. Perhaps the pressure of
+accumulated snows had been responsible, and perhaps some flood from
+the river, or from the bursting of some ancient glacial dam in the
+great range, had helped to create the special state now observable.
+Imagination could conceive almost anything in connection with this
+place.
+
+
+
+
+                                  VI.
+
+
+It would be cumbrous to give a detailed, consecutive account of
+our wanderings inside that cavernous, æon-dead honeycomb of primal
+masonry--that monstrous lair of elder secrets which now echoed for the
+first time, after uncounted epochs, to the tread of human feet.
+
+This is especially true because so much of the horrible drama and
+revelation came from a mere study of the omnipresent mural carvings.
+Our flash-light photographs of those carvings will do much toward
+proving the truth of what we are now disclosing, and it is lamentable
+that we had not a larger film supply with us. As it was, we made crude
+notebook sketches of certain salient features after all our films were
+used up.
+
+The building which we had entered was one of great size and
+elaborateness, and gave us an impressive notion of the architecture of
+that nameless geologic past. The inner partitions were less massive
+than the outer walls, but on the lower levels were excellently
+preserved. Labyrinthine complexity, involving curiously irregular
+differences in floor levels, characterized the entire arrangement; and
+we should certainly have been lost at the very outset but for the trail
+of torn paper left behind us.
+
+We decided to explore the more decrepit upper parts first of all, hence
+climbed aloft in the maze for a distance of some one hundred feet, to
+where the topmost tier of chambers yawned snowily and ruinously open to
+the polar sky. Ascent was effected over the steep, transversely ribbed
+stone ramps or inclined planes which everywhere served in lieu of
+stairs.
+
+The rooms we encountered were of all imaginable shapes and proportions,
+ranging from five-pointed stars to triangles and perfect cubes. It
+might be safe to say that their general average was about 30 x 30 feet
+in floor area, and twenty feet in height, though many larger apartments
+existed.
+
+After thoroughly examining the upper regions and the glacial level
+we descended, story by story, into the submerged part, where indeed
+we soon saw we were in a continuous maze of connected chambers and
+passages probably leading over unlimited areas outside this particular
+building.
+
+The Cyclopean massiveness and giganticism of everything about us became
+curiously oppressive; and there was something vaguely but deeply
+unhuman in all the contours, dimensions, proportions, decorations, and
+constructional nuances of the blasphemously archaic stonework. We soon
+realized, from what the carvings revealed, that this monstrous city was
+many million years old.
+
+We cannot yet explain the engineering principles used in the anomalous
+balancing and adjustment of the vast rock masses, though the function
+of the arch was clearly much relied on. The rooms we visited were
+wholly bare of all portable contents, a circumstance which sustained
+our belief in the city's deliberate desertion. The prime decorative
+feature was the almost universal system of mural sculpture, which
+tended to run in continuous horizontal bands three feet wide and
+arranged from floor to ceiling in alternation with bands of equal width
+given over to geometrical arabesques.
+
+There were exceptions to this rule of arrangement, but its
+preponderance was overwhelming. Often, however, a series of smooth
+cartouches containing oddly patterned groups of dots would be sunk
+along one of the arabesque bands.
+
+       *       *       *       *       *
+
+The technique, we soon saw, was mature, accomplished, and æsthetically
+evolved to the highest degree of civilized mastery, though utterly
+alien in every detail to any known art tradition of the human race.
+In delicacy of execution no sculpture I have ever seen could approach
+it. The minutest details of elaborate vegetation, or of animal life,
+were rendered with astonishing vividness despite the bold scale of the
+carvings; whilst the conventional designs were marvels of skillful
+intricacy.
+
+The arabesques displayed a profound use of mathematical principles, and
+were made up of obscurely symmetrical curves and angles based on the
+quantity of five.
+
+The pictorial bands followed a highly formalized tradition, and
+involved a peculiar treatment of perspective, but had an artistic force
+that moved us profoundly notwithstanding the intervening gulf of vast
+geologic periods.
+
+Their method of design hinged on a singular juxtaposition of the cross
+section with the two-dimensional silhouette, and embodied an analytical
+psychology beyond that of any known race of antiquity. It is useless to
+try to compare this art with any represented in our museums. Those who
+see our photographs will probably find its closest analogue in certain
+grotesque conceptions of the most daring futurists.
+
+The arabesque tracery consisted altogether of depressed lines, whose
+depth on unweathered walls varied from one to two inches. When
+cartouches with dot groups appeared--evidently as inscriptions in some
+unknown and primordial language and alphabet--the depression of the
+smooth surface was perhaps an inch and a half, and of the dots perhaps
+a half inch more. The pictorial bands were in countersunk low relief,
+their background being depressed about two inches from the original
+wall surface.
+
+In some specimens marks of a former coloration could be detected,
+though for the most part the untold æons had disintegrated and banished
+any pigments which may have been applied. The more one studied the
+marvelous technique the more one admired the things. Beneath their
+strict conventionalization one could grasp the minute and accurate
+observation and graphic skill of the artists; and indeed, the very
+conventions themselves served to symbolize and accentuate the real
+essence or vital differentiation of every object delineated.
+
+We felt, too, that besides these recognizable excellences there
+were others lurking beyond the reach of our perceptions. Certain
+touches here and there gave vague hints of latent symbols and stimuli
+which another mental and emotional background, and a fuller or
+different sensory equipment, might have made of profound and poignant
+significance to us.
+
+The subject matter of the sculptures obviously came from the life of
+the vanished epoch of their creation, and contained a large proportion
+of evident history. It is this abnormal historic-mindedness of the
+primal race--a chance circumstance operating, through coincidence,
+miraculously in our favor--which made the carvings so awesomely
+informative to us, and which caused us to place their photography and
+transcription above all other considerations.
+
+In certain rooms the dominant arrangement was varied by the presence of
+maps, astronomical charts, and other scientific designs on an enlarged
+scale--these things giving a naïve and terrible corroboration to what
+we gathered from the pictorial friezes and dados.
+
+In hinting at what the whole revealed, I can only hope that my account
+will not arouse a curiosity greater than sane caution on the part of
+those who believe me at all. It would be tragic if any were to be
+allured to that realm of death and horror by the very warning meant to
+discourage them.
+
+       *       *       *       *       *
+
+Interrupting these sculptured walls were high windows and massive
+twelve-foot doorways; both now and then retaining the petrified wooden
+planks--elaborately carved and polished--of the actual shutters and
+doors. All metal fixtures had long ago vanished, but some of the doors
+remained in place and had to be forced aside as we progressed from room
+to room.
+
+Window frames with odd transparent panes--mostly elliptical--survived
+here and there, though in no considerable quantity. There were also
+frequent niches of great magnitude, generally empty, but once in a
+while containing some bizarre object carved from green soapstone which
+was either broken or perhaps held too inferior to warrant removal.
+
+Other apertures were undoubtedly connected with bygone mechanical
+facilities--heating, lighting, and the like--of a sort suggested in
+many of the carvings. Ceilings tended to be plain, but had sometimes
+been inlaid with green soapstone or other tiles, mostly fallen now.
+Floors were also paved with such tiles, though plain stonework
+predominated.
+
+As I have said, all furniture and other movables were absent; but the
+sculptures gave a clear idea of the strange devices which had once
+filled these tomblike, echoing rooms. Above the glacial sheet the
+floors were generally thick with detritus, litter, and débris, but
+farther down this condition decreased.
+
+In some of the lower chambers and corridors there was little more than
+gritty dust or ancient incrustations, while occasional areas had an
+uncanny air of newly swept immaculateness. Of course, where rifts or
+collapses had occurred, the lower levels were as littered as the
+upper ones.
+
+A central court--as we had seen in other structures, from the
+air--saved the inner regions from total darkness; so that we seldom had
+to use our electric torches in the upper rooms except when studying
+sculptured details. Below the ice cap, however, the twilight deepened;
+and in many parts of the tangled ground level there was an approach to
+absolute blackness.
+
+To form even a rudimentary idea of our thoughts and feelings as we
+penetrated this æon-silent maze of unhuman masonry one must correlate
+a hopelessly bewildering chaos of fugitive moods, memories, and
+impressions. The sheer appalling antiquity and lethal desolation of the
+place were enough to overwhelm almost any sensitive person, but added
+to these elements were the recent unexplained horror at the camp, and
+the revelations all too soon effected by the terrible mural sculptures
+around us.
+
+The moment we came upon a perfect section of carving, where no
+ambiguity of interpretation could exist, it took only a brief study
+to give us the hideous truth--a truth which it would be naïve to claim
+Danforth and I had not independently suspected before, though we had
+carefully refrained from even hinting it to each other. There could
+now be no further merciful doubt about the nature of the beings which
+had built and inhabited this monstrous dead city millions of years
+ago, when man's ancestors were primitive archaic mammals, and vast
+Dinosauria roamed the tropical steppes of Europe and Asia.
+
+We had previously clung to a desperate alternative and insisted--each
+to himself--that the omnipresence of the five-pointed motif meant only
+some cultural or religious exaltation of the archæan natural object
+which had so patently embodied the quality of five-pointedness; as the
+decorative motifs of Minoan Crete exalted the sacred bull, those of
+Egypt the scarabæus, those of Rome the wolf and the eagle, and those of
+various savage tribes some chosen totem animal.
+
+But this lone refuge was now stripped from us, and we were forced to
+face definitely the reason-shaking realization which the reader of
+these pages has doubtless long ago anticipated. I can scarcely bear to
+write it down in black and white even now, but perhaps that will not be
+necessary.
+
+       *       *       *       *       *
+
+The things once rearing and dwelling in this frightful masonry in the
+age of Dinosauria were not indeed Dinosauria, but far worse. Mere
+Dinosauria were new and almost brainless objects--but the builders of
+the city were wise and old, and had left certain traces in rocks even
+then laid down well nigh a thousand million years--rocks laid down
+before the true life of earth had advanced beyond plastic groups of
+cells--rocks laid down before the true life of earth had existed at all.
+
+They were the makers and enslavers of that life, and above all doubt
+the originals of the fiendish elder myths which things like the
+Pnakotic Manuscripts and the _Necronomicon_ affrightedly hint about.
+They were the great "Old Ones" that had filtered down from the stars
+when earth was young--the beings whose substance an alien evolution had
+shaped, and whose powers were such as this planet had never bred. And
+to think that only the day before Danforth and I had actually looked
+upon fragments of their millennially fossilized substance--and that
+poor Lake and his party had seen their complete outlines----
+
+It is, of course, impossible for me to relate in proper order the
+stages by which we picked up what we know of that monstrous chapter of
+prehuman life. After the first shock of the certain revelation, we had
+to pause a while to recuperate, and it was fully three o'clock before
+we got started on our actual tour of systematic research.
+
+The sculptures in the building we entered were of relatively late
+date--perhaps two million years ago--as checked up by geological,
+biological, and astronomical features--and embodied an art which would
+be called decadent in comparison with that of specimens we found in
+older buildings, after crossing bridges under the glacial sheet.
+
+One edifice hewn from the solid rock seemed to go back forty or
+possibly even fifty million years--to the lower Eocene or upper
+Cretaceous--and contained bas-reliefs of an artistry surpassing
+anything else, with one tremendous exception, that we encountered. That
+was, we have since agreed, the oldest domestic structure we traversed.
+
+Were it not for the support of those flashlights soon to be made
+public, I would refrain from telling what I found and inferred, lest I
+be confined as a madman. Of course, the infinitely early parts of the
+patchwork tale--representing the preterrestrial life of the star-headed
+beings on other planets, in other galaxies, and in other universes--can
+readily be interpreted as the fantastic mythology of those beings
+themselves; yet such parts sometimes involved designs and diagrams so
+uncannily close to the latest findings of mathematics and astrophysics
+that I scarcely know what to think. Let others judge when they see the
+photographs I shall publish.
+
+Naturally, no one set of carvings which we encountered told more than a
+fraction of any connected story, nor did we even begin to come upon the
+various stages of that story in their proper order. Some of the vast
+rooms were independent units so far as their designs were concerned,
+whilst in other cases a continuous chronicle would be carried through a
+series of rooms and corridors.
+
+The best of the maps and diagrams were on the walls of a frightful
+abyss below even the ancient ground level--a cavern perhaps two hundred
+feet square and sixty feet high, which had almost undoubtedly been an
+educational center of some sort.
+
+There were many provoking repetitions of the same material in different
+rooms and buildings, since certain chapters of experience, and certain
+summaries or phases of racial history, had evidently been favorites
+with different decorators or dwellers. Sometimes, though, variant
+versions of the same theme proved useful in settling debatable points
+and filling up gaps.
+
+I still wonder that we deduced so much in the short time at our
+disposal. Of course, we even now have only the barest outline--and
+much of that was obtained later on from a study of the photographs and
+sketches we made.
+
+It may be the effect of this later study--the revived memories and
+vague impressions acting in conjunction with his general sensitiveness
+and with that final supposed horror-glimpse whose essence he will not
+reveal even to me--which has been the immediate source of Danforth's
+present breakdown.
+
+But it had to be; for we could not issue our warning intelligently
+without the fullest possible information, and the issuance of that
+warning is a prime necessity. Certain lingering influences in that
+unknown antarctic world of disordered time and alien natural law make
+it imperative that further exploration be discouraged.
+
+
+
+
+                                 VII.
+
+
+The full story, so far as deciphered, will eventually appear in an
+official bulletin of Miskatonic University. Here I shall sketch only
+the salient highlights in a formless, rambling way. Myth or otherwise,
+the sculptures told of the coming of those star-headed things to the
+nascent, lifeless earth out of cosmic space--their coming, and the
+coming of many other alien entities such as at certain times embark
+upon spatial pioneering.
+
+They seemed able to traverse the interstellar ether on their vast
+membranous wings--thus oddly confirming some curious hill folklore long
+ago told me by an antiquarian colleague. They had lived under the sea a
+good deal, building fantastic cities and fighting terrific battles with
+nameless adversaries by means of intricate devices employing unknown
+principles of energy.
+
+Evidently their scientific and mechanical knowledge far surpassed
+man's to-day, though they made use of its more widespread and elaborate
+forms only when obliged to.
+
+Some of the sculptures suggested that they had passed through a stage
+of mechanized life on other planets, but had receded upon finding
+its effects emotionally unsatisfying. Their preternatural toughness
+of organization and simplicity of natural wants made them peculiarly
+able to live on a high plane without the more specialized fruits
+of artificial manufacture, and even without garments, except for
+occasional protection against the elements.
+
+It was under the sea, at first for food and later for other purposes,
+that they first created earth life--using available substances
+according to long-known methods.
+
+The more elaborate experiments came after the annihilation of various
+cosmic enemies. They had done the same thing on other planets, having
+manufactured not only necessary foods, but certain multicellular
+protoplasmic masses capable of molding their tissues into all sorts of
+temporary organs under hypnotic influence and thereby forming ideal
+slaves to perform the heavy work of the community.
+
+These viscous masses were without doubt what Abdul Alhazred whispered
+about as the "Shoggoths" in his frightful _Necronomicon_, though even
+that mad Arab had not hinted that any existed on earth except in the
+dreams of those who had chewed a certain alkaloidal herb.
+
+When the star-headed Old Ones on this planet had synthesized their
+simple food forms and bred a good supply of Shoggoths, they allowed
+other cell groups to develop into other forms of animal and vegetable
+life for sundry purposes, extirpating any whose presence became
+troublesome.
+
+With the aid of the Shoggoths, whose expansions could be made to lift
+prodigious weights, the small, low cities under the sea grew to vast
+and imposing labyrinths of stone not unlike those which later rose on
+land. Indeed, the highly adaptable Old Ones had lived much on land in
+other parts of the universe, and probably retained many traditions of
+land construction.
+
+As we studied the architecture of all these sculptured Palæogæan
+cities, including that whose æon-dead corridors we were even then
+traversing, we were impressed by a curious coincidence which we have
+not yet tried to explain, even to ourselves. The tops of the buildings,
+which in the actual city around us had, of course, been weathered into
+shapeless ruins ages ago, were clearly displayed in the bas-reliefs,
+and showed vast clusters of needlelike spires, delicate finials
+on certain cone and pyramid apexes, and tiers of thin, horizontal
+scalloped disks capping cylindrical shafts.
+
+This was exactly what we had seen in that monstrous and portentous
+mirage, cast by a dead city whence such sky-line features had been
+absent for thousands and ten of thousands of years, which loomed on our
+ignorant eyes across the unfathomed mountains of madness as we first
+approached poor Lake's ill-fated camp.
+
+       *       *       *       *       *
+
+Of the life of the Old Ones, both under the sea and after part of them
+migrated to land, volumes could be written. Those in shallow water had
+continued the fullest use of the eyes at the ends of their five main
+head tentacles, and had practiced the arts of sculpture and of writing
+in quite the usual way--the writing accomplished with a stylus on
+waterproof waxen surfaces.
+
+Those lower down in the ocean depths, though they used a curious
+phosphorescent organism to furnish light, pieced out their vision with
+obscure special senses operating through the prismatic cilia on their
+heads--senses which rendered all the Old Ones partly independent of
+light in emergencies. Their forms of sculpture and writing had changed
+curiously during the descent, embodying certain apparently chemical
+coating processes--probably to secure phosphorescence--which the
+bas-reliefs could not make clear to us.
+
+The beings moved in the sea partly by swimming--using the lateral
+crinoid arms--and partly by wriggling with the lower tier of tentacles
+containing the pseudofeet. Occasionally they accomplished long swoops
+with the auxiliary use of two or more sets of their fan-like folding
+wings.
+
+On land they locally used the pseudofeet, but now and then flew to
+great heights or over long distances with their wings. The many
+slender tentacles into which the crinoid arms branched were infinitely
+delicate, flexible, strong, and accurate in muscular-nervous
+coördination--ensuring the utmost skill and dexterity in all artistic
+and other manual operations.
+
+The toughness of the things was almost incredible. Even the terrific
+pressure of the deepest sea bottoms appeared powerless to harm them.
+Very few seemed to die at all except by violence, and their burial
+places were very limited. The facts that they covered their vertically
+inhumed dead with five-pointed inscribed mounds set up thoughts in
+Danforth and me which made a fresh pause and recuperation necessary
+after the sculptures revealed it.
+
+[Illustration: _The toughness of the things was almost incredible. Even
+terrific pressures were powerless to harm them!_]
+
+The beings multiplied by means of spores--like vegetable pteridophyta,
+as Lake had suspected--but, owing to their prodigious toughness and
+longevity, and consequent lack of replacement needs, they did not
+encourage the large-scale development of new prothallia except when
+they had new regions to colonize.
+
+The young matured swiftly, and received an education evidently beyond
+any standard we can imagine. The prevailing intellectual and æsthetic
+life was highly evolved, and produced a tenaciously enduring set of
+customs and institutions which I shall describe more fully in my coming
+monograph. These varied slightly according to sea or land residence,
+but had the same foundations and essentials.
+
+Though able, like vegetables, to derive nourishment from inorganic
+substances; they vastly preferred organic and especially animal food.
+They ate uncooked marine life under the sea, but cooked their viands on
+land. They hunted game and raised meat herds--slaughtering with sharp
+weapons whose odd marks on certain fossil bones our expedition had
+noted.
+
+They resisted all ordinary temperatures marvelously, and in their
+natural state could live in water down to freezing. When the great
+chill of the Pleistocene drew on, however--nearly a million years
+ago--the land dwellers had to resort to special measures, including
+artificial heating--until, at last, the deadly cold appears to have
+driven them back into the sea.
+
+For their prehistoric flights through cosmic space, legend said, they
+had absorbed certain chemicals and become almost independent of eating,
+breathing, or heat conditions--but by the time of the great cold
+they had lost track of the method. In any case, they could not have
+prolonged the artificial state indefinitely without harm.
+
+Being nonpairing and semivegetable in structure, the Old Ones had
+no biological basis for the family phase of mammal life, but seemed
+to organize large households on the principles of comfortable
+space-utility and--as we deduced from the pictured occupations and
+diversions of codwellers--congenial mental association.
+
+In furnishing their homes they kept everything in the center of the
+huge rooms, leaving all wall spaces free for decorative treatment.
+Lighting, in the case of the land inhabitants, was accomplished by a
+device probably electro-chemical in nature.
+
+Both on land and under water they used curious tables, chairs and
+couches like cylindrical frames--for they rested and slept upright with
+folded-down tentacles--and racks for the hinged sets of dotted surfaces
+forming their books.
+
+       *       *       *       *       *
+
+Government was evidently complex and probably socialistic, though no
+certainties in this regard could be deduced from the sculptures we
+saw. There was extensive commerce, both local and between different
+cities--certain small, flat counters, five-pointed and inscribed,
+serving as money. Probably the smaller of the various greenish
+soapstones found by our expedition were pieces of such currency.
+
+Though the culture was mainly urban, some agriculture and much stock
+raising existed. Mining and a limited amount of manufacturing were also
+practiced. Travel was very frequent, but permanent migration seemed
+relatively rare except for the vast colonizing movements by which the
+race expanded.
+
+For personal locomotion no external aid was used, since in land, air,
+and water movement alike the Old Ones seemed to possess excessively
+vast capacities for speed. Loads, however, were drawn by beasts of
+burden--Shoggoths under the sea, and a curious variety of primitive
+vertebrates in the later years of land existence.
+
+These vertebrates, as well as an infinity of other life forms--animal
+and vegetable, marine, terrestrial, and aërial--were the products of
+unguided evolution acting on life cells made by the Old Ones, but
+escaping beyond their radius of attention. They had been suffered
+to develop unchecked because they had not come in conflict with the
+dominant beings. Bothersome forms, of course, were mechanically
+exterminated.
+
+It interested us to see in some of the very last and most decadent
+sculptures a shambling, primitive mammal, used sometimes for food and
+sometimes as an amusing buffoon by the land dwellers, whose vaguely
+simian and human foreshadowings were unmistakable. In the building of
+land cities the huge stone blocks of the high towers were generally
+lifted by vast-winged pterodactyls of a species heretofore unknown to
+palæontology.
+
+The persistence with which the Old Ones survived various geologic
+changes and convulsions of the earth's crust was little short of
+miraculous. Though few or none of their first cities seem to have
+remained beyond the Archæan Age, there was no interruption in their
+civilization or in the transmission of their records.
+
+Their original place of advent to the planet was the Antarctic Ocean,
+and it is likely that they came not long after the matter forming the
+moon was wrenched from the neighboring South Pacific. According to one
+of the sculptured maps, the whole globe was then under water, with
+stone cities scattered farther and farther from the antarctic as æons
+passed.
+
+Another map shows a vast bulk of dry land around the south pole, where
+it is evident that some of the beings made experimental settlements,
+though their main centers were transferred to the nearest sea bottom.
+
+Later maps, which display this land mass as cracking and drifting, and
+sending certain detached parts northward, uphold in a striking way the
+theories of continental drift lately advanced by Taylor, Wegener, and
+Joly.
+
+With the upheaval of new land in the South Pacific, tremendous events
+began. Some of the marine cities were hopelessly shattered, yet that
+was not the worst misfortune. Another race--a land race of beings
+shaped like octopi and probably corresponding to the fabulous prehuman
+spawn of Cthulhu--soon began filtering down from cosmic infinity and
+precipitated a monstrous war which for a time drove the Old Ones
+wholly back to the sea--a colossal blow in view of the increasing land
+settlements.
+
+Later, peace was made, and the new lands were given to the Cthulhu
+spawn whilst the Old Ones held the sea and the older lands. New land
+cities were founded--the greatest of them in the antarctic, for this
+region of first arrival was sacred.
+
+From then on, as before, the antarctic remained the center of the Old
+Ones' civilization, and all the cities built there by the Cthulhu spawn
+were blotted out.
+
+Then, suddenly, the lands of the Pacific sank again, taking with them
+the frightful stone city of R'lyeh and all the cosmic octopi, so that
+the Old Ones were again supreme on the planet, except for one shadowy
+fear about which they did not like to speak.
+
+At a rather later age their cities dotted all the land and water areas
+of the globe--hence the recommendation in my coming monograph that some
+archæologist make systematic borings with Pabodie's type of apparatus
+in certain widely separated regions.
+
+       *       *       *       *       *
+
+The steady trend down the ages was from water to land--a movement
+encouraged by the rise of new land masses, though the ocean was never
+wholly deserted. Another cause of the landward movement was the new
+difficulty in breeding and managing the Shoggoths upon which successful
+sea life depended.
+
+With the march of time, as the sculptures sadly confessed, the art of
+creating new life from inorganic matter had been lost, so that the Old
+Ones had to depend on the molding of forms already in existence. On
+land the great reptiles proved highly tractable; but the Shoggoths of
+the sea, reproducing by fission and acquiring a dangerous degree of
+accidental intelligence, presented for a time a formidable problem.
+
+They had always been controlled through the hypnotic suggestion of
+the Old Ones, and had modeled their tough plasticity into various
+useful temporary limbs and organs; but now their self-modeling powers
+were sometimes exercised independently, and in various imitative
+forms implanted by past suggestion. They had, it seems, developed a
+semistable brain whose separate and occasionally stubborn volition
+echoed the will of the Old Ones without always obeying it.
+
+Sculptured images of these Shoggoths filled Danforth and me with
+horror and loathing. They were normally shapeless entities composed
+of a viscous jelly which looked like an agglutination of bubbles, and
+each averaged about fifteen feet in diameter when a sphere. They had,
+however, a constantly shifting shape and volume--throwing out temporary
+developments or forming apparent organs of sight, hearing, and speech
+in imitation of their masters, either spontaneously or according to
+suggestion.
+
+They seem to have become peculiarly intractable toward the middle of
+the Permian Age, perhaps one hundred and fifty million years ago, when
+a veritable war of resubjugation was waged upon them by the marine Old
+Ones. Pictures of this war, and of the headless, slime-coated fashion
+in which the Shoggoths typically left their slain victims, held a
+marvelously fearsome quality despite the intervening abyss of untold
+ages.
+
+The Old Ones had used curious weapons of molecular disturbance against
+the rebel entities, and in the end had achieved a complete victory.
+Thereafter the sculptures showed a period in which Shoggoths were tamed
+and broken by armed Old Ones as the wild horses of the American west
+were tamed by cowboys.
+
+Though during the rebellion the Shoggoths had shown an ability to
+live out of water, this transition was not encouraged--since their
+usefulness on land would hardly have been commensurate with the trouble
+of their management.
+
+During the Jurassic Age the Old Ones met fresh adversity in the
+form of a new invasion from outer space--this time by half-fungous,
+half-crustacean creatures--creatures undoubtedly the same as those
+figuring in certain whispered hill legends of the north, and remembered
+in the Himalayas as the Mi-Go, or Abominable Snow Men.
+
+To fight these beings the Old Ones attempted, for the first time
+since their terrene advent, to sally forth again into the planetary
+ether; but, despite all traditional preparations, found it no longer
+possible to leave the earth's atmosphere. Whatever the old secret of
+interstellar travel had been, it was now definitely lost to the race.
+
+In the end the Mi-Go drove the Old Ones out of all the northern lands,
+though they were powerless to disturb those in the sea. Little by
+little the slow retreat of the elder race to their original antarctic
+habitat was beginning.
+
+       *       *       *       *       *
+
+It was curious to note from the pictured battles that both the Cthulhu
+spawn and the Mi-Go seem to have been composed of matter more widely
+different from that which we know than was the substance of the Old
+Ones. They were able to undergo transformations and reintegrations
+impossible for their adversaries, and seem therefore to have originally
+come from even remoter gulfs of cosmic space.
+
+The Old Ones, but for their abnormal toughness and peculiar vital
+properties, were strictly material, and must have had their absolute
+origin within the known space-time continuum--whereas the first
+sources of the other beings can only be guessed at with bated breath.
+All this, of course, assuming that the nonterrestrial linkages and
+the anomalies ascribed to the invading foes are not pure mythology.
+Conceivably, the Old Ones might have invented a cosmic framework
+to account for their occasional defeats, since historical interest
+and pride obviously formed their chief psychological element. It is
+significant that their annals failed to mention many advanced and
+potent races of beings whose mighty cultures and towering ethics figure
+persistently in certain obscure legends.
+
+The changing state of the world through long geologic ages appeared
+with startling vividness in many of the sculptured maps and scenes. In
+certain cases existing science will require revision, while in other
+cases its bold deductions are magnificently confirmed.
+
+As I have said, the hypothesis of Taylor, Wegener, and Joly that all
+the continents are fragments of an original antarctic land mass which
+cracked from centrifugal force and drifted apart over a technically
+viscous lower surface--an hypothesis suggested by such things as the
+complimentary outlines of Africa and South America, and the way the
+great mountain chains are rolled and shoved up--receives striking
+support from this uncanny source.
+
+Maps evidently showing the Carboniferous of a hundred million or
+more years ago displayed significant rifts and chasms destined later
+to separate Africa from the once continuous realms of Europe (then
+the Valusia of primal legend), Asia, the Americas, and the antarctic
+continent.
+
+Other charts--and most significantly one in connection with the
+founding fifty million years ago of the vast dead city around
+us--showed all the present continents well differentiated. And in
+the latest discoverable specimen--dating perhaps from the Pliocene
+Age--the approximate world of to-day appeared quite clearly despite the
+linkage of Alaska with Siberia, of North America with Europe through
+Greenland, and of South America with the antarctic continent through
+Graham Land.
+
+In the Carboniferous map the whole globe--ocean floor and rifted land
+mass alike--bore symbols of the Old Ones' vast stone cities, but in the
+later charts the gradual recession toward the antarctic became very
+plain.
+
+The final Pliocene specimen showed no land cities except on the
+antarctic continent and the tip of South America, nor any ocean
+cities north of the fiftieth parallel of South Latitude. Knowledge
+and interest in the northern world, save for a study of coast lines
+probably made during long exploration flights on those fan-like
+membranous wings, had evidently declined to zero among the Old Ones.
+
+Destruction of cities through the up-thrust of mountains, the
+centrifugal rending of continents, the seismic convulsions of land or
+sea bottom, and other natural causes was a matter of common record; and
+it was curious to observe how fewer and fewer replacements were made as
+the ages wore on.
+
+The vast dead megalopolis that yawned around us seemed to be the last
+general center of the race--built early in the Cretaceous Age after a
+titanic earth buckling had obliterated a still vaster predecessor not
+far distant.
+
+It appeared that this general region was the most sacred spot of
+all, where reputedly the first Old Ones had settled on a primal sea
+bottom. In the new city--many of whose features we could recognize
+in the sculptures, but which stretched fully a hundred miles along
+the mountain range in each direction beyond the farthest limits of
+our aërial survey--there were reputed to be preserved certain sacred
+stones forming part of the first sea-bottom city, which were thrust up
+to light after long epochs in the course of the general crumpling of
+strata.
+
+
+
+
+                                 VIII.
+
+
+Naturally, Danforth and I studied with special interest and a
+peculiarly personal sense of awe everything pertaining to the immediate
+district in which we were. Of this local material there was naturally a
+vast abundance.
+
+On the tangled ground level of the city we were lucky enough to find
+a house of very late date whose walls, though somewhat damaged by a
+neighboring rift, contained sculptures of decadent workmanship carrying
+the story of the region, much beyond the Pliocene map, whence we
+derived our last general glimpse of the prehuman world. This was the
+last place we examined in detail, since what we found there set upon us
+a fresh, immediate objective.
+
+Certainly, we were in one of the strangest, weirdest, and most terrible
+of all the corners of earth's globe. Of all existing lands it was
+infinitely the most ancient. The conviction grew upon us that this
+hideous upland must indeed be the fabled nightmare plateau of Leng
+which even the mad author of the _Necronomicon_ was reluctant to
+discuss.
+
+The great mountain chain was tremendously long--starting as a low range
+at Luitpold Land on the coast of Weddell Sea and virtually crossing the
+entire continent. The really high part stretched in a mighty arc from
+about Latitude 82°, E. Longitude 60° to Latitude 70°, East Longitude
+115°, with its concave side toward our camp and its seaward end in the
+region of that long, ice-locked coast whose hills were glimpsed by
+Wilkes and Mawson at the antarctic circle.
+
+Yet even more monstrous exaggerations of nature seemed disturbingly
+close at hand. I have said that these peaks are higher than the
+Himalayas, but the sculptures forbid me to say that they are earth's
+highest. That grim honor is beyond doubt reserved for something
+which half the sculptures hesitated to record at all, whilst others
+approached it with obvious repugnance and trepidation.
+
+It seems that there was one part of the ancient land--the first part
+that ever rose from the waters after the earth had flung off the moon
+and the Old Ones had seeped down from the stars--which had come to be
+shunned as vaguely and namelessly evil. Cities built there had crumbled
+before their time, and had been found suddenly deserted.
+
+Then when the first great earth buckling had convulsed the region in
+the Comanchean Age, a frightful line of peaks had shot suddenly up
+amidst the most appalling din and chaos--and earth had received her
+loftiest and most terrible mountains.
+
+If the scale of the carvings was correct, these abhorred things must
+have been much over forty thousand feet high--radically vaster than
+even the shocking mountains of madness we had crossed. They extended,
+it appeared, from about Latitude 77°, E. Longitude 70° to Latitude 70°,
+E. Longitude 100°--less than three hundred miles away from the dead
+city, so that we would have spied their dreaded summits in the dim
+western distance had it not been for that vague, opalescent haze. Their
+northern end must likewise be visible from the long antarctic circle
+coast line at Queen Mary Land.
+
+Some of the Old Ones, in the decadent days, had made strange prayers
+to those mountains--but none ever went near them or dared to guess
+what lay beyond. No human eye had ever seen them, and as I studied the
+emotions conveyed in the carvings I prayed that none ever might.
+
+There are protecting hills along the coast beyond them--Queen Mary and
+Kaiser Wilhelm Lands--and I thank Heaven no one has been able to land
+and climb those hills. I am not as sceptical about old tales and fears
+as I used to be, and I do not laugh now at the prehuman sculptor's
+notion that lightning paused meaningfully now and then at each of the
+brooding crests, and that an unexplained glow shone from one of those
+terrible pinnacles all through the long polar night. There may be a
+very real and very monstrous meaning in the old Pnakotic whispers about
+Kadath in the Cold Waste.
+
+But the terrain close at hand was hardly less strange, even if less
+namelessly accursed. Soon after the founding of the city the great
+mountain range became the seat of the principal temples, and many
+carvings showed what grotesque and fantastic towers had pierced the sky
+where now we saw only the curiously clinging cubes and ramparts.
+
+In the course of ages the caves had appeared, and had been shaped into
+adjuncts of the temples. With the advance of still later epochs all
+the limestone veins of the region were hollowed out by ground waters,
+so that the mountains, the foothills, and the plains below them were
+a veritable network of connected caverns and galleries. Many graphic
+sculptures told of explorations deep underground, and of the final
+discovery of the Stygian sunless sea that lurked at earth's bowels.
+
+       *       *       *       *       *
+
+This vast nighted gulf had undoubtedly been worn by the great river
+which flowed down from the nameless and horrible westward mountains,
+and which had formerly turned at the base of the Old Ones' range and
+flowed beside that chain into the Indian Ocean between Budd and Totten
+Lands on Wilkes's coast line. Little by little it had eaten away the
+limestone hill base at its turning, till at last its sapping currents
+reached the caverns of the ground waters and joined with them in
+digging a deeper abyss.
+
+Finally its whole bulk emptied into the hollow hills and left the old
+bed toward the ocean dry. Much of the later city as we now found it
+had been built over that former bed. The Old Ones, understanding what
+had happened, and exercising their always keen artistic sense, had
+carved into ornate pylons those headlands of the foothills where the
+great stream began its descent into eternal darkness.
+
+This river, once crossed by scores of noble stone bridges, was plainly
+the one whose extinct course we had seen in our aëroplane survey.
+Its position in different carvings of the city helped us to orient
+ourselves to the scene as it had been at various stages of the region's
+age-long, æon-dead history, so that we were able to sketch a hasty but
+careful map of the salient features--squares, important buildings, and
+the like--for guidance in further explorations.
+
+We could soon reconstruct in fancy the whole stupendous thing as it was
+a million or ten million or fifty million years ago, for the sculptures
+told us exactly what the buildings and mountains and squares and
+suburbs and landscape setting and luxuriant Tertiary vegetation had
+looked like.
+
+It must have had a marvelous and mystic beauty, and as I thought of
+it I almost forgot the clammy sense of sinister oppression with which
+the city's inhuman age and massiveness and deadness and remoteness and
+glacial twilight had choked and weighed on my spirit.
+
+Yet, according to certain carvings the denizens of that city had
+themselves known the clutch of oppressive terror; for there was a
+somber and recurrent type of scene in which the Old Ones were shown in
+the act of recoiling affrightedly from some object--never allowed to
+appear in the design--found in the great river and indicated as having
+been washed down through waving, vine-draped cycad forests from those
+horrible westward mountains.
+
+It was only in the one late-built house with the decadent carvings that
+we obtained any foreshadowing of the final calamity leading to the
+city's desertion. Undoubtedly there must have been many sculptures of
+the same age elsewhere, even allowing for the slackened energies and
+aspirations of a stressful and uncertain period; indeed, very certain
+evidence of the existence of others came to us shortly afterward. But
+this was the first and only set we directly encountered.
+
+We meant to look farther later on; but as I have said, immediate
+conditions dictated another present objective. There would, though,
+have been a limit--for after all hope of a long future occupancy of the
+place had perished among the Old Ones, there could not but have been a
+complete cessation of mural decoration. The ultimate blow, of course,
+was the coming of the great cold which once held most of the earth in
+thrall, and which has never departed from the ill-fated poles--the
+great cold that, at the world's other extremity, put an end to the
+fabled lands of Lomar and Hyperborea.
+
+Just when this tendency began in the antarctic it would be hard to say
+in terms of exact years. Nowadays we set the beginning of the general
+glacial periods at a distance of about five hundred thousand years from
+the present, but at the poles the terrible scourge must have commenced
+much earlier. All quantitative estimates are partly guesswork, but it
+is quite likely that the decadent sculptures were made considerably
+less than a million years ago, and that the actual desertion of
+the city was complete long before the conventional opening of the
+Pleistocene--five hundred thousand years ago--as reckoned in terms of
+the earth's whole surface.
+
+       *       *       *       *       *
+
+In the decadent sculptures there were signs of thinner vegetation
+everywhere, and of a decreased country life on the part of the Old
+Ones. Heating devices were shown in the houses, and winter travelers
+were represented as muffled in protective fabrics. Then we saw a
+series of cartouches--the continuous band arrangement being frequently
+interrupted in these late carvings--depicting a constantly growing
+migration to the nearest refuges of greater warmth--some fleeing to
+cities under the sea off the far-away coast, and some clambering down
+through networks of limestone caverns in the hollow hills to the
+neighboring black abyss of subterrane waters.
+
+In the end, it seems to have been the neighboring abyss which received
+the greatest colonization. This was partly due, no doubt, to the
+traditional sacredness of this special region, but may have been more
+conclusively determined by the opportunities it gave for continuing
+the use of the great temples on the honeycombed mountains, and for
+retaining the vast land city as a place of summer residence and base of
+communication with various mines.
+
+The linkage of old and new abodes was made more effective by means
+of several gradings and improvements along the connecting routes,
+including the chiseling of numerous direct tunnels from the ancient
+metropolis to the black abyss--sharply down-pointing tunnels whose
+mouths we carefully drew, according to our most thoughtful estimates,
+on the guide map we were compiling.
+
+It was obvious that at least two of these tunnels lay within a
+reasonable exploring distance of where we were--both being on the
+mountainward edge of the city, one less than a quarter of a mile toward
+the ancient rivercourse, and the other perhaps twice that distance in
+the opposite direction.
+
+The abyss, it seems, had shelving shores of dry land at certain places,
+but the Old Ones built their new city under water--no doubt because of
+its greater certainty of uniform warmth. The depth of the hidden sea
+appears to have been very great, so that the earth's internal heat
+could insure its habitability for an indefinite period.
+
+The beings seem to have had no trouble in adapting themselves to
+part-time--and eventually, of course, whole-time--residence under
+water, since they had never allowed their gill systems to atrophy.
+
+There were many sculptures which showed how they had always frequently
+visited their submarine kinsfolk elsewhere, and how they had habitually
+bathed on the deep bottom of their great river. The darkness of inner
+earth could likewise have been no deterrent to a race accustomed to
+long antarctic nights.
+
+Decadent though their style undoubtedly was, these latest carvings
+had a truly epic quality where they told of the building of
+the new city in the cavern sea. The Old Ones had gone about it
+scientifically--quarrying insoluble rocks from the heart of the
+honeycombed mountains, and employing expert workers from the nearest
+submarine city to perform the construction according to the best
+methods.
+
+These workers brought with them all that was necessary to establish
+the new venture--Shoggoth tissue from which to breed stone lifters and
+subsequent beasts of burden for the cavern city, and other protoplasmic
+matter to mold into phosphorescent organisms for lighting purposes.
+
+       *       *       *       *       *
+
+At last a mighty metropolis rose on the bottom of that Stygian sea,
+its architecture much like that of the city above, and its workmanship
+displaying relatively little decadence because of the precise
+mathematical element inherent in building operations.
+
+The newly bred Shoggoths grew to enormous size and singular
+intelligence, and were represented as taking and executing orders with
+marvelous quickness. They seemed to converse with the Old Ones by
+mimicking their voices--a sort of musical piping over a wide range,
+if poor Lake's dissection had indicated aright--and to work more from
+spoken commands than from hypnotic suggestions as in earlier times.
+
+They were, however, kept in admirable control. The phosphorescent
+organisms supplied light with vast effectiveness, and doubtless atoned
+for the loss of the familiar polar auroras of the outer-world night.
+
+Art and decoration were pursued, though, of course, with a certain
+decadence. The Old Ones seemed to realize this falling off themselves,
+and in many cases anticipated the policy of Constantine the Great by
+transplanting especially fine blocks of ancient carving from their
+land city, just as the emperor, in a similar age of decline, stripped
+Greece and Asia of their finest art to give his new Byzantine capital
+greater splendors than its own people could create. That the transfer
+of sculptured blocks had not been more extensive, was doubtless owing
+to the fact that the land city was not at first wholly abandoned.
+
+By the time total abandonment did occur--and it surely must have
+occurred before the polar Pleistocene was far advanced--the Old Ones
+had perhaps become satisfied with their decadent art--or had ceased
+to recognize the superior merit of the older carvings. At any rate,
+the æon-silent ruins around us had certainly undergone no wholesale
+sculptural denudation, though all the best separate statues, like other
+movables, had been taken away.
+
+The decadent cartouches and dados telling this story were, as I have
+said, the latest we could find in our limited search. They left us with
+a picture of the Old Ones shuttling back and forth betwixt the land
+city in summer and the sea-cavern city in winter, and sometimes trading
+with the sea-bottom cities off the antarctic coast.
+
+By this time the ultimate doom of the land city must have been
+recognized, for the sculptures showed many signs of the cold's malign
+encroachments. Vegetation was declining, and the terrible snows of the
+winter no longer melted completely even in midsummer.
+
+The saurian live stock were nearly all dead, and the mammals were
+standing it none too well. To keep on with the work of the upper
+world it had become necessary to adapt some of the amorphous and
+curiously cold-resistant Shoggoths to land life--a thing the Old Ones
+had formerly been reluctant to do. The great river was now lifeless,
+and the upper sea had lost most of its denizens except the seals and
+whales. All the birds had flown away, save only the great, grotesque
+penguins.
+
+What had happened afterward we could only guess. How long had the new
+sea-cavern city survived? Was it still down there, a stony corpse in
+eternal blackness? Had the subterranean waters frozen at last? To what
+fate had the ocean-bottom cities of the outer world been delivered?
+Had any of the Old Ones shifted north ahead of the creeping ice cap?
+Existing geology shows no trace of their presence. Had the frightful
+Mi-Go been still a menace in the outer land world of the north? Could
+one be sure of what might or might not linger, even to this day, in the
+lightless and unplumbed abysses of earth's deepest water?
+
+Those things had seemingly been able to withstand any amount of
+pressure--and men of the sea have fished up curious objects at
+times. And has the killer-whale theory really explained the savage
+and mysterious scars on antarctic seals noticed a generation ago by
+Borchgrevingk?
+
+The specimens found by poor Lake did not enter into these guesses, for
+their geologic setting proved them to have lived at what must have been
+a very early date in the land city's history. They were, according to
+their location, certainly not less than thirty million years old, and
+we reflected that in their day the sea-cavern city, and indeed the
+cavern itself, had had no existence.
+
+They would have remembered an older scene, with lush Tertiary
+vegetation everywhere, a younger land city of flourishing arts around
+them, and a great river sweeping northward along the base of the mighty
+mountains toward a far-away tropic ocean.
+
+And yet we could not help thinking about these specimens--especially
+about the eight perfect ones that were missing from Lake's hideously
+ravaged camp. There was something abnormal about that whole
+business--the strange things we had tried so hard to lay to somebody's
+madness--those frightful graves--the amount _and nature_ of the
+missing material--Gedney--the unearthly toughness of those archaic
+monstrosities, and the queer vital freaks the sculptures now showed
+the race to have----Danforth and I had seen a good deal in the last
+few hours, and were prepared to believe and keep silent about many
+appalling and incredible secrets of primal nature.
+
+
+
+
+                                  IX.
+
+
+I have said that our study of the decadent sculptures brought about a
+change in our immediate objective. This, of course, had to do with the
+chiseled avenues to the black inner world, of whose existence we had
+not known before, but which we were now eager to find and traverse.
+
+From the evident scale of the carvings we deduced that a steeply
+descending walk of about a mile through either of the neighboring
+tunnels would bring us to the brink of the dizzy, sunless cliffs about
+the great abyss, down whose side paths, improved by the Old Ones, led
+to the rocky shore of the hidden and nighted ocean. To behold this
+fabulous gulf in stark reality was a lure which seemed impossible of
+resistance once we knew of the thing--yet we realized we must begin the
+quest at once if we expected to include it in our present trip.
+
+In was now eight p.m., and we had not enough battery replacements to
+let our torches burn on forever. We had done so much of our studying
+and copying below the glacial level that our battery supply had had at
+least five hours of nearly continuous use, and despite the special dry
+cell formula would obviously be good for only about four more--though
+by keeping one torch unused, except for especially interesting or
+difficult places, we might manage to eke out a safe margin beyond that.
+
+It would not do to be without a light in these Cyclopean catacombs,
+hence in order to make the abyss trip we must give up all further
+mural deciphering. Of course, we intended to revisit the place for days
+and perhaps weeks of intensive study and photography--curiosity having
+long ago gotten the better of horror--but just now we must hasten.
+
+Our supply of trail-blazing paper was far from unlimited, and we were
+reluctant to sacrifice spare notebooks or sketching paper to augment
+it, but we did let one large notebook go. If worst came to worst, we
+could resort to rock chipping--and, of course, it would be possible,
+even in case of really lost direction, to work up to full daylight by
+one channel or another if granted sufficient time for plentiful trial
+and error. So, at last, we set off eagerly in the indicated direction
+of the nearest tunnel.
+
+According to the carvings from which we had made our map, the desired
+tunnel mouth could not be much more than a quarter of a mile from where
+we stood; the intervening space showing solid-looking buildings quite
+likely to be penetrable still at a subglacial level. The opening itself
+would be in the basement--on the angle nearest the foothills--of a
+vast five-pointed structure of evidently public and perhaps ceremonial
+nature, which we tried to identify from our aërial survey of the ruins.
+
+No such structure came to our minds as we recalled our flight, hence we
+concluded that its upper parts had been greatly damaged, or that it had
+been totally shattered in an ice rift we had noticed. In the latter
+case the tunnel would probably turn out to be choked, so that we would
+have to try the next nearest one--the one less than a mile to the north.
+
+The intervening river course prevented our trying any of the more
+southern tunnels on this trip; and indeed, if both of the neighboring
+ones were choked it was doubtful whether our batteries would warrant
+an attempt on the next northerly one--about a mile beyond our second
+choice.
+
+       *       *       *       *       *
+
+As we threaded our dim way through the labyrinth with the aid of map
+and compass--traversing rooms and corridors in every stage of ruin or
+preservation, clambering up ramps, crossing upper floors and bridges
+and clambering down again, encountering choked doorways and piles of
+débris, hastening now and then along finely preserved and uncannily
+immaculate stretches, taking false leads and retracing our way (in such
+cases removing the blind paper trail we had left), and once in a while
+striking the bottom of an open shaft through which daylight poured or
+trickled down--we were repeatedly tantalized by the sculptured walls
+along our route.
+
+We had wormed our way very close to the computed site of the tunnel's
+mouth--having crossed a second-story bridge to what seemed plainly the
+tip of a pointed wall, and descended to a ruinous corridor especially
+rich in decadently elaborate and apparently ritualistic sculptures of
+late workmanship--when, about eight thirty p.m., Danforth's keen young
+nostrils gave us the first hint of something unusual.
+
+If we had had a dog with us, I suppost we would have been warned
+before. At first we could not precisely say what was wrong with the
+formerly crystal-pure air, but after a few seconds our memories reached
+only too definitely. Let me try to state the thing without flinching.
+There was an odor--and that odor was vaguely, subtly, and unmistakably
+akin to what had nauseated us upon opening the insane grave of the
+horror poor Lake had dissected.
+
+Of course, the revelation was not as clearly cut at the time as it
+sounds now. There were several conceivable explanations, and we did a
+good deal of indecisive whispering. Most important of all, we did not
+retreat without further investigation; for having come this far, we
+were loath to be balked by anything short of certain disaster.
+
+Anyway, what we must have suspected was altogether too wild to believe.
+Such things did not happen in any normal world. It was probably sheer
+irrational instinct which made us dim our single torch--tempted no
+longer by the decadent and sinister sculptures that leered menacingly
+from the oppressive walls--and which softened our progress to a
+cautious tiptoeing and crawling over the increasingly littered floor
+and heaps of débris.
+
+Danforth's eyes as well as nose proved better than mine, for it was
+likewise he who first noticed the queer aspect of the débris after we
+had passed many half-choked arches leading to chambers and corridors
+on the ground level. It did not look quite as it ought after countless
+thousands of years of desertion, and when we cautiously turned on more
+light we saw that a kind of swath seemed to have been lately tracked
+through it. The irregular nature of the latter precluded any definite
+marks, but in the smoother places there were suggestions of the
+dragging of heavy objects. Once we thought there was a hint of parallel
+tracks, as if of runners. This was what made us pause again.
+
+It was during that pause that we caught--simultaneously this time--the
+other odor ahead. Paradoxically, it was both a less frightful and a
+more frightful odor--less frightful intrinsically, but infinitely
+appalling in this place under the known circumstances--unless, of
+course, Gedney----For the odor was the plain and familiar one of common
+petrol--every-day gasoline.
+
+       *       *       *       *       *
+
+Our motivation after that is something I will leave to psychologists.
+We knew now that some terrible extension of the camp horrors must
+have crawled into this nighted burial place of the æons, hence could
+not doubt any longer the existence of nameless conditions--present
+or at least recent--just ahead. Yet in the end we did let sheer
+burning curiosity--or anxiety--or autohypnotism--or vague thoughts of
+responsibility toward Gedney--of what not--drive us on.
+
+Danforth whispered again of the print he thought he had seen at
+the alley turning in the ruins above; and of the faint musical
+piping--potentially of tremendous significance in the light of Lake's
+dissection report, despite its close resemblance to the cave-mouth
+echoes of the windy peaks--which he thought he had shortly afterward
+half heard from unknown depths below.
+
+I, in my turn, whispered of how the camp was left--of what had
+disappeared, and of how the madness of a lone survivor might have
+conceived the inconceivable--a wild trip across the monstrous mountains
+and a descent into the unknown, primal masonry----
+
+But we could not convince each other, or even ourselves, of anything
+definite. We had turned off all light as we stood still, and vaguely
+noticed that a trace of deeply filtered upper daylight kept the
+blackness from being absolute.
+
+Having automatically begun to move ahead, we guided ourselves by
+occasional flashes from our torch. The disturbed débris formed an
+impression we could not shake off, and the smell of gasoline grew
+stronger. More and more ruin met our eyes and hampered our feet, until
+very soon we saw that the forward way was about to cease. We had been
+all too correct in our pessimistic guess about that rift glimpsed from
+the air. Our tunnel quest was a blind one, and we were not even going
+to be able to reach the basement out of which the abyssward aperture
+opened.
+
+The torch, flashing over the grotesquely carved walls of the blocked
+corridor in which we stood, showed several doorways in various
+states of obstruction; and from one of them the gasoline odor--quite
+submerging that other hint of odor--came with especial distinctness. As
+we looked more steadily, we saw that beyond a doubt there had been a
+slight and recent clearing away of débris from that particular opening.
+Whatever the lurking horror might be, we believed the direct avenue
+toward it was now plainly manifest. I do not think any one will wonder
+that we waited an appreciable time before making any further motion.
+
+And yet, when we did venture inside that black arch, our first
+impression was one of anticlimax. For amidst the littered expanse
+of that sculptured crypt--a perfect cube with sides of about twenty
+feet--there remained no recent object of instantly discernible size; so
+that we looked instinctively, though in vain, for a farther doorway.
+
+In another moment, however, Danforth's sharp vision had discovered a
+place where the floor débris had been disturbed. We turned on both
+torches full strength. Though what we saw in that light was actually
+simple and trifling, I am none the less reluctant to tell of it because
+of what it implied.
+
+It was a rough leveling of the débris, upon which several small objects
+lay carelessly scattered, and at one corner of which a considerable
+amount of gasoline must have been spilled lately enough to leave a
+strong odor even at this extreme superplateau altitude. In other words,
+it could not be other than a sort of camp--a camp made by questing
+beings who, like us, had been turned back by the unexpectedly choked
+way to the abyss.
+
+Let me be plain. The scattered objects were, so far as substance was
+concerned, all from Lake's camp, and consisted of: tin cans as queerly
+opened as those we had seen at that ravaged place, many spent matches,
+three illustrated books more or less curiously smudged, an empty ink
+bottle with its pictorial and instructional carton, a broken fountain
+pen, some oddly snipped fragments of fur and tent cloth, a used
+electric battery with circular of directions, a folder that came with
+our type of tent heater, and a sprinkling of crumpled papers.
+
+It was all bad enough, but when we smoothed out the papers and looked
+at what was on them we felt we had come to the worst. We had found
+certain inexplicably blotted papers at the camp which might have
+prepared us, yet the effect of the sight, down there in the prehuman
+vaults of a nightmare city, was almost too much to bear.
+
+       *       *       *       *       *
+
+A mad Gedney might have made the groups of dots in imitation of
+those found on the greenish soapstones, just as the dots on those
+insane five-pointed grave mounds might have been made; and he might
+conceivably have prepared rough, hasty sketches--varying in their
+accuracy--or lack of it--which outlined the neighboring parts of the
+city and traced the way from a circularly represented place outside
+our previous route--a place we identified as a great cylindrical tower
+in the carvings and as a vast circular gulf glimpsed in our aërial
+survey--to the present five-pointed structure and the tunnel mouth
+therein.
+
+He might, I repeat, have prepared such sketches; for those before
+us were quite obviously compiled, as our own had been, from late
+sculptures somewhere in the glacial labyrinth, though not from the
+ones which we had seen and used. But what this art-blind bungler could
+never have done was to execute those sketches in a strange and assured
+technique perhaps superior, despite haste and carelessness, to any of
+the decadent carvings from which they were taken--the characteristic
+and unmistakable technique of the Old Ones themselves in the dead
+city's heyday.
+
+There are those who will say Danforth and I were utterly mad not
+to flee for our lives after that; since our conclusions were
+now--notwithstanding their wildness--completely fixed, and of a nature
+I need not even mention to those who have read my account as far as
+this. Perhaps we were mad--for have I not said those horrible peaks
+were mountains of madness? But I think I can detect something of the
+same spirit--albeit in a less extreme form--in the men who stalk
+deadly beasts through African jungles to photograph them or study
+their habits. Half paralyzed with terror though we were, there was
+nevertheless fanned within us a blazing flame of awe and curiosity
+which triumphed in the end.
+
+Of course, we did not mean to face that--or those--which we knew had
+been there, but we felt that they must be gone by now. They would by
+this time have found the other neighboring entrance to the abyss, and
+have passed within, to whatever night-black fragments of the past might
+await them in the ultimate gulf--the ultimate gulf they had never seen.
+Or if that entrance, too, was blocked, they would have gone on to the
+north seeking another. They were, we remembered, partly independent of
+light.
+
+Looking back to that moment, I can scarcely recall just what precise
+form our new emotions took--just what change of immediate objective it
+was that so sharpened our sense of expectancy. We certainly did not
+mean to face what we feared--yet I will not deny that we may have had
+a lurking, unconscious wish to spy certain things from some hidden
+vantage point.
+
+Probably we had not given up our zeal to glimpse the abyss itself,
+though there was interposed a new goal in the form of that great
+circular place shown on the crumpled sketches we had found. We had at
+once recognized it as a monstrous cylindrical tower in the carvings,
+but appearing only as a prodigious, round aperture from above.
+
+Something about the impressiveness of its rendering, even in these
+hasty diagrams, made us think that its subglacial levels must
+still form a feature of peculiar importance. Perhaps it embodied
+architectural marvels as yet unencountered by us. It was certainly of
+incredible age, according to the sculptures in which it figured--being
+indeed among the first things built in the city. Its carvings, if
+preserved, could not but be highly significant. Moreover, it might form
+a good present link with the upper world--a shorter route than the one
+we were so carefully blazing and probably that by which those others
+had descended.
+
+       *       *       *       *       *
+
+At any rate, the thing we did was to study the terrible sketches--which
+quite perfectly confirmed our own--and start back over the indicated
+course to the circular place; the course which our nameless
+predecessors must have traversed twice before us. The other neighboring
+gate to the abyss would lie beyond that. I need not speak of our
+journey--during which we continued to leave an economical trail of
+paper--for it was precisely the same in kind as that by which we had
+reached the cul-de-sac, except that it tended to adhere more closely to
+the ground level and even descend to basement corridors.
+
+Every now and then we could trace certain disturbing marks
+in the débris or litter underfoot; and, after we had passed
+outside the radius of the gasoline scent, we were again faintly
+conscious--spasmodically--of that more hideous and more persistent
+scent. After the way had branched from our former course, we sometimes
+gave the rays of our single torch a furtive sweep along the walls;
+noting in almost every case the well-nigh omnipresent sculptures, which
+indeed seem to have formed a main æsthetic outlet for the Old Ones.
+
+About nine-thirty p.m., while traversing a vaulted corridor whose
+increasingly glaciated floor seemed somewhat below the ground level and
+whose roof grew lower as we advanced, we began to see strong daylight
+ahead and were able to turn off our torch. It appeared that we were
+coming to the vast, circular place, and that our distance from the
+upper air could not be very great.
+
+The corridor ended in an arch, surprisingly low for these megalithic
+ruins, but we could see much through it even before we emerged. Beyond,
+there stretched a prodigious round space--fully two hundred feet in
+diameter--strewn with débris and containing many choked archways
+corresponding to the one we were about to cross. The walls were--in
+available spaces--boldly sculptured into a spiral band of heroic
+proportions; and displayed, despite the destructive weathering caused
+by the openness of the spot, an artistic splendor far beyond anything
+we had encountered before. The littered floor was quite heavily
+glaciated, and we fancied that the true bottom lay at a considerably
+lower depth.
+
+But the salient object of the place was the titanic stone ramp which,
+eluding the archways by a sharp turn outward into the open floor, wound
+spirally up the stupendous cylindrical wall like an inside counterpart
+of those once climbing outside the monstrous towers or zikkurats of
+antique Babylon. Only the rapidity of our flight, and the perspective
+which confounded the descent with the tower's inner wall, had
+prevented our noticing this feature from the air, and thus caused us to
+seek another avenue to the subglacial level.
+
+Pabodie might have been able to tell what sort of engineering held it
+in place, but Danforth and I could merely admire and marvel. We could
+see mighty stone corbels and pillars here and there, but what we saw
+seemed inadequate to the function performed. The thing was excellently
+preserved up to the present top of the tower--a highly remarkable
+circumstance in view of its exposure--and its shelter had done much to
+protect the bizarre and disturbing cosmic sculptures on the walls.
+
+       *       *       *       *       *
+
+As we stepped out into the awesome half daylight of this monstrous
+cylinder bottom--fifty million years old, and without doubt the most
+primally ancient structure ever to meet our eyes--we saw that the
+ramp-traversed sides stretched dizzily up to a height of fully sixty
+feet.
+
+This, we recalled from our aërial survey, meant an outside glaciation
+of some forty feet; since the yawning gulf we had seen from the plane
+had been at the top of an approximately twenty-foot mound of crumbled
+masonry, somewhat sheltered for three fourths of its circumference by
+the massive curving walls of a line of higher ruins. According to the
+sculptures the original tower had stood in the center of an immense
+circular plaza, and had been perhaps five hundred or six hundred
+feet high, with tiers of horizontal disks near the top, and a row of
+needlelike spires along the upper rim.
+
+Most of the masonry had obviously toppled outward rather than inward--a
+fortunate happening, since otherwise the ramp might have been shattered
+and the whole interior choked. As it was, the ramp showed sad
+battering; whilst the choking was such that all the archways seemed to
+have been half cleared.
+
+It took us only a moment to conclude that this was indeed the route by
+which those others had descended, and that this would be the logical
+route for our own ascent, despite the long trail of paper we had left
+elsewhere. The tower's mouth was no farther from the foothills and our
+waiting plane than was the great terraced building we had entered, and
+any further subglacial exploration we might make on this trip would lie
+in this general region.
+
+Oddly, we were still thinking about possible later trips--even after
+all we had seen and guessed. Then, as we picked our way cautiously over
+the débris of the great floor, there came a sight which for the time
+excluded all other matters.
+
+It was the neatly huddled array of three sledges in that farther angle
+of the ramp's lower and outward-projecting course which had hitherto
+been screened from our view. There they were--the three sledges missing
+from Lake's camp--shaken by a hard usage which must have included
+forcible dragging along great reaches of snowless masonry and débris,
+as well as much hand portage over utterly unnavigable places.
+
+They were carefully and intelligently packed and strapped, and
+contained things memorably familiar enough: the gasoline stove, fuel
+cans, instrument cases, provision tins, tarpaulins obviously bulging
+with books, and some bulging with less obvious contents--everything
+derived from Lake's equipment.
+
+After what we had found in that other room, we were in a measure
+prepared for this encounter. The really great shock came when we
+stepped over and undid one tarpaulin, whose outlines had peculiarly
+disquieted us. It seems that others as well as Lake had been interested
+in collecting typical specimens; for there were two here, both stiffly
+frozen, perfectly preserved, patched with adhesive plaster where some
+wounds around the neck had occurred, and wrapped with care to prevent
+further damage. They were the bodies of young Gedney and the missing
+dog.
+
+
+
+
+                                  X.
+
+
+Many people will probably judge us callous as well as mad for thinking
+about the northward tunnel and the abyss so soon after our somber
+discovery, and I am not prepared to say that we would have immediately
+revived such thoughts but for a specific circumstance which broke in
+upon us and set up a whole new train of speculations.
+
+We had replaced the tarpaulin over poor Gedney and were standing
+in a kind of mute bewilderment when the sounds finally reached our
+consciousness--the first sounds we had heard since descending out of
+the open where the mountain wind whined faintly from its unearthly
+heights. Well-known and mundane though they were, their presence in
+this remote world of death was more unexpected and unnerving than any
+grotesque or fabulous tones could possibly have been--since they gave a
+fresh upsetting to all our notions of cosmic harmony.
+
+Had it been some trace of that bizarre musical piping over a wide
+range, which Lake's dissection report had led us to expect in those
+others--and which, indeed, our overwrought fancies had been reading
+into every wind howl we had heard since coming on the camp horror--it
+would have had a kind of hellish congruity with the æon-dead region
+around us. A voice from other epochs belongs in a graveyard of other
+epochs.
+
+As it was, however, the noise shattered all our profoundly seated
+adjustments--all out tacit acceptance of the inner antarctic as a waste
+utterly and irrevocably void of every vestige of normal life.
+
+What we heard was not the fabulous note of any buried blasphemy of
+elder earth from whose supernal toughness an age-denied polar sun had
+evoked a monstrous response. Instead, it was a thing so mockingly
+normal and so unerringly familiarized by our sea days off Victoria Land
+and our camp days at McMurdo Sound that we shuddered to think of it
+here, where such things ought not to be. To be brief--it was simply the
+raucous squawking of a penguin.
+
+The muffled sound floated from subglacial recesses nearly opposite to
+the corridor whence we had come--regions manifestly in the direction
+of that other tunnel to the vast abyss. The presence of a living water
+bird in such a direction--in a world whose surface was one of age-long
+and uniform lifelessness--could lead to only one conclusion; hence our
+first thought was to verify the objective reality of the sound. It was,
+indeed, repeated, and seemed at times to come from more than one throat.
+
+Seeking its source, we entered an archway from which much débris had
+been cleared; resuming our trail blazing--with an added paper supply
+taken with curious repugnance from one of the tarpaulin bundles on the
+sledges--when we left daylight behind.
+
+As the glaciated floor gave place to a litter of detritus, we plainly
+discerned some curious, dragging tracks; and once Danforth found
+a distinct print of a sort whose description would be only too
+superfluous. The course indicated by the penguin cries was precisely
+what our map and compass prescribed as an approach to the more
+northerly tunnel mouth, and we were glad to find that a bridgeless
+thoroughfare on the ground and basement levels seemed open.
+
+The tunnel, according to the chart, ought to start from the basement of
+a large pyramidal structure which we seemed vaguely to recall from our
+aërial survey as remarkably well-preserved. Along our path the single
+torch showed a customary profusion of carvings, but we did not pause to
+examine any of these.
+
+       *       *       *       *       *
+
+Suddenly a bulky white shape loomed up ahead of us, and we flashed on
+the second torch. It is odd how wholly this new quest had turned our
+minds from earlier fears of what might lurk near. Those other ones,
+having left their supplies in the great circular place, must have
+planned to return after their scouting trip toward or into the abyss;
+yet we had now discarded all caution concerning them as completely as
+if they had never existed.
+
+This white, waddling thing was fully six feet high, yet we seemed to
+realize at once that it was not one of those others. They were larger
+and dark, and, according to the sculptures, their motion over land
+surfaces was a swift, assured matter despite the queerness of their
+sea-born tentacle equipment. But to say that the white thing did not
+profoundly frighten us would be vain. We were indeed clutched for an
+instant by a primitive dread almost sharper than the worst of our
+reasoned fears regarding those others.
+
+Then came a flash of anticlimax as the white shape sidled into a
+lateral archway to our left, to join two others of its kind which
+had summoned it in raucous tones. For it was only a penguin--albeit
+of a huge, unknown species larger than the greatest of the known
+king penguins, and monstrous in its combined albinism and virtual
+eyelessness.
+
+When we had followed the thing into the archway and turned both our
+torches on the indifferent and unheeding group of three, we saw that
+they were all eyeless albinos of the same unknown and gigantic species.
+
+Their size reminded us of some of the archaic penguins depicted in the
+Old Ones' sculptures, and it did not take us long to conclude that
+they were descended from the same stock--undoubtedly surviving through
+a retreat to some warmer inner region whose perpetual blackness had
+destroyed their pigmentation and atrophied their eyes to mere useless
+slits.
+
+That their present habitat was the vast abyss we sought, was not for a
+moment to be doubted; and this evidence of the gulf's continued warmth
+and habitability filled us with the most curious and subtly perturbing
+fancies.
+
+We wondered, too, what had caused these three birds to venture out
+of their usual domain. The state and silence of the great dead city
+made it clear that it had at no time been a habitual seasonal rookery,
+whilst the manifest indifference of the trio to our presence made it
+seem odd that any passing party of those others should have startled
+them.
+
+Was it possible that those others had taken some aggressive notion or
+tried to increase their meat supply? We doubted whether that pungent
+odor which the dogs had hated could cause an equal antipathy in these
+penguins; since their ancestors had obviously lived on excellent terms
+with the Old Ones--an amicable relationship which must have survived in
+the abyss below as long as any of the Old Ones remained.
+
+Regretting--in a flare-up of the old spirit of pure science--that we
+could not photograph these anomalous creatures, we shortly left them
+to their squawking and pushed on toward the abyss whose openness was
+now so positively proved to us, and whose exact direction occasional
+penguin tracks made clear.
+
+       *       *       *       *       *
+
+Not long afterward a steep descent in a long, low, doorless, and
+peculiarly sculptureless corridor led us to believe that we were
+approaching the tunnel mouth at last. We had passed two more penguins.
+
+Then the corridor ended in a prodigious open space which made us
+gasp involuntarily--a perfect inverted hemisphere, obviously deep
+underground, fully a hundred feet in diameter and fifty feet high, with
+low archways opening around all parts of the circumference but one, and
+that one yawning cavernously with a black, arched aperture which broke
+the symmetry of the vault to a height of nearly fifteen feet. It was
+the entrance to the great abyss.
+
+In this vast hemisphere, whose concave roof was impressively though
+decadently carved to a likeness of the primordial celestial dome, a few
+albino penguins waddled--aliens there, but indifferent and unseeing.
+The black tunnel yawned indefinitely off at a steep, descending grade,
+its aperture adorned with grotesquely chiseled jambs and lintel.
+
+From that cryptical mouth we fancied a current of slightly warmer air
+and perhaps even a suspicion of vapor proceeded; and we wondered what
+living entities other than penguins the limitless void below, and the
+contiguous honeycombings of the land and the titan mountains, might
+conceal.
+
+We wondered, too, whether the trace of mountaintop smoke at first
+suspected by poor Lake, as well as the odd haze we had ourselves
+perceived around the rampart-crowned peak, might not be caused by
+the tortuous-channeled rising of some such vapor from the unfathomed
+regions of earth's core.
+
+Entering the tunnel, we saw that its outline was--at least at the
+start--about fifteen feet each way--sides, floor, and arched roof
+composed of the usual megalithic masonry. The sides were sparsely
+decorated with cartouches of conventional designs in a later, decadent
+style; and all the construction and carving were marvellously
+well-preserved.
+
+The floor was quite clear, except for a slight detritus bearing
+outgoing penguin tracks and the inward tracks of those others. The
+farther one advanced, the warmer it became; so that we were soon
+unbuttoning our heavy garments. We wondered whether there were any
+actually igneous manifestations below, and whether the waters of that
+sunless sea were hot.
+
+After a short distance the masonry gave place to solid rock, though
+the tunnel kept the same proportions and presented the same aspect of
+carved regularity. Occasionally its varying grade became so steep that
+grooves were cut in the floor.
+
+Several times we noted the mouths of small lateral galleries not
+recorded in our diagrams; none of them such as to complicate the
+problem of our return, and all of them welcome as possible refuges in
+case we met unwelcome entities on their way back from the abyss.
+
+The nameless scent of such things was very distinct. Doubtless it
+was suicidally foolish to venture into that tunnel under the known
+conditions, but the lure of the unplumbed is stronger in certain
+persons than most suspect--indeed, it was just such a lure which had
+brought us to this unearthly polar waste in the first place.
+
+We saw several penguins as we passed along, and speculated on the
+distance we would have to traverse. The carvings had led us to expect
+a steep downhill walk of about a mile to the abyss, but our previous
+wanderings had shown us that matters of scale were not wholly to be
+depended on.
+
+After about a quarter of a mile that nameless scent became greatly
+accentuated, and we kept very careful track of the various lateral
+openings we passed. There was no visible vapor as at the mouth, but
+this was doubtless due to the lack of contrasting cooler air. The
+temperature was rapidly ascending, and we were not surprised to come
+upon a careless heap of material shudderingly familiar to us. It was
+composed of furs and tent cloths taken from Lake's camp, and we did
+not pause to study the bizarre forms into which the fabrics had been
+slashed.
+
+Slightly beyond this point we noticed a decided increase in the size
+and number of the side galleries, and concluded that the densely
+honeycombed region beneath the higher foothills must now have been
+reached.
+
+The nameless scent was now curiously mixed with another and scarcely
+less offensive odor--of what nature we could not guess, though we
+thought of decaying organisms and perhaps unknown subterrane fungi.
+
+Then came a startling expansion of the tunnel for which the
+carvings had not prepared us--a broadening and rising into a lofty,
+natural-looking elliptical cavern with a level floor, some seventy-five
+feet long and fifty broad, and with many immense side passages leading
+away into cryptical darkness.
+
+       *       *       *       *       *
+
+Though this cavern was natural in appearance, an inspection with both
+torches suggested that it had been formed by the artificial destruction
+of several walls between adjacent honeycombings. The walls were
+rough, and the high, vaulted roof was thick with stalactites; but the
+solid rock floor had been smoothed off, and was free from all débris,
+detritus, or even dust to a positively abnormal extent.
+
+Except for the avenue through which we had come, this was true of
+the floors of all the great galleries opening off from it; and the
+singularity of the condition was such as to set us vainly puzzling.
+
+The curious new fetor which had supplemented the nameless scent was
+excessively pungent here; so much so that it destroyed all trace of the
+other. Something about this whole place, with its polished and almost
+glistening floor, struck us as more vaguely baffling and horrible than
+any of the monstrous things we have previously encountered.
+
+The regularity of the passage immediately ahead, prevented all
+confusion as to the right course amidst this plethora of equally great
+cave mouths. Nevertheless we resolved to resume our paper trail blazing
+if any further complexity should develop; for dust tracks, of course,
+could no longer be expected.
+
+Upon resuming our direct progress we cast a beam of torchlight over the
+tunnel walls--and stopped short in amazement at the supremely radical
+change which had come over the carvings in this part of the passage.
+We realized, of course, the great decadence of the Old Ones' sculpture
+at the time of the tunneling, and had indeed noticed the inferior
+workmanship of the arabesques in the stretches behind us.
+
+But now, in this deeper section beyond the cavern, there was a sudden
+difference wholly transcending explanation--a difference in basic
+nature as well as in mere quality, and involving so profound and
+calamitous a degradation of skill that nothing in the hitherto observed
+rate of decline could have led one to expect it.
+
+This new and degenerate work was coarse, bold, and wholly lacking in
+delicacy of detail. It was countersunk with exaggerated depth in bands
+following the same general line as the sparse cartouches of the earlier
+sections, but the height of the reliefs did not reach the level of the
+general surface.
+
+Danforth had the idea that it was a second carving--a sort of
+palimpsest formed after the obliteration of a previous design. In
+nature it was wholly decorative and conventional, and consisted of
+crude spirals and angles roughly following the quintile mathematical
+tradition of the Old Ones, yet seeming more like a parody than a
+perpetuation of that tradition.
+
+Since we could not afford to spend any considerable time in study, we
+resumed our advance after a cursory look.
+
+We saw and heard fewer penguins, but thought we caught a vague
+suspicion of an infinitely distant chorus of them somewhere deep within
+the earth. The new and inexplicable odor was abominably strong, and we
+could detect scarcely a sign of that other nameless scent.
+
+Puffs of visible vapor ahead bespoke increasing contrasts in
+temperature, and the relative nearness of the sunless sea cliffs of the
+great abyss. Then, quite unexpectedly, we saw certain obstructions on
+the polished floor ahead--obstructions which were quite definitely not
+penguins--and turned on our second torch after making sure that the
+objects were quite stationary.
+
+
+
+
+                                  XI.
+
+
+Still another time have I come to a place where it is very difficult
+to proceed. I ought to be hardened by this stage; but there are some
+experiences and intimations which scar too deeply to permit of healing,
+and leave only such added sensitiveness that memory re-inspired all the
+original horror.
+
+We saw, as I have said, certain obstructions on the polished
+floor ahead; and I may add that our nostrils were assailed almost
+simultaneously by a very curious intensification of the strange,
+prevailing fetor, now quite plainly mixed with the nameless stench of
+those others which had gone before us.
+
+The light of the second torch left no doubt of what the obstructions
+were, and we dared approach them only because we could see, even from
+a distance, that they were quite as past all harming power as had been
+the six similar specimens unearthed from the monstrous star-mounded
+graves at poor Lake's camp.
+
+They were, indeed, as lacking in completeness as most of those we
+had unearthed--though it grew plain from the thick, dark-green pool
+gathering around them that their incompleteness was of infinitely
+greater recency. There seemed to be only four of them, whereas Lake's
+bulletins would have suggested no less than eight as forming the
+group which had preceded us. To find them in this state was wholly
+unexpected, and we wondered what sort of monstrous struggle had
+occurred down here in the dark.
+
+Penguins, attacked in a body, retaliate savagely with their beaks; and
+our ears now made certain the existence of a rookery far beyond. Had
+those others disturbed such a place and aroused murderous pursuit? The
+obstructions did not suggest it, for penguin beaks against the tough
+tissues Lake had dissected could hardly account for the terrible damage
+our approaching glance was beginning to make out. Besides, the huge
+blind birds we had seen appeared to be singularly peaceful.
+
+Had there, then, been a struggle among those others, and were the
+absent four responsible? If so, where were they? Were they close at
+hand and likely to form an immediate menace to us? We glanced anxiously
+at some of the smooth-floored lateral passages as we continued our slow
+and frankly reluctant approach.
+
+Whatever the conflict was, it had clearly been that which had
+frightened the penguins into their unaccustomed wandering. It must,
+then, have arisen near that faintly heard rookery in the incalculable
+gulf beyond, since there were no signs that any birds had normally
+dwelt here.
+
+Perhaps, we reflected, there had been a hideous running fight, with
+the weaker party seeking to get back to the cached sledges when their
+pursuers finished them. One could picture the demonic fray between
+namelessly monstrous entities as it surged out of the black abyss with
+great clouds of frantic penguins squawking and scurrying ahead.
+
+I say that we approached those sprawling and incomplete obstructions
+slowly and reluctantly. Would to Heaven we had never approached them at
+all, but had run back at top speed out of that blasphemous tunnel with
+the greasily smooth floors and the degenerate murals aping and mocking
+the things they had superseded--run back, before we had seen what we
+did see, and before our minds were burned with something which will
+never let us breathe easily again!
+
+       *       *       *       *       *
+
+Both of our torches were turned on the prostrate objects, so that we
+soon realized the dominant factor in their incompleteness. Mauled,
+compressed, twisted, and ruptured as they were, their chief common
+injury was total decapitation.
+
+From each one the tentacled starfish head had been removed; and as
+we drew near we saw that the manner of removal looked more like some
+hellish tearing or suction than like any ordinary form of cleavage.
+
+Their noisome dark-green ichor formed a large, spreading pool; but its
+stench was half overshadowed by that newer and stranger stench, here
+more pungent than at any other point along our route.
+
+Only when we had come very close to the sprawling obstructions could we
+trace that second, unexplainable fetor to any immediate source--and the
+instant we did so Danforth, remembering certain very vivid sculptures
+of the Old Ones' history in the Permian Age one hundred and fifty
+million years ago, gave vent to a nerve-tortured cry which echoed
+hysterically through that vaulted and archaic passage with the evil,
+palimpsest carvings.
+
+I came only just short of echoing his cry myself; for I had seen those
+primal sculptures, too, and had shudderingly admired the way the
+nameless artist had suggested that hideous slime coating found on
+certain incomplete and prostrate Old Ones--those whom the frightful
+Shoggoths had characteristically slain and sucked to a ghastly
+headlessness in the great war of resubjugation.
+
+They were infamous, nightmare sculptures even when telling of age-old,
+bygone things; for Shoggoths and their work ought not to be seen by
+human beings or portrayed by any beings.
+
+The mad author of the _Necronomicon_ had nervously tried to swear that
+none had been bred on this planet, and that only drugged dreamers
+had ever conceived them. Formless protoplasm able to mock and
+reflect all forms and organs and processes--viscous agglutinations
+of bubbling cells--rubbery fifteen-foot spheroids infinitely plastic
+and ductile--slaves of suggestion, builders of cities--more and more
+sullen, more and more intelligent, more and more amphibious, more and
+more imitative! Great Heaven! What madness made even those blasphemous
+Old Ones willing to use and to carve such things?
+
+And now, when Danforth and I saw the freshly glistening and
+reflectively iridescent black slime which clung thickly to those
+headless bodies and stank obscenely with that new, unknown odor whose
+cause only a diseased fancy could envisage--clung to those bodies
+and sparkled less voluminously on a smooth part of the accursedly
+resculptured wall in a series of grouped dots--we understood the
+quality of cosmic fear to its uttermost depths.
+
+It was not fear of those four missing others--for all too well did we
+suspect they would do no harm again. Poor devils! After all, they were
+not evil things of their kind. They were the men of another age and
+another order of being. Nature had played a hellish jest on them--as
+it will on any others that human madness, callousness, or cruelty may
+hereafter drag up in that hideously dead or sleeping polar waste--and
+this was their tragic homecoming.
+
+They had not been even savages--for what indeed had they done? That
+awful awakening in the cold of an unknown epoch--perhaps an attack by
+the furry, frantically barking quadrupeds, and a dazed defense against
+them and the equally frantic white simians with the queer wrappings and
+paraphernalia! Poor Lake. Poor Gedney. And poor Old Ones! Scientists
+to the last--what had they done that we would not have done in their
+place? Lord, what intelligence and persistence! What a facing of the
+incredible, just as those carven kinsmen and forbears had faced things
+only a little less incredible! Radiates, vegetables, monstrosities,
+star spawn--whatever they had been, they were men!
+
+       *       *       *       *       *
+
+They had crossed the icy peaks on whose templed slopes they had once
+worshiped and roamed among the tree ferns. They had found their dead
+city brooding under its curse, and had read its carven latter days as
+we had done. They had tried to reach their living fellows in fabled
+depths of blackness they had never seen--and what had they found?
+
+All this flashed in unison through the thoughts of Danforth and me as
+we looked from those headless, slime-coated shapes to the loathsome
+palimpsest sculptures and the diabolical dot groups of fresh slime on
+the wall beside them--looked and understood what must have triumphed
+and survived down there in the Cyclopean water city of that nighted,
+penguin-fringed abyss, whence even now a sinister curling mist had
+begun to belch pallidly as if in answer to Danforth's hysterical scream.
+
+The shock of recognizing that monstrous slime and headlessness had
+frozen us into mute, motionless statues, and it is only through later
+conversations that we have learned of the complete identity of our
+thoughts at that moment.
+
+It seemed æons that we stood there, but actually it could not have been
+more than ten or fifteen seconds. That hateful, pallid mist curled
+forward as if veritably driven by some remoter advancing bulk--and then
+came a sound which upset much of what we had just decided, and in so
+doing broke the spell and enabled us to run like mad past squawking,
+confused penguins over our former trail back to the city, along
+ice-sunken megalithic corridors to the great open circle, and up that
+archaic spiral ramp in a frenzied, automatic plunge for the sane outer
+air and light of day.
+
+[Illustration: _And then came a sound--a horrible sound--which enabled
+us to run like mad for the sane outer air_----]
+
+The new sound, as I have intimated, upset much that we had decided;
+because it was what poor Lake's dissection had led us to attribute
+to those we had just judged dead. It was, Danforth later told me,
+precisely what he had caught in infinitely muffled form when at that
+spot beyond the alley corner above the glacial level; and it certainly
+had a shocking resemblance to the wind pipings we had both heard around
+the lofty mountain caves.
+
+At the risk of seeming puerile I will add another thing, too, if
+only because of the surprising way Danforth's impression chimed with
+mine. Of course, common reading is what prepared us both to make the
+interpretation, though Danforth has hinted at queer notions about
+unsuspected and forbidden sources to which Poe may have had access when
+writing his "Arthur Gordon Pym" a century ago.
+
+It will be remembered that in that fantastic tale there is a word of
+unknown but terrible and prodigious significance connected with the
+antarctic and screamed eternally by the gigantic, spectrally snowy
+birds of that malign region's core. "_Tekeli-li! Tekeli-li!_" That, I
+may admit, is exactly what we thought we heard conveyed by that sudden
+sound behind the advancing white mist--that insidious, musical piping
+over a singularly wide range.
+
+       *       *       *       *       *
+
+We were in full flight before three notes or syllables had been
+uttered, though we knew that the swiftness of the Old Ones would enable
+any scream-roused and pursuing survivor of the slaughter to overtake us
+in a moment if it really wished to do so.
+
+We had a vague hope, however, that nonaggressive conduct and a display
+of kindred reason might cause such a being to spare us in case of
+capture, if only from scientific curiosity.
+
+After all, if such a one had nothing to fear for itself it would have
+no motive in harming us. Concealment being futile at this juncture, we
+used our torch for a running glance behind, and perceived that the mist
+was thinning. Would we see at last, a complete and living specimen of
+those others? Again came that insidious musical piping--"_Tekeli-li!
+Tekeli-li!_"
+
+Then, noting that we were actually gaining on our pursuer, it occurred
+to us that the entity might be wounded. We could take no chances,
+however, since it was very obviously approaching in answer to
+Danforth's scream, rather than in flight from any other entity. The
+timing was too close to admit of doubt.
+
+Of the whereabouts of that less conceivable and less mentionable
+nightmare--that fetid, unglimpsed mountain of slime-spewing protoplasm
+whose race had conquered the abyss and sent land pioneers to recarve
+and squirm through the burrows of the hills--we could form no guess;
+and it cost us a genuine pang to leave this probably crippled Old
+One--perhaps a lone survivor--to the peril of recapture and a nameless
+fate.
+
+Thank Heaven we did not slacken our run. The curling mist had thickened
+again, and was driving ahead with increased speed; whilst the straying
+penguins in our rear were squawking and screaming and displaying
+signs of a panic really surprising in view of their relatively minor
+confusion when we had passed them.
+
+Once more came that sinister, wide-ranged piping--"_Tekeli-li!
+Tekeli-li!_" We had been wrong. The thing was not wounded, but had
+merely paused on encountering the bodies of its fallen kindred and the
+hellish slime inscription above them. We could never know what that
+demon message was--but those burials at Lake's camp had shown how much
+importance the beings attached to their dead.
+
+Our recklessly used torch now revealed ahead of us the large open
+cavern where various ways converged, and we were glad to be leaving
+those morbid palimpsest sculptures--almost felt even when scarcely
+seen--behind.
+
+Another thought which the advent of the cave inspired was the
+possibility of losing our pursuer at this bewildering focus of large
+galleries. There were several of the blind albino penguins in the open
+space, and it seemed clear that their fear of the oncoming entity was
+extreme to the point of unaccountability.
+
+If at that point we dimmed our torch to the very lowest limit of
+traveling need, keeping it strictly in front of us, the frightened
+squawking motions of the huge birds in the mist might muffle our
+footfalls, screen our true course, and somehow set up a false lead.
+
+Amidst the churning, spiraling fog, the littered and unglistening floor
+of the main tunnel beyond this point, as differing from the other
+morbidly polished burrows, could hardly form a highly distinguishing
+feature; even, so far as we could conjecture, for those indicated
+special senses which made the Old Ones partly, though imperfectly,
+independent of light in emergencies.
+
+In fact, we were somewhat apprehensive lest we go astray ourselves
+in our haste. For we had, of course, decided to keep straight on
+toward the dead city; since the consequences of loss in those unknown
+foothill honeycombings would be unthinkable.
+
+The fact that we survived and emerged is sufficient proof that the
+thing did take a wrong gallery whilst we providentially hit on
+the right one. The penguins alone could not have saved us, but in
+conjunction with the mist they seem to have done so. Only a benign fate
+kept the curling vapors thick enough at the right moment, for they were
+constantly shifting and threatening to vanish.
+
+Indeed, they did lift for a second just before we emerged from the
+nauseously resculptured tunnel into the cave; so that we actually
+caught one first and only half glimpse of the oncoming entity as we
+cast a final, desperately fearful glance backward before dimming the
+torch and mixing with the penguins in the hope of dodging pursuit. If
+the fate which screened us was benign, that which gave us the half
+glimpse was infinitely the opposite; for to that flash of semivision
+can be traced a full half of the horror which has ever since haunted us.
+
+       *       *       *       *       *
+
+Our exact motive in looking back again was perhaps no more than the
+immemorial instinct of the pursued to gauge the nature and course
+of its pursuer; or perhaps it was an automatic attempt to answer a
+subconscious question raised by one of our senses.
+
+In the midst of our flight, with all our faculties centered on the
+problem of escape, we were in no condition to observe and analyze
+details; yet even so our latent brain cells must have wondered at the
+message brought them by our nostrils. Afterward, we realized what it
+was--that our retreat from the fetid slime coating on those headless
+obstructions, and the coincident approach of the pursuing entity, had
+not brought us the exchange of stenches which logic called for.
+
+In the neighborhood of the prostrate things that new and lately
+unexplainable fetor had been wholly dominant; but by this time it ought
+to have largely given place to the nameless stench associated with
+those others. This it had not done--for instead, the newer and less
+bearable smell was now virtually undiluted, and growing more and more
+poisonously insistent each second.
+
+So we glanced back--simultaneously, it would appear; though no doubt
+the incipient motion of one prompted the imitation of the other. As
+we did so we flashed both torches full strength at the momentarily
+thinned mist; either from sheer primitive anxiety to see all we could,
+or in a less primitive but equally unconscious effort to dazzle the
+entity before we dimmed our light and dodged among the penguins of the
+labyrinth center ahead.
+
+Unhappy act! Not Orpheus himself, or Lot's wife, paid much more dearly
+for a backward glance. And again came that shocking, wide-ranged
+piping--"_Tekeli-li! Tekeli-li!_"
+
+Danforth was totally unstrung, and the first thing I remember of the
+rest of the journey was hearing him light-headedly chant a hysterical
+formula in which I alone of mankind could have found anything but
+insane irrelevance. It reverberated in falsetto echoes among the
+squawks of the penguins; reverberated through the vaulting ahead,
+and--thank Heaven--through the now empty vaultings behind. He could not
+have begun it at once--else we would not have been alive and blindly
+racing. I shudder to think of what a shade of difference in his nervous
+reactions might have brought.
+
+"South Station Under--Washington Under--Park Street
+Under--Kendall--Central--Harvard----" The poor fellow was chanting the
+familiar stations of the Boston-Cambridge tunnel that burrowed through
+our peaceful native soil thousands of miles away in New England, yet to
+me the ritual had neither irrelevance nor home feeling. It had only
+horror, because I knew unerringly the monstrous, nefandous analogy that
+had suggested it.
+
+We had expected, upon looking back, to see a terrible and incredible
+moving entity if the mists were thin enough; but of that entity we had
+formed a clear idea. What we did see--for the mists were indeed all too
+malignly thinned--was something altogether different, and immeasurably
+more hideous and detestable. It was the utter, objective embodiment of
+the fantastic novelist's 'thing that should not be'; and its nearest
+comprehensible analogue is a vast, onrushing subway train as one sees
+it from a station platform--the great black front looming colossally
+out of infinite subterraneous distance, constellated with strangely
+colored lights and filling the prodigious burrow.
+
+But we were not on a station platform. We were on the track ahead as
+the nightmare, plastic column of fetid black iridescence oozed tightly
+onward through its fifteen-foot sinus, gathering unholy speed and
+driving before it a spiral, rethickening cloud of the pallid abyss
+vapor.
+
+It was a terrible, indescribable thing, vaster than any subway train--a
+shapeless congeries of protoplasmic bubbles, faintly self-luminous, and
+with myriads of temporary eyes forming and unforming as pustules of
+greenish light all over the tunnel-filling front that bore down upon
+us, crushing the frantic penguins and slithering over the glistening
+floor that it and its kind had swept so evilly free of all litter.
+
+Still came that eldritch, mocking cry--"_Tekeli-li! Tekeli-li!_" And at
+last we remembered that the demonic Shoggoths--given life, though, and
+plastic organ patterns solely by the Old Ones, and having no language
+save that which the dot groups expressed--had likewise no voice save
+the imitated accents of their bygone masters.
+
+
+
+
+                                 XII.
+
+
+Danforth and I have recollections of emerging into the great sculptured
+hemisphere and of threading our back trail through the Cyclopean rooms
+and corridors of the dead city; yet these are purely dream fragments
+involving no memory of volition, details, or physical exertion.
+
+There was something vaguely appropriate about our departure from those
+buried epochs; for as we wound our panting way up the sixty-foot
+cylinder of primal masonry we glimpsed beside us a continuous
+procession of heroic sculptures in the dead race's early and undecayed
+technique--a farewell from the Old Ones, written fifty million years
+ago.
+
+Finally, scrambling out at the top, we found ourselves on a great mound
+of tumbled blocks, with the curved walls of higher stonework rising
+westward, and the brooding peaks of the great mountains showing beyond
+the more crumbled structures toward the east.
+
+The sky above was a churning and opalescent mass of tenuous ice vapors,
+and the cold clutched at our vitals.
+
+In less than a quarter of an hour we had found the steep grade to the
+foothills--the probable ancient terrace--by which we had descended, and
+could see the dark bulk of our great plane amidst the sparse ruins on
+the rising slope ahead.
+
+Halfway uphill toward our goal we paused for a momentary breathing
+spell, and turned to look again at the fantastic tangle of incredible
+stone shapes below us--once more outlined mystically against an unknown
+west. As we did so we saw that the sky beyond had lost its morning
+haziness; the restless ice vapors having moved up to the zenith, where
+their mocking outlines seemed on the point of settling into some
+bizarre pattern which they feared to make quite definite or conclusive.
+
+       *       *       *       *       *
+
+There now lay revealed on the ultimate white horizon behind
+the grotesque city a dim, elfin line of pinnacled violet whose
+needle-pointed heights loomed dreamlike against the beckoning rose
+color of the western sky. Up toward this shimmering rim sloped the
+ancient table-land, the depressed course of the bygone river traversing
+it as an irregular ribbon of shadow.
+
+For a second we gasped in admiration of the scene's unearthly cosmic
+beauty, and then vague horror began to creep into our souls. For this
+far violet line could be nothing else than the terrible mountains of
+the forbidden land--highest of earth's peaks and focus of earth's evil;
+harborers of nameless horrors and Archæan secrets; shunned and prayed
+to by those who feared to carve their meaning; untrodden by any living
+thing of earth, but visited by the sinister lightnings and sending
+strange beams across the plains in the polar night.
+
+If the sculptured maps and pictures in that prehuman city had told
+truly, these cryptic violet mountains could not be much less than three
+hundred miles away; yet none the less sharply did their dim elfin
+essence jut above that remote and snowy rim, like the serrated edge of
+a monstrous alien planet about to rise into unaccustomed heavens.
+
+Looking at them, I thought nervously of certain sculptured hints of
+what the great bygone river had washed down into the city from their
+accursed sloping--and wondered how much sense and how much folly had
+lain in the fears of those Old Ones who carved them so reticently.
+
+I recalled how their northerly end must come near the coast at Queen
+Mary Land, where even at that moment Sir Douglas Mawson's expedition
+was doubtless working less than a thousand miles away; and hoped that
+no evil fate would give Sir Douglas and his men a glimpse of what
+might lie beyond the protecting coastal range. Such thoughts formed a
+measure of my overwrought condition at the time--and Danforth seemed to
+be even worse.
+
+Yet before we had passed the great star-shaped ruin and reached our
+plane our fears had become transferred to the lesser, but vast enough,
+range whose re-crossing lay ahead of us.
+
+From these foothills the black, ruin-crusted slopes reared up starkly
+and hideously against the east, again reminding us of those strange
+Asian paintings of Nicholas Roerich; and when we thought of the
+damnable honeycombings inside them, and of the frightful amorphous
+entities that might have pushed their fetidly squirming sway even to
+the topmost hollow pinnacles, we could not face without panic the
+prospect of again sailing by those suggestive skyward cave mouths where
+the wind made sounds like an evil musical piping over a wide range.
+
+To make matters worse, we saw distinct traces of local mist around
+several of the summits--as poor Lake must have done when he made that
+early mistake about volcanism--and thought shiveringly of that kindred
+mist from which we had just escaped--of that, and of the blasphemous,
+horror-fostering abyss whence all such vapors came.
+
+       *       *       *       *       *
+
+All was well with the plane, and we clumsily hauled on our heavy flying
+furs. Danforth got the engine started without trouble, and we made a
+very smooth take-off over the nightmare city.
+
+At a very high level there must have been great disturbance, since the
+ice-dust clouds of the zenith were doing all sorts of fantastic things;
+but at twenty-four thousand feet, the height we needed for the pass, we
+found navigation quite practicable.
+
+As we drew close to the jutting peaks the wind's strange piping again
+became manifest, and I could see Danforth's hands trembling at the
+controls. Rank amateur though I was, I thought at that moment that I
+might be a better navigator than he in effecting the dangerous crossing
+between pinnacles; and when I made motions to change seats and take
+over his duties he did not protest.
+
+I tried to keep all my skill and self-possession about me, and stared
+at the sector of reddish farther sky betwixt the walls of the pass.
+
+But Danforth, released from his piloting and keyed up to a dangerous
+nervous pitch, could not keep quiet. I felt him turning and wriggling
+about as he looked back at the terrible receding city, ahead at the
+cave-riddled, cube-barnacled peaks, sidewise at the bleak sea of snowy,
+rampart-strown foothills, and upward at the seething, grotesquely
+clouded sky.
+
+It was then, just as I was trying to steer safely through the pass,
+that his mad shrieking brought us so close to disaster, by shattering
+my tight hold on myself and causing me to fumble helplessly with the
+controls for a moment. A second afterward my resolution triumphed and
+we made the crossing safely----Yet I am afraid that Danforth will never
+be the same again.
+
+I have said that Danforth refused to tell me what final horror made him
+scream out so insanely--a horror which, I feel sadly sure, is mainly
+responsible for his present breakdown. We had snatches of shouted
+conversation above the wind's piping and the engine's buzzing as we
+reached the safe side of the range and swooped slowly down toward the
+camp, but that had mostly to do with the pledges of secrecy we had made
+as we prepared to leave the nightmare city.
+
+       *       *       *       *       *
+
+All that Danforth has ever hinted is that the final horror was a
+mirage. It was not, he declares, anything connected with the cubes
+and caves of those echoing, vaporous, wormily honeycombed mountains
+of madness which we crossed; but a single fantastic, demonic glimpse,
+among the churning westward zenith clouds, of what lay back of those
+other violet westward mountains which the Old Ones had shunned and
+feared.
+
+He has on rare occasions whispered disjointed and irresponsible things
+about "the black pit," "the carven rim," "the proto-Shoggoths," "the
+windowless solids with five dimensions," "the nameless cylinders," "the
+elder pharos," "Yog-Sothoth," "the primal white jelly," "the color out
+of space," "the wings," "the eyes in darkness," "the moon-ladder," "the
+original, the eternal, the undying," and other bizarre conceptions;
+but when he is fully himself he repudiates all this and attributes it
+to his curious and macabre reading of earlier years. Danforth, indeed,
+is known to be among the few who have ever dared go completely through
+that worm-riddled copy of the _Necronomicon_ kept under lock and key in
+the college library.
+
+The higher sky, as we crossed the range, was surely vaporous and
+disturbed enough; and although I did not see the zenith I can well
+imagine that its swirls of ice dust may have taken strange forms.
+Imagination, knowing how vividly distant scenes can sometimes be
+reflected, refracted, and magnified by such layers of restless cloud,
+might easily have supplied the rest--and, of course, Danforth did not
+hint any of these specific horrors till after his memory had had a
+chance to draw on his bygone reading. He could never have seen so much
+in one instantaneous glance.
+
+At the time, his shrieks were confined to the repetition of a single,
+mad word of all too obvious source: "_Tekeli-li! Tekeli-li!_"
+
+
+                                THE END
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK AT THE MOUNTAINS OF MADNESS ***
+
+
+    
+
+Updated editions will replace the previous one—the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg™ electronic works to protect the PROJECT GUTENBERG™
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away—you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg™ mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg™ License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg™
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg™
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg™ electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg™ electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the person
+or entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg™ electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg™ electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg™
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the
+Foundation” or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg™ electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg™ mission of promoting
+free access to electronic works by freely sharing Project Gutenberg™
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg™ name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg™ License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg™ work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg™ License must appear
+prominently whenever any copy of a Project Gutenberg™ work (any work
+on which the phrase “Project Gutenberg” appears, or with which the
+phrase “Project Gutenberg” is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+    This eBook is for the use of anyone anywhere in the United States and most
+    other parts of the world at no cost and with almost no restrictions
+    whatsoever. You may copy it, give it away or re-use it under the terms
+    of the Project Gutenberg License included with this eBook or online
+    at www.gutenberg.org. If you
+    are not located in the United States, you will have to check the laws
+    of the country where you are located before using this eBook.
+  
+1.E.2. If an individual Project Gutenberg™ electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase “Project
+Gutenberg” associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg™
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg™ electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg™ License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg™
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg™.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg™ License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg™ work in a format
+other than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg™ website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the
+full Project Gutenberg™ License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg™ works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg™ electronic works
+provided that:
+
+    • You pay a royalty fee of 20% of the gross profits you derive from
+        the use of Project Gutenberg™ works calculated using the method
+        you already use to calculate your applicable taxes. The fee is owed
+        to the owner of the Project Gutenberg™ trademark, but he has
+        agreed to donate royalties under this paragraph to the Project
+        Gutenberg Literary Archive Foundation. Royalty payments must be paid
+        within 60 days following each date on which you prepare (or are
+        legally required to prepare) your periodic tax returns. Royalty
+        payments should be clearly marked as such and sent to the Project
+        Gutenberg Literary Archive Foundation at the address specified in
+        Section 4, “Information about donations to the Project Gutenberg
+        Literary Archive Foundation.”
+    
+    • You provide a full refund of any money paid by a user who notifies
+        you in writing (or by e-mail) within 30 days of receipt that s/he
+        does not agree to the terms of the full Project Gutenberg™
+        License. You must require such a user to return or destroy all
+        copies of the works possessed in a physical medium and discontinue
+        all use of and all access to other copies of Project Gutenberg™
+        works.
+    
+    • You provide, in accordance with paragraph 1.F.3, a full refund of
+        any money paid for a work or a replacement copy, if a defect in the
+        electronic work is discovered and reported to you within 90 days of
+        receipt of the work.
+    
+    • You comply with all other terms of this agreement for free
+        distribution of Project Gutenberg™ works.
+    
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg™ electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg™ trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg™ collection. Despite these efforts, Project Gutenberg™
+electronic works, and the medium on which they may be stored, may
+contain “Defects,” such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg™ trademark, and any other party distributing a Project
+Gutenberg™ electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’, WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg™ electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg™
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg™ work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg™ work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg™
+
+Project Gutenberg™ is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg™’s
+goals and ensuring that the Project Gutenberg™ collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg™ and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at www.gutenberg.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation’s EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state’s laws.
+
+The Foundation’s business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation’s website
+and official page at www.gutenberg.org/contact
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg™ depends upon and cannot survive without widespread
+public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit www.gutenberg.org/donate.
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate.
+
+Section 5. General Information About Project Gutenberg™ electronic works
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg™ concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg™ eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg™ eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org.
+
+This website includes information about Project Gutenberg™,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/corpora/originals/poeWorksOG.txt
+++ b/corpora/originals/poeWorksOG.txt
@@ -1,0 +1,10692 @@
+﻿The Project Gutenberg eBook of The Works of Edgar Allan Poe — Volume 2
+    
+This ebook is for the use of anyone anywhere in the United States and
+most other parts of the world at no cost and with almost no restrictions
+whatsoever. You may copy it, give it away or re-use it under the terms
+of the Project Gutenberg License included with this ebook or online
+at www.gutenberg.org. If you are not located in the United States,
+you will have to check the laws of the country where you are located
+before using this eBook.
+
+Title: The Works of Edgar Allan Poe — Volume 2
+
+Author: Edgar Allan Poe
+
+Release date: April 1, 2000 [eBook #2148]
+                Most recently updated: May 19, 2024
+
+Language: English
+
+Credits: David Widger
+
+
+*** START OF THE PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE — VOLUME 2 ***
+
+
+
+
+The Works of Edgar Allan Poe
+
+by Edgar Allan Poe
+
+The Raven Edition
+
+VOLUME II.
+
+
+Contents
+
+ THE PURLOINED LETTER
+ THE THOUSAND-AND-SECOND TALE OF SCHEHERAZADE
+ A DESCENT INTO THE MAELSTROM.
+ VON KEMPELEN AND HIS DISCOVERY
+ MESMERIC REVELATION
+ THE FACTS IN THE CASE OF M. VALDEMAR
+ THE BLACK CAT.
+ THE FALL OF THE HOUSE OF USHER
+ SILENCE—A FABLE
+ THE MASQUE OF THE RED DEATH.
+ THE CASK OF AMONTILLADO.
+ THE IMP OF THE PERVERSE
+ THE ISLAND OF THE FAY
+ THE ASSIGNATION
+ THE PIT AND THE PENDULUM
+ THE PREMATURE BURIAL
+ THE DOMAIN OF ARNHEIM
+ LANDOR’S COTTAGE
+ WILLIAM WILSO
+ THE TELL-TALE HEART.
+ BERENICE
+ ELEONORA
+ NOTES TO THE SECOND VOLUME
+
+[Redactor’s Note—Some endnotes are by Poe and some were added by
+Griswold. In this volume the notes are at the end.]
+
+
+
+
+THE PURLOINED LETTER
+
+
+Nil sapientiæ odiosius acumine nimio.—_Seneca_.
+
+      At Paris, just after dark one gusty evening in the autumn of 18-,
+      I was enjoying the twofold luxury of meditation and a meerschaum,
+      in company with my friend C. Auguste Dupin, in his little back
+      library, or book-closet, _au troisième_, No. 33, _Rue Dunôt,
+      Faubourg St. Germain_. For one hour at least we had maintained a
+      profound silence; while each, to any casual observer, might have
+      seemed intently and exclusively occupied with the curling eddies
+      of smoke that oppressed the atmosphere of the chamber. For
+      myself, however, I was mentally discussing certain topics which
+      had formed matter for conversation between us at an earlier
+      period of the evening; I mean the affair of the Rue Morgue, and
+      the mystery attending the murder of Marie Rogêt. I looked upon
+      it, therefore, as something of a coincidence, when the door of
+      our apartment was thrown open and admitted our old acquaintance,
+      Monsieur G——, the Prefect of the Parisian police.
+
+      We gave him a hearty welcome; for there was nearly half as much
+      of the entertaining as of the contemptible about the man, and we
+      had not seen him for several years. We had been sitting in the
+      dark, and Dupin now arose for the purpose of lighting a lamp, but
+      sat down again, without doing so, upon G.‘s saying that he had
+      called to consult us, or rather to ask the opinion of my friend,
+      about some official business which had occasioned a great deal of
+      trouble.
+
+      “If it is any point requiring reflection,” observed Dupin, as he
+      forebore to enkindle the wick, “we shall examine it to better
+      purpose in the dark.”
+
+      “That is another of your odd notions,” said the Prefect, who had
+      a fashion of calling every thing “odd” that was beyond his
+      comprehension, and thus lived amid an absolute legion of
+      “oddities.”
+
+      “Very true,” said Dupin, as he supplied his visitor with a pipe,
+      and rolled towards him a comfortable chair.
+
+      “And what is the difficulty now?” I asked. “Nothing more in the
+      assassination way, I hope?”
+
+      “Oh no; nothing of that nature. The fact is, the business is very
+      simple indeed, and I make no doubt that we can manage it
+      sufficiently well ourselves; but then I thought Dupin would like
+      to hear the details of it, because it is so excessively odd.”
+
+      “Simple and odd,” said Dupin.
+
+      “Why, yes; and not exactly that, either. The fact is, we have all
+      been a good deal puzzled because the affair is so simple, and yet
+      baffles us altogether.”
+
+      “Perhaps it is the very simplicity of the thing which puts you at
+      fault,” said my friend.
+
+      “What nonsense you do talk!” replied the Prefect, laughing
+      heartily.
+
+      “Perhaps the mystery is a little too plain,” said Dupin.
+
+      “Oh, good heavens! who ever heard of such an idea?”
+
+      “A little too self-evident.”
+
+      “Ha! ha! ha—ha! ha! ha!—ho! ho! ho!” roared our visitor,
+      profoundly amused, “oh, Dupin, you will be the death of me yet!”
+
+      “And what, after all, is the matter on hand?” I asked.
+
+      “Why, I will tell you,” replied the Prefect, as he gave a long,
+      steady and contemplative puff, and settled himself in his chair.
+      “I will tell you in a few words; but, before I begin, let me
+      caution you that this is an affair demanding the greatest
+      secrecy, and that I should most probably lose the position I now
+      hold, were it known that I confided it to any one.”
+
+      “Proceed,” said I.
+
+      “Or not,” said Dupin.
+
+      “Well, then; I have received personal information, from a very
+      high quarter, that a certain document of the last importance has
+      been purloined from the royal apartments. The individual who
+      purloined it is known; this beyond a doubt; he was seen to take
+      it. It is known, also, that it still remains in his possession.”
+
+      “How is this known?” asked Dupin.
+
+      “It is clearly inferred,” replied the Prefect, “from the nature
+      of the document, and from the non-appearance of certain results
+      which would at once arise from its passing out of the robber’s
+      possession; that is to say, from his employing it as he must
+      design in the end to employ it.”
+
+      “Be a little more explicit,” I said.
+
+      “Well, I may venture so far as to say that the paper gives its
+      holder a certain power in a certain quarter where such power is
+      immensely valuable.” The Prefect was fond of the cant of
+      diplomacy.
+
+      “Still I do not quite understand,” said Dupin.
+
+      “No? Well; the disclosure of the document to a third person, who
+      shall be nameless, would bring in question the honor of a
+      personage of most exalted station; and this fact gives the holder
+      of the document an ascendancy over the illustrious personage
+      whose honor and peace are so jeopardized.”
+
+      “But this ascendancy,” I interposed, “would depend upon the
+      robber’s knowledge of the loser’s knowledge of the robber. Who
+      would dare—”
+
+      “The thief,” said G., “is the Minister D——, who dares all things,
+      those unbecoming as well as those becoming a man. The method of
+      the theft was not less ingenious than bold. The document in
+      question—a letter, to be frank—had been received by the personage
+      robbed while alone in the royal boudoir. During its perusal she
+      was suddenly interrupted by the entrance of the other exalted
+      personage from whom especially it was her wish to conceal it.
+      After a hurried and vain endeavor to thrust it in a drawer, she
+      was forced to place it, open as it was, upon a table. The
+      address, however, was uppermost, and, the contents thus
+      unexposed, the letter escaped notice. At this juncture enters the
+      Minister D——. His lynx eye immediately perceives the paper,
+      recognises the handwriting of the address, observes the confusion
+      of the personage addressed, and fathoms her secret. After some
+      business transactions, hurried through in his ordinary manner, he
+      produces a letter somewhat similar to the one in question, opens
+      it, pretends to read it, and then places it in close
+      juxtaposition to the other. Again he converses, for some fifteen
+      minutes, upon the public affairs. At length, in taking leave, he
+      takes also from the table the letter to which he had no claim.
+      Its rightful owner saw, but, of course, dared not call attention
+      to the act, in the presence of the third personage who stood at
+      her elbow. The minister decamped; leaving his own letter—one of
+      no importance—upon the table.”
+
+      “Here, then,” said Dupin to me, “you have precisely what you
+      demand to make the ascendancy complete—the robber’s knowledge of
+      the loser’s knowledge of the robber.”
+
+      “Yes,” replied the Prefect; “and the power thus attained has, for
+      some months past, been wielded, for political purposes, to a very
+      dangerous extent. The personage robbed is more thoroughly
+      convinced, every day, of the necessity of reclaiming her letter.
+      But this, of course, cannot be done openly. In fine, driven to
+      despair, she has committed the matter to me.”
+
+      “Than whom,” said Dupin, amid a perfect whirlwind of smoke, “no
+      more sagacious agent could, I suppose, be desired, or even
+      imagined.”
+
+      “You flatter me,” replied the Prefect; “but it is possible that
+      some such opinion may have been entertained.”
+
+      “It is clear,” said I, “as you observe, that the letter is still
+      in possession of the minister; since it is this possession, and
+      not any employment of the letter, which bestows the power. With
+      the employment the power departs.”
+
+      “True,” said G.; “and upon this conviction I proceeded. My first
+      care was to make thorough search of the minister’s hotel; and
+      here my chief embarrassment lay in the necessity of searching
+      without his knowledge. Beyond all things, I have been warned of
+      the danger which would result from giving him reason to suspect
+      our design.”
+
+      “But,” said I, “you are quite au fait in these investigations.
+      The Parisian police have done this thing often before.”
+
+      “Oh, yes; and for this reason I did not despair. The habits of
+      the minister gave me, too, a great advantage. He is frequently
+      absent from home all night. His servants are by no means
+      numerous. They sleep at a distance from their master’s apartment,
+      and, being chiefly Neapolitans, are readily made drunk. I have
+      keys, as you know, with which I can open any chamber or cabinet
+      in Paris. For three months a night has not passed, during the
+      greater part of which I have not been engaged, personally, in
+      ransacking the D—— Hotel. My honor is interested, and, to mention
+      a great secret, the reward is enormous. So I did not abandon the
+      search until I had become fully satisfied that the thief is a
+      more astute man than myself. I fancy that I have investigated
+      every nook and corner of the premises in which it is possible
+      that the paper can be concealed.”
+
+      “But is it not possible,” I suggested, “that although the letter
+      may be in possession of the minister, as it unquestionably is, he
+      may have concealed it elsewhere than upon his own premises?”
+
+      “This is barely possible,” said Dupin. “The present peculiar
+      condition of affairs at court, and especially of those intrigues
+      in which D—— is known to be involved, would render the instant
+      availability of the document—its susceptibility of being produced
+      at a moment’s notice—a point of nearly equal importance with its
+      possession.”
+
+      “Its susceptibility of being produced?” said I.
+
+      “That is to say, of being destroyed,” said Dupin.
+
+      “True,” I observed; “the paper is clearly then upon the premises.
+      As for its being upon the person of the minister, we may consider
+      that as out of the question.”
+
+      “Entirely,” said the Prefect. “He has been twice waylaid, as if
+      by footpads, and his person rigorously searched under my own
+      inspection.”
+
+      “You might have spared yourself this trouble,” said Dupin. “D——,
+      I presume, is not altogether a fool, and, if not, must have
+      anticipated these waylayings, as a matter of course.”
+
+      “Not altogether a fool,” said G., “but then he’s a poet, which I
+      take to be only one remove from a fool.”
+
+      “True,” said Dupin, after a long and thoughtful whiff from his
+      meerschaum, “although I have been guilty of certain doggrel
+      myself.”
+
+      “Suppose you detail,” said I, “the particulars of your search.”
+
+      “Why the fact is, we took our time, and we searched _everywhere_.
+      I have had long experience in these affairs. I took the entire
+      building, room by room; devoting the nights of a whole week to
+      each. We examined, first, the furniture of each apartment. We
+      opened every possible drawer; and I presume you know that, to a
+      properly trained police agent, such a thing as a secret drawer is
+      impossible. Any man is a dolt who permits a ‘secret’ drawer to
+      escape him in a search of this kind. The thing is so plain. There
+      is a certain amount of bulk—of space—to be accounted for in every
+      cabinet. Then we have accurate rules. The fiftieth part of a line
+      could not escape us. After the cabinets we took the chairs. The
+      cushions we probed with the fine long needles you have seen me
+      employ. From the tables we removed the tops.”
+
+      “Why so?”
+
+      “Sometimes the top of a table, or other similarly arranged piece
+      of furniture, is removed by the person wishing to conceal an
+      article; then the leg is excavated, the article deposited within
+      the cavity, and the top replaced. The bottoms and tops of
+      bedposts are employed in the same way.”
+
+      “But could not the cavity be detected by sounding?” I asked.
+
+      “By no means, if, when the article is deposited, a sufficient
+      wadding of cotton be placed around it. Besides, in our case, we
+      were obliged to proceed without noise.”
+
+      “But you could not have removed—you could not have taken to
+      pieces all articles of furniture in which it would have been
+      possible to make a deposit in the manner you mention. A letter
+      may be compressed into a thin spiral roll, not differing much in
+      shape or bulk from a large knitting-needle, and in this form it
+      might be inserted into the rung of a chair, for example. You did
+      not take to pieces all the chairs?”
+
+      “Certainly not; but we did better—we examined the rungs of every
+      chair in the hotel, and, indeed the jointings of every
+      description of furniture, by the aid of a most powerful
+      microscope. Had there been any traces of recent disturbance we
+      should not have failed to detect it instantly. A single grain of
+      gimlet-dust, for example, would have been as obvious as an apple.
+      Any disorder in the glueing—any unusual gaping in the
+      joints—would have sufficed to insure detection.”
+
+      “I presume you looked to the mirrors, between the boards and the
+      plates, and you probed the beds and the bed-clothes, as well as
+      the curtains and carpets.”
+
+      “That of course; and when we had absolutely completed every
+      particle of the furniture in this way, then we examined the house
+      itself. We divided its entire surface into compartments, which we
+      numbered, so that none might be missed; then we scrutinized each
+      individual square inch throughout the premises, including the two
+      houses immediately adjoining, with the microscope, as before.”
+
+      “The two houses adjoining!” I exclaimed; “you must have had a
+      great deal of trouble.”
+
+      “We had; but the reward offered is prodigious!”
+
+      “You include the grounds about the houses?”
+
+      “All the grounds are paved with brick. They gave us comparatively
+      little trouble. We examined the moss between the bricks, and
+      found it undisturbed.”
+
+      “You looked among D——‘s papers, of course, and into the books of
+      the library?”
+
+      “Certainly; we opened every package and parcel; we not only
+      opened every book, but we turned over every leaf in each volume,
+      not contenting ourselves with a mere shake, according to the
+      fashion of some of our police officers. We also measured the
+      thickness of every book-cover, with the most accurate
+      admeasurement, and applied to each the most jealous scrutiny of
+      the microscope. Had any of the bindings been recently meddled
+      with, it would have been utterly impossible that the fact should
+      have escaped observation. Some five or six volumes, just from the
+      hands of the binder, we carefully probed, longitudinally, with
+      the needles.”
+
+      “You explored the floors beneath the carpets?”
+
+      “Beyond doubt. We removed every carpet, and examined the boards
+      with the microscope.”
+
+      “And the paper on the walls?”
+
+      “Yes.”
+
+      “You looked into the cellars?”
+
+      “We did.”
+
+      “Then,” I said, “you have been making a miscalculation, and the
+      letter is not upon the premises, as you suppose.”
+
+      “I fear you are right there,” said the Prefect. “And now, Dupin,
+      what would you advise me to do?”
+
+      “To make a thorough re-search of the premises.”
+
+      “That is absolutely needless,” replied G——. “I am not more sure
+      that I breathe than I am that the letter is not at the Hotel.”
+
+      “I have no better advice to give you,” said Dupin. “You have, of
+      course, an accurate description of the letter?”
+
+      “Oh yes!”—And here the Prefect, producing a memorandum-book,
+      proceeded to read aloud a minute account of the internal, and
+      especially of the external appearance of the missing document.
+      Soon after finishing the perusal of this description, he took his
+      departure, more entirely depressed in spirits than I had ever
+      known the good gentleman before.
+
+      In about a month afterwards he paid us another visit, and found
+      us occupied very nearly as before. He took a pipe and a chair and
+      entered into some ordinary conversation. At length I said,—
+
+      “Well, but G——, what of the purloined letter? I presume you have
+      at last made up your mind that there is no such thing as
+      overreaching the Minister?”
+
+      “Confound him, say I—yes; I made the re-examination, however, as
+      Dupin suggested—but it was all labor lost, as I knew it would
+      be.”
+
+      “How much was the reward offered, did you say?” asked Dupin.
+
+      “Why, a very great deal—a very liberal reward—I don’t like to say
+      how much, precisely; but one thing I will say, that I wouldn’t
+      mind giving my individual check for fifty thousand francs to any
+      one who could obtain me that letter. The fact is, it is becoming
+      of more and more importance every day; and the reward has been
+      lately doubled. If it were trebled, however, I could do no more
+      than I have done.”
+
+      “Why, yes,” said Dupin, drawlingly, between the whiffs of his
+      meerschaum, “I really—think, G——, you have not exerted
+      yourself—to the utmost in this matter. You might—do a little
+      more, I think, eh?”
+
+      “How?—in what way?”
+
+      “Why—puff, puff—you might—puff, puff—employ counsel in the
+      matter, eh?—puff, puff, puff. Do you remember the story they tell
+      of Abernethy?”
+
+      “No; hang Abernethy!”
+
+      “To be sure! hang him and welcome. But, once upon a time, a
+      certain rich miser conceived the design of spunging upon this
+      Abernethy for a medical opinion. Getting up, for this purpose, an
+      ordinary conversation in a private company, he insinuated his
+      case to the physician, as that of an imaginary individual.
+
+      “‘We will suppose,’ said the miser, ‘that his symptoms are such
+      and such; now, doctor, what would you have directed him to take?’
+
+      “‘Take!’ said Abernethy, ‘why, take advice, to be sure.’”
+
+      “But,” said the Prefect, a little discomposed, “I am perfectly
+      willing to take advice, and to pay for it. I would really give
+      fifty thousand francs to any one who would aid me in the matter.”
+
+      “In that case,” replied Dupin, opening a drawer, and producing a
+      check-book, “you may as well fill me up a check for the amount
+      mentioned. When you have signed it, I will hand you the letter.”
+
+      I was astounded. The Prefect appeared absolutely
+      thunder-stricken. For some minutes he remained speechless and
+      motionless, looking incredulously at my friend with open mouth,
+      and eyes that seemed starting from their sockets; then,
+      apparently recovering himself in some measure, he seized a pen,
+      and after several pauses and vacant stares, finally filled up and
+      signed a check for fifty thousand francs, and handed it across
+      the table to Dupin. The latter examined it carefully and
+      deposited it in his pocket-book; then, unlocking an escritoire,
+      took thence a letter and gave it to the Prefect. This functionary
+      grasped it in a perfect agony of joy, opened it with a trembling
+      hand, cast a rapid glance at its contents, and then, scrambling
+      and struggling to the door, rushed at length unceremoniously from
+      the room and from the house, without having uttered a syllable
+      since Dupin had requested him to fill up the check.
+
+      When he had gone, my friend entered into some explanations.
+
+      “The Parisian police,” he said, “are exceedingly able in their
+      way. They are persevering, ingenious, cunning, and thoroughly
+      versed in the knowledge which their duties seem chiefly to
+      demand. Thus, when G—— detailed to us his mode of searching the
+      premises at the Hotel D——, I felt entire confidence in his having
+      made a satisfactory investigation—so far as his labors extended.”
+
+      “So far as his labors extended?” said I.
+
+      “Yes,” said Dupin. “The measures adopted were not only the best
+      of their kind, but carried out to absolute perfection. Had the
+      letter been deposited within the range of their search, these
+      fellows would, beyond a question, have found it.”
+
+      I merely laughed—but he seemed quite serious in all that he said.
+
+      “The measures, then,” he continued, “were good in their kind, and
+      well executed; their defect lay in their being inapplicable to
+      the case, and to the man. A certain set of highly ingenious
+      resources are, with the Prefect, a sort of Procrustean bed, to
+      which he forcibly adapts his designs. But he perpetually errs by
+      being too deep or too shallow for the matter in hand; and many a
+      schoolboy is a better reasoner than he. I knew one about eight
+      years of age, whose success at guessing in the game of ‘even and
+      odd’ attracted universal admiration. This game is simple, and is
+      played with marbles. One player holds in his hand a number of
+      these toys, and demands of another whether that number is even or
+      odd. If the guess is right, the guesser wins one; if wrong, he
+      loses one. The boy to whom I allude won all the marbles of the
+      school. Of course he had some principle of guessing; and this lay
+      in mere observation and admeasurement of the astuteness of his
+      opponents. For example, an arrant simpleton is his opponent, and,
+      holding up his closed hand, asks, ‘are they even or odd?’ Our
+      schoolboy replies, ‘odd,’ and loses; but upon the second trial he
+      wins, for he then says to himself, ‘the simpleton had them even
+      upon the first trial, and his amount of cunning is just
+      sufficient to make him have them odd upon the second; I will
+      therefore guess odd;’—he guesses odd, and wins. Now, with a
+      simpleton a degree above the first, he would have reasoned thus:
+      ‘This fellow finds that in the first instance I guessed odd, and,
+      in the second, he will propose to himself, upon the first
+      impulse, a simple variation from even to odd, as did the first
+      simpleton; but then a second thought will suggest that this is
+      too simple a variation, and finally he will decide upon putting
+      it even as before. I will therefore guess even;’—he guesses even,
+      and wins. Now this mode of reasoning in the schoolboy, whom his
+      fellows termed ‘lucky,’—what, in its last analysis, is it?”
+
+      “It is merely,” I said, “an identification of the reasoner’s
+      intellect with that of his opponent.”
+
+      “It is,” said Dupin; “and, upon inquiring of the boy by what
+      means he effected the thorough identification in which his
+      success consisted, I received answer as follows: ‘When I wish to
+      find out how wise, or how stupid, or how good, or how wicked is
+      any one, or what are his thoughts at the moment, I fashion the
+      expression of my face, as accurately as possible, in accordance
+      with the expression of his, and then wait to see what thoughts or
+      sentiments arise in my mind or heart, as if to match or
+      correspond with the expression.’ This response of the schoolboy
+      lies at the bottom of all the spurious profundity which has been
+      attributed to Rochefoucault, to La Bougive, to Machiavelli, and
+      to Campanella.”
+
+      “And the identification,” I said, “of the reasoner’s intellect
+      with that of his opponent, depends, if I understand you aright,
+      upon the accuracy with which the opponent’s intellect is
+      admeasured.”
+
+      “For its practical value it depends upon this,” replied Dupin;
+      “and the Prefect and his cohort fail so frequently, first, by
+      default of this identification, and, secondly, by
+      ill-admeasurement, or rather through non-admeasurement, of the
+      intellect with which they are engaged. They consider only their
+      own ideas of ingenuity; and, in searching for anything hidden,
+      advert only to the modes in which they would have hidden it. They
+      are right in this much—that their own ingenuity is a faithful
+      representative of that of the mass; but when the cunning of the
+      individual felon is diverse in character from their own, the
+      felon foils them, of course. This always happens when it is above
+      their own, and very usually when it is below. They have no
+      variation of principle in their investigations; at best, when
+      urged by some unusual emergency—by some extraordinary reward—they
+      extend or exaggerate their old modes of practice, without
+      touching their principles. What, for example, in this case of
+      D——, has been done to vary the principle of action? What is all
+      this boring, and probing, and sounding, and scrutinizing with the
+      microscope and dividing the surface of the building into
+      registered square inches—what is it all but an exaggeration of
+      the application of the one principle or set of principles of
+      search, which are based upon the one set of notions regarding
+      human ingenuity, to which the Prefect, in the long routine of his
+      duty, has been accustomed? Do you not see he has taken it for
+      granted that all men proceed to conceal a letter,—not exactly in
+      a gimlet hole bored in a chair-leg—but, at least, in some
+      out-of-the-way hole or corner suggested by the same tenor of
+      thought which would urge a man to secrete a letter in a
+      gimlet-hole bored in a chair-leg? And do you not see also, that
+      such recherchés nooks for concealment are adapted only for
+      ordinary occasions, and would be adopted only by ordinary
+      intellects; for, in all cases of concealment, a disposal of the
+      article concealed—a disposal of it in this recherché manner,—is,
+      in the very first instance, presumable and presumed; and thus its
+      discovery depends, not at all upon the acumen, but altogether
+      upon the mere care, patience, and determination of the seekers;
+      and where the case is of importance—or, what amounts to the same
+      thing in the political eyes, when the reward is of magnitude,—the
+      qualities in question have never been known to fail. You will now
+      understand what I meant in suggesting that, had the purloined
+      letter been hidden any where within the limits of the Prefect’s
+      examination—in other words, had the principle of its concealment
+      been comprehended within the principles of the Prefect—its
+      discovery would have been a matter altogether beyond question.
+      This functionary, however, has been thoroughly mystified; and the
+      remote source of his defeat lies in the supposition that the
+      Minister is a fool, because he has acquired renown as a poet. All
+      fools are poets; this the Prefect feels; and he is merely guilty
+      of a non distributio medii in thence inferring that all poets are
+      fools.”
+
+      “But is this really the poet?” I asked. “There are two brothers,
+      I know; and both have attained reputation in letters. The
+      Minister I believe has written learnedly on the Differential
+      Calculus. He is a mathematician, and no poet.”
+
+      “You are mistaken; I know him well; he is both. As poet and
+      mathematician, he would reason well; as mere mathematician, he
+      could not have reasoned at all, and thus would have been at the
+      mercy of the Prefect.”
+
+      “You surprise me,” I said, “by these opinions, which have been
+      contradicted by the voice of the world. You do not mean to set at
+      naught the well-digested idea of centuries. The mathematical
+      reason has long been regarded as the reason par excellence.”
+
+      “‘Il y a à parièr,’” replied Dupin, quoting from Chamfort, “‘que
+      toute idée publique, toute convention reçue est une sottise, car
+      elle a convenue au plus grand nombre.’ The mathematicians, I
+      grant you, have done their best to promulgate the popular error
+      to which you allude, and which is none the less an error for its
+      promulgation as truth. With an art worthy a better cause, for
+      example, they have insinuated the term ‘analysis’ into
+      application to algebra. The French are the originators of this
+      particular deception; but if a term is of any importance—if words
+      derive any value from applicability—then ‘analysis’ conveys
+      ‘algebra’ about as much as, in Latin, ‘ambitus’ implies
+      ‘ambition,’ ‘_religio_’ ‘religion,’ or ‘_homines honesti_’ a set
+      of _honorable_ men.”
+
+      “You have a quarrel on hand, I see,” said I, “with some of the
+      algebraists of Paris; but proceed.”
+
+      “I dispute the availability, and thus the value, of that reason
+      which is cultivated in any especial form other than the
+      abstractly logical. I dispute, in particular, the reason educed
+      by mathematical study. The mathematics are the science of form
+      and quantity; mathematical reasoning is merely logic applied to
+      observation upon form and quantity. The great error lies in
+      supposing that even the truths of what is called pure algebra,
+      are abstract or general truths. And this error is so egregious
+      that I am confounded at the universality with which it has been
+      received. Mathematical axioms are not axioms of general truth.
+      What is true of relation—of form and quantity—is often grossly
+      false in regard to morals, for example. In this latter science it
+      is very usually untrue that the aggregated parts are equal to the
+      whole. In chemistry also the axiom fails. In the consideration of
+      motive it fails; for two motives, each of a given value, have
+      not, necessarily, a value when united, equal to the sum of their
+      values apart. There are numerous other mathematical truths which
+      are only truths within the limits of relation. But the
+      mathematician argues, from his finite truths, through habit, as
+      if they were of an absolutely general applicability—as the world
+      indeed imagines them to be. Bryant, in his very learned
+      ‘Mythology,’ mentions an analogous source of error, when he says
+      that ‘although the Pagan fables are not believed, yet we forget
+      ourselves continually, and make inferences from them as existing
+      realities.’ With the algebraists, however, who are Pagans
+      themselves, the ‘Pagan fables’ are believed, and the inferences
+      are made, not so much through lapse of memory, as through an
+      unaccountable addling of the brains. In short, I never yet
+      encountered the mere mathematician who could be trusted out of
+      equal roots, or one who did not clandestinely hold it as a point
+      of his faith that x2+px was absolutely and unconditionally equal
+      to q. Say to one of these gentlemen, by way of experiment, if you
+      please, that you believe occasions may occur where x2+px is not
+      altogether equal to q, and, having made him understand what you
+      mean, get out of his reach as speedily as convenient, for, beyond
+      doubt, he will endeavor to knock you down.
+
+      “I mean to say,” continued Dupin, while I merely laughed at his
+      last observations, “that if the Minister had been no more than a
+      mathematician, the Prefect would have been under no necessity of
+      giving me this check. I know him, however, as both mathematician
+      and poet, and my measures were adapted to his capacity, with
+      reference to the circumstances by which he was surrounded. I knew
+      him as a courtier, too, and as a bold intriguant. Such a man, I
+      considered, could not fail to be aware of the ordinary policial
+      modes of action. He could not have failed to anticipate—and
+      events have proved that he did not fail to anticipate—the
+      waylayings to which he was subjected. He must have foreseen, I
+      reflected, the secret investigations of his premises. His
+      frequent absences from home at night, which were hailed by the
+      Prefect as certain aids to his success, I regarded only as ruses,
+      to afford opportunity for thorough search to the police, and thus
+      the sooner to impress them with the conviction to which G——, in
+      fact, did finally arrive—the conviction that the letter was not
+      upon the premises. I felt, also, that the whole train of thought,
+      which I was at some pains in detailing to you just now,
+      concerning the invariable principle of policial action in
+      searches for articles concealed—I felt that this whole train of
+      thought would necessarily pass through the mind of the Minister.
+      It would imperatively lead him to despise all the ordinary nooks
+      of concealment. He could not, I reflected, be so weak as not to
+      see that the most intricate and remote recess of his hotel would
+      be as open as his commonest closets to the eyes, to the probes,
+      to the gimlets, and to the microscopes of the Prefect. I saw, in
+      fine, that he would be driven, as a matter of course, to
+      simplicity, if not deliberately induced to it as a matter of
+      choice. You will remember, perhaps, how desperately the Prefect
+      laughed when I suggested, upon our first interview, that it was
+      just possible this mystery troubled him so much on account of its
+      being so very self-evident.”
+
+      “Yes,” said I, “I remember his merriment well. I really thought
+      he would have fallen into convulsions.”
+
+      “The material world,” continued Dupin, “abounds with very strict
+      analogies to the immaterial; and thus some color of truth has
+      been given to the rhetorical dogma, that metaphor, or simile, may
+      be made to strengthen an argument, as well as to embellish a
+      description. The principle of the vis inertiæ, for example, seems
+      to be identical in physics and metaphysics. It is not more true
+      in the former, that a large body is with more difficulty set in
+      motion than a smaller one, and that its subsequent momentum is
+      commensurate with this difficulty, than it is, in the latter,
+      that intellects of the vaster capacity, while more forcible, more
+      constant, and more eventful in their movements than those of
+      inferior grade, are yet the less readily moved, and more
+      embarrassed and full of hesitation in the first few steps of
+      their progress. Again: have you ever noticed which of the street
+      signs, over the shop-doors, are the most attractive of
+      attention?”
+
+      “I have never given the matter a thought,” I said.
+
+      “There is a game of puzzles,” he resumed, “which is played upon a
+      map. One party playing requires another to find a given word—the
+      name of town, river, state or empire—any word, in short, upon the
+      motley and perplexed surface of the chart. A novice in the game
+      generally seeks to embarrass his opponents by giving them the
+      most minutely lettered names; but the adept selects such words as
+      stretch, in large characters, from one end of the chart to the
+      other. These, like the over-largely lettered signs and placards
+      of the street, escape observation by dint of being excessively
+      obvious; and here the physical oversight is precisely analogous
+      with the moral inapprehension by which the intellect suffers to
+      pass unnoticed those considerations which are too obtrusively and
+      too palpably self-evident. But this is a point, it appears,
+      somewhat above or beneath the understanding of the Prefect. He
+      never once thought it probable, or possible, that the Minister
+      had deposited the letter immediately beneath the nose of the
+      whole world, by way of best preventing any portion of that world
+      from perceiving it.
+
+      “But the more I reflected upon the daring, dashing, and
+      discriminating ingenuity of D——; upon the fact that the document
+      must always have been at hand, if he intended to use it to good
+      purpose; and upon the decisive evidence, obtained by the Prefect,
+      that it was not hidden within the limits of that dignitary’s
+      ordinary search—the more satisfied I became that, to conceal this
+      letter, the Minister had resorted to the comprehensive and
+      sagacious expedient of not attempting to conceal it at all.
+
+      “Full of these ideas, I prepared myself with a pair of green
+      spectacles, and called one fine morning, quite by accident, at
+      the Ministerial hotel. I found D—— at home, yawning, lounging,
+      and dawdling, as usual, and pretending to be in the last
+      extremity of ennui. He is, perhaps, the most really energetic
+      human being now alive—but that is only when nobody sees him.
+
+      “To be even with him, I complained of my weak eyes, and lamented
+      the necessity of the spectacles, under cover of which I
+      cautiously and thoroughly surveyed the whole apartment, while
+      seemingly intent only upon the conversation of my host.
+
+      “I paid especial attention to a large writing-table near which he
+      sat, and upon which lay confusedly, some miscellaneous letters
+      and other papers, with one or two musical instruments and a few
+      books. Here, however, after a long and very deliberate scrutiny,
+      I saw nothing to excite particular suspicion.
+
+      “At length my eyes, in going the circuit of the room, fell upon a
+      trumpery fillagree card-rack of pasteboard, that hung dangling by
+      a dirty blue ribbon, from a little brass knob just beneath the
+      middle of the mantel-piece. In this rack, which had three or four
+      compartments, were five or six visiting cards and a solitary
+      letter. This last was much soiled and crumpled. It was torn
+      nearly in two, across the middle—as if a design, in the first
+      instance, to tear it entirely up as worthless, had been altered,
+      or stayed, in the second. It had a large black seal, bearing the
+      D—— cipher _very_ conspicuously, and was addressed, in a
+      diminutive female hand, to D——, the minister, himself. It was
+      thrust carelessly, and even, as it seemed, contemptuously, into
+      one of the uppermost divisions of the rack.
+
+      “No sooner had I glanced at this letter, than I concluded it to
+      be that of which I was in search. To be sure, it was, to all
+      appearance, radically different from the one of which the Prefect
+      had read us so minute a description. Here the seal was large and
+      black, with the D—— cipher; there it was small and red, with the
+      ducal arms of the S—— family. Here, the address, to the Minister,
+      diminutive and feminine; there the superscription, to a certain
+      royal personage, was markedly bold and decided; the size alone
+      formed a point of correspondence. But, then, the radicalness of
+      these differences, which was excessive; the dirt; the soiled and
+      torn condition of the paper, so inconsistent with the true
+      methodical habits of D——, and so suggestive of a design to delude
+      the beholder into an idea of the worthlessness of the
+      document—these things, together with the hyper-obtrusive
+      situation of this document, full in the view of every visitor,
+      and thus exactly in accordance with the conclusions to which I
+      had previously arrived; these things, I say, were strongly
+      corroborative of suspicion, in one who came with the intention to
+      suspect.
+
+      “I protracted my visit as long as possible, and, while I
+      maintained a most animated discussion with the Minister upon a
+      topic which I knew well had never failed to interest and excite
+      him, I kept my attention really riveted upon the letter. In this
+      examination, I committed to memory its external appearance and
+      arrangement in the rack; and also fell, at length, upon a
+      discovery which set at rest whatever trivial doubt I might have
+      entertained. In scrutinizing the edges of the paper, I observed
+      them to be more chafed than seemed necessary. They presented the
+      broken appearance which is manifested when a stiff paper, having
+      been once folded and pressed with a folder, is refolded in a
+      reversed direction, in the same creases or edges which had formed
+      the original fold. This discovery was sufficient. It was clear to
+      me that the letter had been turned, as a glove, inside out,
+      re-directed, and re-sealed. I bade the Minister good morning, and
+      took my departure at once, leaving a gold snuff-box upon the
+      table.
+
+      “The next morning I called for the snuff-box, when we resumed,
+      quite eagerly, the conversation of the preceding day. While thus
+      engaged, however, a loud report, as if of a pistol, was heard
+      immediately beneath the windows of the hotel, and was succeeded
+      by a series of fearful screams, and the shoutings of a terrified
+      mob. D—— rushed to a casement, threw it open, and looked out. In
+      the meantime, I stepped to the card-rack, took the letter, put it
+      in my pocket, and replaced it by a fac-simile, (so far as regards
+      externals,) which I had carefully prepared at my
+      lodgings—imitating the D—— cipher, very readily, by means of a
+      seal formed of bread.
+
+      “The disturbance in the street had been occasioned by the frantic
+      behavior of a man with a musket. He had fired it among a crowd of
+      women and children. It proved, however, to have been without
+      ball, and the fellow was suffered to go his way as a lunatic or a
+      drunkard. When he had gone, D—— came from the window, whither I
+      had followed him immediately upon securing the object in view.
+      Soon afterwards I bade him farewell. The pretended lunatic was a
+      man in my own pay.”
+
+      “But what purpose had you,” I asked, “in replacing the letter by
+      a fac-simile? Would it not have been better, at the first visit,
+      to have seized it openly, and departed?”
+
+      “D——,” replied Dupin, “is a desperate man, and a man of nerve.
+      His hotel, too, is not without attendants devoted to his
+      interests. Had I made the wild attempt you suggest, I might never
+      have left the Ministerial presence alive. The good people of
+      Paris might have heard of me no more. But I had an object apart
+      from these considerations. You know my political prepossessions.
+      In this matter, I act as a partisan of the lady concerned. For
+      eighteen months the Minister has had her in his power. She has
+      now him in hers—since, being unaware that the letter is not in
+      his possession, he will proceed with his exactions as if it was.
+      Thus will he inevitably commit himself, at once, to his political
+      destruction. His downfall, too, will not be more precipitate than
+      awkward. It is all very well to talk about the facilis descensus
+      Averni; but in all kinds of climbing, as Catalani said of
+      singing, it is far more easy to get up than to come down. In the
+      present instance I have no sympathy—at least no pity—for him who
+      descends. He is that monstrum horrendum, an unprincipled man of
+      genius. I confess, however, that I should like very well to know
+      the precise character of his thoughts, when, being defied by her
+      whom the Prefect terms ‘a certain personage’ he is reduced to
+      opening the letter which I left for him in the card-rack.”
+
+      “How? did you put any thing particular in it?”
+
+      “Why—it did not seem altogether right to leave the interior
+      blank—that would have been insulting. D——, at Vienna once, did me
+      an evil turn, which I told him, quite good-humoredly, that I
+      should remember. So, as I knew he would feel some curiosity in
+      regard to the identity of the person who had outwitted him, I
+      thought it a pity not to give him a clue. He is well acquainted
+      with my MS., and I just copied into the middle of the blank sheet
+      the words—
+
+      “‘— — Un dessein si funeste,
+      S’il n’est digne d’Atrée, est digne de Thyeste.
+
+      They are to be found in Crébillon’s ‘Atrée.’”
+
+
+
+
+THE THOUSAND-AND-SECOND TALE OF SCHEHERAZADE
+
+
+Truth is stranger than fiction.—_Old Saying_
+
+      Having had occasion, lately, in the course of some Oriental
+      investigations, to consult the Tellmenow Isitsöornot, a work
+      which (like the Zohar of Simeon Jochaides) is scarcely known at
+      all, even in Europe; and which has never been quoted, to my
+      knowledge, by any American—if we except, perhaps, the author of
+      the “Curiosities of American Literature”;—having had occasion, I
+      say, to turn over some pages of the first-mentioned very
+      remarkable work, I was not a little astonished to discover that
+      the literary world has hitherto been strangely in error
+      respecting the fate of the vizier’s daughter, Scheherazade, as
+      that fate is depicted in the “Arabian Nights”; and that the
+      _dénouement_ there given, if not altogether inaccurate, as far as
+      it goes, is at least to blame in not having gone very much
+      farther.
+
+      For full information on this interesting topic, I must refer the
+      inquisitive reader to the “Isitsöornot” itself; but in the
+      meantime, I shall be pardoned for giving a summary of what I
+      there discovered.
+
+      It will be remembered, that, in the usual version of the tales, a
+      certain monarch having good cause to be jealous of his queen, not
+      only puts her to death, but makes a vow, by his beard and the
+      prophet, to espouse each night the most beautiful maiden in his
+      dominions, and the next morning to deliver her up to the
+      executioner.
+
+      Having fulfilled this vow for many years to the letter, and with
+      a religious punctuality and method that conferred great credit
+      upon him as a man of devout feeling and excellent sense, he was
+      interrupted one afternoon (no doubt at his prayers) by a visit
+      from his grand vizier, to whose daughter, it appears, there had
+      occurred an idea.
+
+      Her name was Scheherazade, and her idea was, that she would
+      either redeem the land from the depopulating tax upon its beauty,
+      or perish, after the approved fashion of all heroines, in the
+      attempt.
+
+      Accordingly, and although we do not find it to be leap-year
+      (which makes the sacrifice more meritorious), she deputes her
+      father, the grand vizier, to make an offer to the king of her
+      hand. This hand the king eagerly accepts—(he had intended to take
+      it at all events, and had put off the matter from day to day,
+      only through fear of the vizier),—but, in accepting it now, he
+      gives all parties very distinctly to understand, that, grand
+      vizier or no grand vizier, he has not the slightest design of
+      giving up one iota of his vow or of his privileges. When,
+      therefore, the fair Scheherazade insisted upon marrying the king,
+      and did actually marry him despite her father’s excellent advice
+      not to do any thing of the kind—when she would and did marry him,
+      I say, will I, nill I, it was with her beautiful black eyes as
+      thoroughly open as the nature of the case would allow.
+
+      It seems, however, that this politic damsel (who had been reading
+      Machiavelli, beyond doubt), had a very ingenious little plot in
+      her mind. On the night of the wedding, she contrived, upon I
+      forget what specious pretence, to have her sister occupy a couch
+      sufficiently near that of the royal pair to admit of easy
+      conversation from bed to bed; and, a little before cock-crowing,
+      she took care to awaken the good monarch, her husband (who bore
+      her none the worse will because he intended to wring her neck on
+      the morrow),—she managed to awaken him, I say, (although on
+      account of a capital conscience and an easy digestion, he slept
+      well) by the profound interest of a story (about a rat and a
+      black cat, I think) which she was narrating (all in an undertone,
+      of course) to her sister. When the day broke, it so happened that
+      this history was not altogether finished, and that Scheherazade,
+      in the nature of things could not finish it just then, since it
+      was high time for her to get up and be bowstrung—a thing very
+      little more pleasant than hanging, only a trifle more genteel!
+
+      The king’s curiosity, however, prevailing, I am sorry to say,
+      even over his sound religious principles, induced him for this
+      once to postpone the fulfilment of his vow until next morning,
+      for the purpose and with the hope of hearing that night how it
+      fared in the end with the black cat (a black cat, I think it was)
+      and the rat.
+
+      The night having arrived, however, the lady Scheherazade not only
+      put the finishing stroke to the black cat and the rat (the rat
+      was blue) but before she well knew what she was about, found
+      herself deep in the intricacies of a narration, having reference
+      (if I am not altogether mistaken) to a pink horse (with green
+      wings) that went, in a violent manner, by clockwork, and was
+      wound up with an indigo key. With this history the king was even
+      more profoundly interested than with the other—and, as the day
+      broke before its conclusion (notwithstanding all the queen’s
+      endeavors to get through with it in time for the bowstringing),
+      there was again no resource but to postpone that ceremony as
+      before, for twenty-four hours. The next night there happened a
+      similar accident with a similar result; and then the next—and
+      then again the next; so that, in the end, the good monarch,
+      having been unavoidably deprived of all opportunity to keep his
+      vow during a period of no less than one thousand and one nights,
+      either forgets it altogether by the expiration of this time, or
+      gets himself absolved of it in the regular way, or (what is more
+      probable) breaks it outright, as well as the head of his father
+      confessor. At all events, Scheherazade, who, being lineally
+      descended from Eve, fell heir, perhaps, to the whole seven
+      baskets of talk, which the latter lady, we all know, picked up
+      from under the trees in the garden of Eden; Scheherazade, I say,
+      finally triumphed, and the tariff upon beauty was repealed.
+
+      Now, this conclusion (which is that of the story as we have it
+      upon record) is, no doubt, excessively proper and pleasant—but
+      alas! like a great many pleasant things, is more pleasant than
+      true, and I am indebted altogether to the “Isitsöornot” for the
+      means of correcting the error. “Le mieux,” says a French proverb,
+      “est l’ennemi du bien,” and, in mentioning that Scheherazade had
+      inherited the seven baskets of talk, I should have added that she
+      put them out at compound interest until they amounted to
+      seventy-seven.
+
+      “My dear sister,” said she, on the thousand-and-second night, (I
+      quote the language of the “Isitsöornot” at this point, verbatim)
+      “my dear sister,” said she, “now that all this little difficulty
+      about the bowstring has blown over, and that this odious tax is
+      so happily repealed, I feel that I have been guilty of great
+      indiscretion in withholding from you and the king (who I am sorry
+      to say, snores—a thing no gentleman would do) the full conclusion
+      of Sinbad the sailor. This person went through numerous other and
+      more interesting adventures than those which I related; but the
+      truth is, I felt sleepy on the particular night of their
+      narration, and so was seduced into cutting them short—a grievous
+      piece of misconduct, for which I only trust that Allah will
+      forgive me. But even yet it is not too late to remedy my great
+      neglect—and as soon as I have given the king a pinch or two in
+      order to wake him up so far that he may stop making that horrible
+      noise, I will forthwith entertain you (and him if he pleases)
+      with the sequel of this very remarkable story.”
+
+      Hereupon the sister of Scheherazade, as I have it from the
+      “Isitsöornot,” expressed no very particular intensity of
+      gratification; but the king, having been sufficiently pinched, at
+      length ceased snoring, and finally said, “Hum!” and then “Hoo!”
+      when the queen, understanding these words (which are no doubt
+      Arabic) to signify that he was all attention, and would do his
+      best not to snore any more—the queen, I say, having arranged
+      these matters to her satisfaction, re-entered thus, at once, into
+      the history of Sinbad the sailor:
+
+      “‘At length, in my old age,’ [these are the words of Sinbad
+      himself, as retailed by Scheherazade]—‘at length, in my old age,
+      and after enjoying many years of tranquillity at home, I became
+      once more possessed of a desire of visiting foreign countries;
+      and one day, without acquainting any of my family with my design,
+      I packed up some bundles of such merchandise as was most precious
+      and least bulky, and, engaging a porter to carry them, went with
+      him down to the sea-shore, to await the arrival of any chance
+      vessel that might convey me out of the kingdom into some region
+      which I had not as yet explored.
+
+      “‘Having deposited the packages upon the sands, we sat down
+      beneath some trees, and looked out into the ocean in the hope of
+      perceiving a ship, but during several hours we saw none whatever.
+      At length I fancied that I could hear a singular buzzing or
+      humming sound; and the porter, after listening awhile, declared
+      that he also could distinguish it. Presently it grew louder, and
+      then still louder, so that we could have no doubt that the object
+      which caused it was approaching us. At length, on the edge of the
+      horizon, we discovered a black speck, which rapidly increased in
+      size until we made it out to be a vast monster, swimming with a
+      great part of its body above the surface of the sea. It came
+      toward us with inconceivable swiftness, throwing up huge waves of
+      foam around its breast, and illuminating all that part of the sea
+      through which it passed, with a long line of fire that extended
+      far off into the distance.
+
+      “‘As the thing drew near we saw it very distinctly. Its length
+      was equal to that of three of the loftiest trees that grow, and
+      it was as wide as the great hall of audience in your palace, O
+      most sublime and munificent of the Caliphs. Its body, which was
+      unlike that of ordinary fishes, was as solid as a rock, and of a
+      jetty blackness throughout all that portion of it which floated
+      above the water, with the exception of a narrow blood-red streak
+      that completely begirdled it. The belly, which floated beneath
+      the surface, and of which we could get only a glimpse now and
+      then as the monster rose and fell with the billows, was entirely
+      covered with metallic scales, of a color like that of the moon in
+      misty weather. The back was flat and nearly white, and from it
+      there extended upwards of six spines, about half the length of
+      the whole body.
+
+      “‘This horrible creature had no mouth that we could perceive;
+      but, as if to make up for this deficiency, it was provided with
+      at least four score of eyes, that protruded from their sockets
+      like those of the green dragon-fly, and were arranged all around
+      the body in two rows, one above the other, and parallel to the
+      blood-red streak, which seemed to answer the purpose of an
+      eyebrow. Two or three of these dreadful eyes were much larger
+      than the others, and had the appearance of solid gold.
+
+      “‘Although this beast approached us, as I have before said, with
+      the greatest rapidity, it must have been moved altogether by
+      necromancy—for it had neither fins like a fish nor web-feet like
+      a duck, nor wings like the seashell which is blown along in the
+      manner of a vessel; nor yet did it writhe itself forward as do
+      the eels. Its head and its tail were shaped precisely alike,
+      only, not far from the latter, were two small holes that served
+      for nostrils, and through which the monster puffed out its thick
+      breath with prodigious violence, and with a shrieking,
+      disagreeable noise.
+
+      “‘Our terror at beholding this hideous thing was very great, but
+      it was even surpassed by our astonishment, when upon getting a
+      nearer look, we perceived upon the creature’s back a vast number
+      of animals about the size and shape of men, and altogether much
+      resembling them, except that they wore no garments (as men do),
+      being supplied (by nature, no doubt) with an ugly uncomfortable
+      covering, a good deal like cloth, but fitting so tight to the
+      skin, as to render the poor wretches laughably awkward, and put
+      them apparently to severe pain. On the very tips of their heads
+      were certain square-looking boxes, which, at first sight, I
+      thought might have been intended to answer as turbans, but I soon
+      discovered that they were excessively heavy and solid, and I
+      therefore concluded they were contrivances designed, by their
+      great weight, to keep the heads of the animals steady and safe
+      upon their shoulders. Around the necks of the creatures were
+      fastened black collars, (badges of servitude, no doubt,) such as
+      we keep on our dogs, only much wider and infinitely stiffer, so
+      that it was quite impossible for these poor victims to move their
+      heads in any direction without moving the body at the same time;
+      and thus they were doomed to perpetual contemplation of their
+      noses—a view puggish and snubby in a wonderful, if not positively
+      in an awful degree.
+
+      “‘When the monster had nearly reached the shore where we stood,
+      it suddenly pushed out one of its eyes to a great extent, and
+      emitted from it a terrible flash of fire, accompanied by a dense
+      cloud of smoke, and a noise that I can compare to nothing but
+      thunder. As the smoke cleared away, we saw one of the odd
+      man-animals standing near the head of the large beast with a
+      trumpet in his hand, through which (putting it to his mouth) he
+      presently addressed us in loud, harsh, and disagreeable accents,
+      that, perhaps, we should have mistaken for language, had they not
+      come altogether through the nose.
+
+      “‘Being thus evidently spoken to, I was at a loss how to reply,
+      as I could in no manner understand what was said; and in this
+      difficulty I turned to the porter, who was near swooning through
+      affright, and demanded of him his opinion as to what species of
+      monster it was, what it wanted, and what kind of creatures those
+      were that so swarmed upon its back. To this the porter replied,
+      as well as he could for trepidation, that he had once before
+      heard of this sea-beast; that it was a cruel demon, with bowels
+      of sulphur and blood of fire, created by evil genii as the means
+      of inflicting misery upon mankind; that the things upon its back
+      were vermin, such as sometimes infest cats and dogs, only a
+      little larger and more savage; and that these vermin had their
+      uses, however evil—for, through the torture they caused the beast
+      by their nibbling and stingings, it was goaded into that degree
+      of wrath which was requisite to make it roar and commit ill, and
+      so fulfil the vengeful and malicious designs of the wicked genii.
+
+      “This account determined me to take to my heels, and, without
+      once even looking behind me, I ran at full speed up into the
+      hills, while the porter ran equally fast, although nearly in an
+      opposite direction, so that, by these means, he finally made his
+      escape with my bundles, of which I have no doubt he took
+      excellent care—although this is a point I cannot determine, as I
+      do not remember that I ever beheld him again.
+
+      “‘For myself, I was so hotly pursued by a swarm of the men-vermin
+      (who had come to the shore in boats) that I was very soon
+      overtaken, bound hand and foot, and conveyed to the beast, which
+      immediately swam out again into the middle of the sea.
+
+      “‘I now bitterly repented my folly in quitting a comfortable home
+      to peril my life in such adventures as this; but regret being
+      useless, I made the best of my condition, and exerted myself to
+      secure the goodwill of the man-animal that owned the trumpet, and
+      who appeared to exercise authority over his fellows. I succeeded
+      so well in this endeavor that, in a few days, the creature
+      bestowed upon me various tokens of his favor, and in the end even
+      went to the trouble of teaching me the rudiments of what it was
+      vain enough to denominate its language; so that, at length, I was
+      enabled to converse with it readily, and came to make it
+      comprehend the ardent desire I had of seeing the world.
+
+      “‘Washish squashish squeak, Sinbad, hey-diddle diddle, grunt unt
+      grumble, hiss, fiss, whiss,’ said he to me, one day after
+      dinner—but I beg a thousand pardons, I had forgotten that your
+      majesty is not conversant with the dialect of the Cock-neighs (so
+      the man-animals were called; I presume because their language
+      formed the connecting link between that of the horse and that of
+      the rooster). With your permission, I will translate. ‘Washish
+      squashish,’ and so forth:—that is to say, ‘I am happy to find, my
+      dear Sinbad, that you are really a very excellent fellow; we are
+      now about doing a thing which is called circumnavigating the
+      globe; and since you are so desirous of seeing the world, I will
+      strain a point and give you a free passage upon back of the
+      beast.’”
+
+      When the Lady Scheherazade had proceeded thus far, relates the
+      “Isitsöornot,” the king turned over from his left side to his
+      right, and said:
+
+      “It is, in fact, very surprising, my dear queen, that you
+      omitted, hitherto, these latter adventures of Sinbad. Do you know
+      I think them exceedingly entertaining and strange?”
+
+      The king having thus expressed himself, we are told, the fair
+      Scheherazade resumed her history in the following words:
+
+      “Sinbad went on in this manner with his narrative—‘I thanked the
+      man-animal for its kindness, and soon found myself very much at
+      home on the beast, which swam at a prodigious rate through the
+      ocean; although the surface of the latter is, in that part of the
+      world, by no means flat, but round like a pomegranate, so that we
+      went—so to say—either up hill or down hill all the time.’
+
+      “That I think, was very singular,” interrupted the king.
+
+      “Nevertheless, it is quite true,” replied Scheherazade.
+
+      “I have my doubts,” rejoined the king; “but, pray, be so good as
+      to go on with the story.”
+
+      “I will,” said the queen. “‘The beast,’ continued Sinbad to the
+      caliph, ‘swam, as I have related, up hill and down hill until, at
+      length, we arrived at an island, many hundreds of miles in
+      circumference, but which, nevertheless, had been built in the
+      middle of the sea by a colony of little things like
+      caterpillars.’” (*1)
+
+      “Hum!” said the king.
+
+      “‘Leaving this island,’ said Sinbad—(for Scheherazade, it must be
+      understood, took no notice of her husband’s ill-mannered
+      ejaculation) ‘leaving this island, we came to another where the
+      forests were of solid stone, and so hard that they shivered to
+      pieces the finest-tempered axes with which we endeavoured to cut
+      them down.’” (*2)
+
+      “Hum!” said the king, again; but Scheherazade, paying him no
+      attention, continued in the language of Sinbad.
+
+      “‘Passing beyond this last island, we reached a country where
+      there was a cave that ran to the distance of thirty or forty
+      miles within the bowels of the earth, and that contained a
+      greater number of far more spacious and more magnificent palaces
+      than are to be found in all Damascus and Bagdad. From the roofs
+      of these palaces there hung myriads of gems, like diamonds, but
+      larger than men; and in among the streets of towers and pyramids
+      and temples, there flowed immense rivers as black as ebony, and
+      swarming with fish that had no eyes.’” (*3)
+
+      “Hum!” said the king.
+
+      “‘We then swam into a region of the sea where we found a lofty
+      mountain, down whose sides there streamed torrents of melted
+      metal, some of which were twelve miles wide and sixty miles long
+      (*4); while from an abyss on the summit, issued so vast a
+      quantity of ashes that the sun was entirely blotted out from the
+      heavens, and it became darker than the darkest midnight; so that
+      when we were even at the distance of a hundred and fifty miles
+      from the mountain, it was impossible to see the whitest object,
+      however close we held it to our eyes.’” (*5)
+
+      “Hum!” said the king.
+
+      “‘After quitting this coast, the beast continued his voyage until
+      we met with a land in which the nature of things seemed
+      reversed—for we here saw a great lake, at the bottom of which,
+      more than a hundred feet beneath the surface of the water, there
+      flourished in full leaf a forest of tall and luxuriant trees.’”
+      (*6)
+
+      “Hoo!” said the king.
+
+      “Some hundred miles farther on brought us to a climate where the
+      atmosphere was so dense as to sustain iron or steel, just as our
+      own does feather.’” (*7)
+
+      “Fiddle de dee,” said the king.
+
+      “Proceeding still in the same direction, we presently arrived at
+      the most magnificent region in the whole world. Through it there
+      meandered a glorious river for several thousands of miles. This
+      river was of unspeakable depth, and of a transparency richer than
+      that of amber. It was from three to six miles in width; and its
+      banks which arose on either side to twelve hundred feet in
+      perpendicular height, were crowned with ever-blossoming trees and
+      perpetual sweet-scented flowers, that made the whole territory
+      one gorgeous garden; but the name of this luxuriant land was the
+      Kingdom of Horror, and to enter it was inevitable death.’” (*8)
+
+      “Humph!” said the king.
+
+      “‘We left this kingdom in great haste, and, after some days, came
+      to another, where we were astonished to perceive myriads of
+      monstrous animals with horns resembling scythes upon their heads.
+      These hideous beasts dig for themselves vast caverns in the soil,
+      of a funnel shape, and line the sides of them with rocks, so
+      disposed one upon the other that they fall instantly, when
+      trodden upon by other animals, thus precipitating them into the
+      monster’s dens, where their blood is immediately sucked, and
+      their carcasses afterwards hurled contemptuously out to an
+      immense distance from “the caverns of death."’” (*9)
+
+      “Pooh!” said the king.
+
+      “‘Continuing our progress, we perceived a district with
+      vegetables that grew not upon any soil but in the air. (*10)
+      There were others that sprang from the substance of other
+      vegetables; (*11) others that derived their substance from the
+      bodies of living animals; (*12) and then again, there were others
+      that glowed all over with intense fire; (*13) others that moved
+      from place to place at pleasure, (*14) and what was still more
+      wonderful, we discovered flowers that lived and breathed and
+      moved their limbs at will and had, moreover, the detestable
+      passion of mankind for enslaving other creatures, and confining
+      them in horrid and solitary prisons until the fulfillment of
+      appointed tasks.’” (*15)
+
+      “Pshaw!” said the king.
+
+      “‘Quitting this land, we soon arrived at another in which the
+      bees and the birds are mathematicians of such genius and
+      erudition, that they give daily instructions in the science of
+      geometry to the wise men of the empire. The king of the place
+      having offered a reward for the solution of two very difficult
+      problems, they were solved upon the spot—the one by the bees, and
+      the other by the birds; but the king keeping their solution a
+      secret, it was only after the most profound researches and labor,
+      and the writing of an infinity of big books, during a long series
+      of years, that the men-mathematicians at length arrived at the
+      identical solutions which had been given upon the spot by the
+      bees and by the birds.’” (*16)
+
+      “Oh my!” said the king.
+
+      “‘We had scarcely lost sight of this empire when we found
+      ourselves close upon another, from whose shores there flew over
+      our heads a flock of fowls a mile in breadth, and two hundred and
+      forty miles long; so that, although they flew a mile during every
+      minute, it required no less than four hours for the whole flock
+      to pass over us—in which there were several millions of millions
+      of fowl.’” (*17)
+
+      “Oh fy!” said the king.
+
+      “‘No sooner had we got rid of these birds, which occasioned us
+      great annoyance, than we were terrified by the appearance of a
+      fowl of another kind, and infinitely larger than even the rocs
+      which I met in my former voyages; for it was bigger than the
+      biggest of the domes on your seraglio, oh, most Munificent of
+      Caliphs. This terrible fowl had no head that we could perceive,
+      but was fashioned entirely of belly, which was of a prodigious
+      fatness and roundness, of a soft-looking substance, smooth,
+      shining and striped with various colors. In its talons, the
+      monster was bearing away to his eyrie in the heavens, a house
+      from which it had knocked off the roof, and in the interior of
+      which we distinctly saw human beings, who, beyond doubt, were in
+      a state of frightful despair at the horrible fate which awaited
+      them. We shouted with all our might, in the hope of frightening
+      the bird into letting go of its prey, but it merely gave a snort
+      or puff, as if of rage and then let fall upon our heads a heavy
+      sack which proved to be filled with sand!’”
+
+      “Stuff!” said the king.
+
+      “‘It was just after this adventure that we encountered a
+      continent of immense extent and prodigious solidity, but which,
+      nevertheless, was supported entirely upon the back of a sky-blue
+      cow that had no fewer than four hundred horns.’” (*18)
+
+      “That, now, I believe,” said the king, “because I have read
+      something of the kind before, in a book.”
+
+      “‘We passed immediately beneath this continent, (swimming in
+      between the legs of the cow), and, after some hours, found
+      ourselves in a wonderful country indeed, which, I was informed by
+      the man-animal, was his own native land, inhabited by things of
+      his own species. This elevated the man-animal very much in my
+      esteem, and in fact, I now began to feel ashamed of the
+      contemptuous familiarity with which I had treated him; for I
+      found that the man-animals in general were a nation of the most
+      powerful magicians, who lived with worms in their brain, (*19)
+      which, no doubt, served to stimulate them by their painful
+      writhings and wrigglings to the most miraculous efforts of
+      imagination!’”
+
+      “Nonsense!” said the king.
+
+      “‘Among the magicians, were domesticated several animals of very
+      singular kinds; for example, there was a huge horse whose bones
+      were iron and whose blood was boiling water. In place of corn, he
+      had black stones for his usual food; and yet, in spite of so hard
+      a diet, he was so strong and swift that he would drag a load more
+      weighty than the grandest temple in this city, at a rate
+      surpassing that of the flight of most birds.’” (*20)
+
+      “Twattle!” said the king.
+
+      “‘I saw, also, among these people a hen without feathers, but
+      bigger than a camel; instead of flesh and bone she had iron and
+      brick; her blood, like that of the horse, (to whom, in fact, she
+      was nearly related,) was boiling water; and like him she ate
+      nothing but wood or black stones. This hen brought forth very
+      frequently, a hundred chickens in the day; and, after birth, they
+      took up their residence for several weeks within the stomach of
+      their mother.’” (*21)
+
+      “Fal lal!” said the king.
+
+      “‘One of this nation of mighty conjurors created a man out of
+      brass and wood, and leather, and endowed him with such ingenuity
+      that he would have beaten at chess, all the race of mankind with
+      the exception of the great Caliph, Haroun Alraschid. (*22)
+      Another of these magi constructed (of like material) a creature
+      that put to shame even the genius of him who made it; for so
+      great were its reasoning powers that, in a second, it performed
+      calculations of so vast an extent that they would have required
+      the united labor of fifty thousand fleshy men for a year. (*23)
+      But a still more wonderful conjuror fashioned for himself a
+      mighty thing that was neither man nor beast, but which had brains
+      of lead, intermixed with a black matter like pitch, and fingers
+      that it employed with such incredible speed and dexterity that it
+      would have had no trouble in writing out twenty thousand copies
+      of the Koran in an hour, and this with so exquisite a precision,
+      that in all the copies there should not be found one to vary from
+      another by the breadth of the finest hair. This thing was of
+      prodigious strength, so that it erected or overthrew the
+      mightiest empires at a breath; but its powers were exercised
+      equally for evil and for good.’”
+
+      “Ridiculous!” said the king.
+
+      “‘Among this nation of necromancers there was also one who had in
+      his veins the blood of the salamanders; for he made no scruple of
+      sitting down to smoke his chibouc in a red-hot oven until his
+      dinner was thoroughly roasted upon its floor. (*24) Another had
+      the faculty of converting the common metals into gold, without
+      even looking at them during the process. (*25) Another had such a
+      delicacy of touch that he made a wire so fine as to be invisible.
+      (*26) Another had such quickness of perception that he counted
+      all the separate motions of an elastic body, while it was
+      springing backward and forward at the rate of nine hundred
+      millions of times in a second.’” (*27)
+
+      “Absurd!” said the king.
+
+      “‘Another of these magicians, by means of a fluid that nobody
+      ever yet saw, could make the corpses of his friends brandish
+      their arms, kick out their legs, fight, or even get up and dance
+      at his will. (*28) Another had cultivated his voice to so great
+      an extent that he could have made himself heard from one end of
+      the world to the other. (*29) Another had so long an arm that he
+      could sit down in Damascus and indite a letter at Bagdad—or
+      indeed at any distance whatsoever. (*30) Another commanded the
+      lightning to come down to him out of the heavens, and it came at
+      his call; and served him for a plaything when it came. Another
+      took two loud sounds and out of them made a silence. Another
+      constructed a deep darkness out of two brilliant lights. (*31)
+      Another made ice in a red-hot furnace. (*32) Another directed the
+      sun to paint his portrait, and the sun did. (*33) Another took
+      this luminary with the moon and the planets, and having first
+      weighed them with scrupulous accuracy, probed into their depths
+      and found out the solidity of the substance of which they were
+      made. But the whole nation is, indeed, of so surprising a
+      necromantic ability, that not even their infants, nor their
+      commonest cats and dogs have any difficulty in seeing objects
+      that do not exist at all, or that for twenty millions of years
+      before the birth of the nation itself had been blotted out from
+      the face of creation.’” (*34)
+
+      “Preposterous!” said the king.
+
+      “‘The wives and daughters of these incomparably great and wise
+      magi,’” continued Scheherazade, without being in any manner
+      disturbed by these frequent and most ungentlemanly interruptions
+      on the part of her husband—“‘the wives and daughters of these
+      eminent conjurers are every thing that is accomplished and
+      refined; and would be every thing that is interesting and
+      beautiful, but for an unhappy fatality that besets them, and from
+      which not even the miraculous powers of their husbands and
+      fathers has, hitherto, been adequate to save. Some fatalities
+      come in certain shapes, and some in others—but this of which I
+      speak has come in the shape of a crotchet.’”
+
+      “A what?” said the king.
+
+      “‘A crotchet’” said Scheherazade. “‘One of the evil genii, who
+      are perpetually upon the watch to inflict ill, has put it into
+      the heads of these accomplished ladies that the thing which we
+      describe as personal beauty consists altogether in the
+      protuberance of the region which lies not very far below the
+      small of the back. Perfection of loveliness, they say, is in the
+      direct ratio of the extent of this lump. Having been long
+      possessed of this idea, and bolsters being cheap in that country,
+      the days have long gone by since it was possible to distinguish a
+      woman from a dromedary—’”
+
+      “Stop!” said the king—“I can’t stand that, and I won’t. You have
+      already given me a dreadful headache with your lies. The day,
+      too, I perceive, is beginning to break. How long have we been
+      married?—my conscience is getting to be troublesome again. And
+      then that dromedary touch—do you take me for a fool? Upon the
+      whole, you might as well get up and be throttled.”
+
+      These words, as I learn from the “Isitsöornot,” both grieved and
+      astonished Scheherazade; but, as she knew the king to be a man of
+      scrupulous integrity, and quite unlikely to forfeit his word, she
+      submitted to her fate with a good grace. She derived, however,
+      great consolation, (during the tightening of the bowstring,) from
+      the reflection that much of the history remained still untold,
+      and that the petulance of her brute of a husband had reaped for
+      him a most righteous reward, in depriving him of many
+      inconceivable adventures.
+
+
+
+
+A DESCENT INTO THE MAELSTROM.
+
+
+  The ways of God in Nature, as in Providence, are not as our ways; 
+  nor are the models that we frame any way commensurate to the
+  vastness, profundity, and unsearchableness of His works, _which have
+  a depth in them greater than the well of Democritus_.
+
+—_Joseph Glanville_.
+
+      We had now reached the summit of the loftiest crag. For some
+      minutes the old man seemed too much exhausted to speak.
+
+      “Not long ago,” said he at length, “and I could have guided you
+      on this route as well as the youngest of my sons; but, about
+      three years past, there happened to me an event such as never
+      happened to mortal man—or at least such as no man ever survived
+      to tell of—and the six hours of deadly terror which I then
+      endured have broken me up body and soul. You suppose me a _very_
+      old man—but I am not. It took less than a single day to change
+      these hairs from a jetty black to white, to weaken my limbs, and
+      to unstring my nerves, so that I tremble at the least exertion,
+      and am frightened at a shadow. Do you know I can scarcely look
+      over this little cliff without getting giddy?”
+
+      The “little cliff,” upon whose edge he had so carelessly thrown
+      himself down to rest that the weightier portion of his body hung
+      over it, while he was only kept from falling by the tenure of his
+      elbow on its extreme and slippery edge—this “little cliff” arose,
+      a sheer unobstructed precipice of black shining rock, some
+      fifteen or sixteen hundred feet from the world of crags beneath
+      us. Nothing would have tempted me to within half a dozen yards of
+      its brink. In truth so deeply was I excited by the perilous
+      position of my companion, that I fell at full length upon the
+      ground, clung to the shrubs around me, and dared not even glance
+      upward at the sky—while I struggled in vain to divest myself of
+      the idea that the very foundations of the mountain were in danger
+      from the fury of the winds. It was long before I could reason
+      myself into sufficient courage to sit up and look out into the
+      distance.
+
+      “You must get over these fancies,” said the guide, “for I have
+      brought you here that you might have the best possible view of
+      the scene of that event I mentioned—and to tell you the whole
+      story with the spot just under your eye.”
+
+      “We are now,” he continued, in that particularizing manner which
+      distinguished him—“we are now close upon the Norwegian coast—in
+      the sixty-eighth degree of latitude—in the great province of
+      Nordland—and in the dreary district of Lofoden. The mountain upon
+      whose top we sit is Helseggen, the Cloudy. Now raise yourself up
+      a little higher—hold on to the grass if you feel giddy—so—and
+      look out, beyond the belt of vapor beneath us, into the sea.”
+
+      I looked dizzily, and beheld a wide expanse of ocean, whose
+      waters wore so inky a hue as to bring at once to my mind the
+      Nubian geographer’s account of the _Mare Tenebrarum_. A panorama
+      more deplorably desolate no human imagination can conceive. To
+      the right and left, as far as the eye could reach, there lay
+      outstretched, like ramparts of the world, lines of horridly black
+      and beetling cliff, whose character of gloom was but the more
+      forcibly illustrated by the surf which reared high up against its
+      white and ghastly crest, howling and shrieking forever. Just
+      opposite the promontory upon whose apex we were placed, and at a
+      distance of some five or six miles out at sea, there was visible
+      a small, bleak-looking island; or, more properly, its position
+      was discernible through the wilderness of surge in which it was
+      enveloped. About two miles nearer the land, arose another of
+      smaller size, hideously craggy and barren, and encompassed at
+      various intervals by a cluster of dark rocks.
+
+      The appearance of the ocean, in the space between the more
+      distant island and the shore, had something very unusual about
+      it. Although, at the time, so strong a gale was blowing landward
+      that a brig in the remote offing lay to under a double-reefed
+      trysail, and constantly plunged her whole hull out of sight,
+      still there was here nothing like a regular swell, but only a
+      short, quick, angry cross dashing of water in every direction—as
+      well in the teeth of the wind as otherwise. Of foam there was
+      little except in the immediate vicinity of the rocks.
+
+      “The island in the distance,” resumed the old man, “is called by
+      the Norwegians Vurrgh. The one midway is Moskoe. That a mile to
+      the northward is Ambaaren. Yonder are Islesen, Hotholm,
+      Keildhelm, Suarven, and Buckholm. Farther off—between Moskoe and
+      Vurrgh—are Otterholm, Flimen, Sandflesen, and Stockholm. These
+      are the true names of the places—but why it has been thought
+      necessary to name them at all, is more than either you or I can
+      understand. Do you hear anything? Do you see any change in the
+      water?”
+
+      We had now been about ten minutes upon the top of Helseggen, to
+      which we had ascended from the interior of Lofoden, so that we
+      had caught no glimpse of the sea until it had burst upon us from
+      the summit. As the old man spoke, I became aware of a loud and
+      gradually increasing sound, like the moaning of a vast herd of
+      buffaloes upon an American prairie; and at the same moment I
+      perceived that what seamen term the _chopping_ character of the
+      ocean beneath us, was rapidly changing into a current which set
+      to the eastward. Even while I gazed, this current acquired a
+      monstrous velocity. Each moment added to its speed—to its
+      headlong impetuosity. In five minutes the whole sea, as far as
+      Vurrgh, was lashed into ungovernable fury; but it was between
+      Moskoe and the coast that the main uproar held its sway. Here the
+      vast bed of the waters, seamed and scarred into a thousand
+      conflicting channels, burst suddenly into phrensied
+      convulsion—heaving, boiling, hissing—gyrating in gigantic and
+      innumerable vortices, and all whirling and plunging on to the
+      eastward with a rapidity which water never elsewhere assumes
+      except in precipitous descents.
+
+      In a few minutes more, there came over the scene another radical
+      alteration. The general surface grew somewhat more smooth, and
+      the whirlpools, one by one, disappeared, while prodigious streaks
+      of foam became apparent where none had been seen before. These
+      streaks, at length, spreading out to a great distance, and
+      entering into combination, took unto themselves the gyratory
+      motion of the subsided vortices, and seemed to form the germ of
+      another more vast. Suddenly—very suddenly—this assumed a distinct
+      and definite existence, in a circle of more than a mile in
+      diameter. The edge of the whirl was represented by a broad belt
+      of gleaming spray; but no particle of this slipped into the mouth
+      of the terrific funnel, whose interior, as far as the eye could
+      fathom it, was a smooth, shining, and jet-black wall of water,
+      inclined to the horizon at an angle of some forty-five degrees,
+      speeding dizzily round and round with a swaying and sweltering
+      motion, and sending forth to the winds an appalling voice, half
+      shriek, half roar, such as not even the mighty cataract of
+      Niagara ever lifts up in its agony to Heaven.
+
+      The mountain trembled to its very base, and the rock rocked. I
+      threw myself upon my face, and clung to the scant herbage in an
+      excess of nervous agitation.
+
+      “This,” said I at length, to the old man—“this _can_ be nothing
+      else than the great whirlpool of the Maelström.”
+
+      “So it is sometimes termed,” said he. “We Norwegians call it the
+      Moskoe-ström, from the island of Moskoe in the midway.”
+
+      The ordinary accounts of this vortex had by no means prepared me
+      for what I saw. That of Jonas Ramus, which is perhaps the most
+      circumstantial of any, cannot impart the faintest conception
+      either of the magnificence, or of the horror of the scene—or of
+      the wild bewildering sense of _the novel_ which confounds the
+      beholder. I am not sure from what point of view the writer in
+      question surveyed it, nor at what time; but it could neither have
+      been from the summit of Helseggen, nor during a storm. There are
+      some passages of his description, nevertheless, which may be
+      quoted for their details, although their effect is exceedingly
+      feeble in conveying an impression of the spectacle.
+
+      “Between Lofoden and Moskoe,” he says, “the depth of the water is
+      between thirty-six and forty fathoms; but on the other side,
+      toward Ver (Vurrgh) this depth decreases so as not to afford a
+      convenient passage for a vessel, without the risk of splitting on
+      the rocks, which happens even in the calmest weather. When it is
+      flood, the stream runs up the country between Lofoden and Moskoe
+      with a boisterous rapidity; but the roar of its impetuous ebb to
+      the sea is scarce equalled by the loudest and most dreadful
+      cataracts; the noise being heard several leagues off, and the
+      vortices or pits are of such an extent and depth, that if a ship
+      comes within its attraction, it is inevitably absorbed and
+      carried down to the bottom, and there beat to pieces against the
+      rocks; and when the water relaxes, the fragments thereof are
+      thrown up again. But these intervals of tranquility are only at
+      the turn of the ebb and flood, and in calm weather, and last but
+      a quarter of an hour, its violence gradually returning. When the
+      stream is most boisterous, and its fury heightened by a storm, it
+      is dangerous to come within a Norway mile of it. Boats, yachts,
+      and ships have been carried away by not guarding against it
+      before they were within its reach. It likewise happens
+      frequently, that whales come too near the stream, and are
+      overpowered by its violence; and then it is impossible to
+      describe their howlings and bellowings in their fruitless
+      struggles to disengage themselves. A bear once, attempting to
+      swim from Lofoden to Moskoe, was caught by the stream and borne
+      down, while he roared terribly, so as to be heard on shore. Large
+      stocks of firs and pine trees, after being absorbed by the
+      current, rise again broken and torn to such a degree as if
+      bristles grew upon them. This plainly shows the bottom to consist
+      of craggy rocks, among which they are whirled to and fro. This
+      stream is regulated by the flux and reflux of the sea—it being
+      constantly high and low water every six hours. In the year 1645,
+      early in the morning of Sexagesima Sunday, it raged with such
+      noise and impetuosity that the very stones of the houses on the
+      coast fell to the ground.”
+
+      In regard to the depth of the water, I could not see how this
+      could have been ascertained at all in the immediate vicinity of
+      the vortex. The “forty fathoms” must have reference only to
+      portions of the channel close upon the shore either of Moskoe or
+      Lofoden. The depth in the centre of the Moskoe-ström must be
+      immeasurably greater; and no better proof of this fact is
+      necessary than can be obtained from even the sidelong glance into
+      the abyss of the whirl which may be had from the highest crag of
+      Helseggen. Looking down from this pinnacle upon the howling
+      Phlegethon below, I could not help smiling at the simplicity with
+      which the honest Jonas Ramus records, as a matter difficult of
+      belief, the anecdotes of the whales and the bears; for it
+      appeared to me, in fact, a self-evident thing, that the largest
+      ship of the line in existence, coming within the influence of
+      that deadly attraction, could resist it as little as a feather
+      the hurricane, and must disappear bodily and at once.
+
+      The attempts to account for the phenomenon—some of which, I
+      remember, seemed to me sufficiently plausible in perusal—now wore
+      a very different and unsatisfactory aspect. The idea generally
+      received is that this, as well as three smaller vortices among
+      the Ferroe islands, “have no other cause than the collision of
+      waves rising and falling, at flux and reflux, against a ridge of
+      rocks and shelves, which confines the water so that it
+      precipitates itself like a cataract; and thus the higher the
+      flood rises, the deeper must the fall be, and the natural result
+      of all is a whirlpool or vortex, the prodigious suction of which
+      is sufficiently known by lesser experiments.”—These are the words
+      of the Encyclopædia Britannica. Kircher and others imagine that
+      in the centre of the channel of the Maelström is an abyss
+      penetrating the globe, and issuing in some very remote part—the
+      Gulf of Bothnia being somewhat decidedly named in one instance.
+      This opinion, idle in itself, was the one to which, as I gazed,
+      my imagination most readily assented; and, mentioning it to the
+      guide, I was rather surprised to hear him say that, although it
+      was the view almost universally entertained of the subject by the
+      Norwegians, it nevertheless was not his own. As to the former
+      notion he confessed his inability to comprehend it; and here I
+      agreed with him—for, however conclusive on paper, it becomes
+      altogether unintelligible, and even absurd, amid the thunder of
+      the abyss.
+
+      “You have had a good look at the whirl now,” said the old man,
+      “and if you will creep round this crag, so as to get in its lee,
+      and deaden the roar of the water, I will tell you a story that
+      will convince you I ought to know something of the Moskoe-ström.”
+
+      I placed myself as desired, and he proceeded.
+
+      “Myself and my two brothers once owned a schooner-rigged smack of
+      about seventy tons burthen, with which we were in the habit of
+      fishing among the islands beyond Moskoe, nearly to Vurrgh. In all
+      violent eddies at sea there is good fishing, at proper
+      opportunities, if one has only the courage to attempt it; but
+      among the whole of the Lofoden coastmen, we three were the only
+      ones who made a regular business of going out to the islands, as
+      I tell you. The usual grounds are a great way lower down to the
+      southward. There fish can be got at all hours, without much risk,
+      and therefore these places are preferred. The choice spots over
+      here among the rocks, however, not only yield the finest variety,
+      but in far greater abundance; so that we often got in a single
+      day, what the more timid of the craft could not scrape together
+      in a week. In fact, we made it a matter of desperate
+      speculation—the risk of life standing instead of labor, and
+      courage answering for capital.
+
+      “We kept the smack in a cove about five miles higher up the coast
+      than this; and it was our practice, in fine weather, to take
+      advantage of the fifteen minutes’ slack to push across the main
+      channel of the Moskoe-ström, far above the pool, and then drop
+      down upon anchorage somewhere near Otterholm, or Sandflesen,
+      where the eddies are not so violent as elsewhere. Here we used to
+      remain until nearly time for slack-water again, when we weighed
+      and made for home. We never set out upon this expedition without
+      a steady side wind for going and coming—one that we felt sure
+      would not fail us before our return—and we seldom made a
+      mis-calculation upon this point. Twice, during six years, we were
+      forced to stay all night at anchor on account of a dead calm,
+      which is a rare thing indeed just about here; and once we had to
+      remain on the grounds nearly a week, starving to death, owing to
+      a gale which blew up shortly after our arrival, and made the
+      channel too boisterous to be thought of. Upon this occasion we
+      should have been driven out to sea in spite of everything, (for
+      the whirlpools threw us round and round so violently, that, at
+      length, we fouled our anchor and dragged it) if it had not been
+      that we drifted into one of the innumerable cross currents—here
+      to-day and gone to-morrow—which drove us under the lee of Flimen,
+      where, by good luck, we brought up.
+
+      “I could not tell you the twentieth part of the difficulties we
+      encountered ‘on the grounds’—it is a bad spot to be in, even in
+      good weather—but we made shift always to run the gauntlet of the
+      Moskoe-ström itself without accident; although at times my heart
+      has been in my mouth when we happened to be a minute or so behind
+      or before the slack. The wind sometimes was not as strong as we
+      thought it at starting, and then we made rather less way than we
+      could wish, while the current rendered the smack unmanageable. My
+      eldest brother had a son eighteen years old, and I had two stout
+      boys of my own. These would have been of great assistance at such
+      times, in using the sweeps, as well as afterward in fishing—but,
+      somehow, although we ran the risk ourselves, we had not the heart
+      to let the young ones get into the danger—for, after all is said
+      and done, it _was_ a horrible danger, and that is the truth.
+
+      “It is now within a few days of three years since what I am going
+      to tell you occurred. It was on the tenth day of July, 18—, a day
+      which the people of this part of the world will never forget—for
+      it was one in which blew the most terrible hurricane that ever
+      came out of the heavens. And yet all the morning, and indeed
+      until late in the afternoon, there was a gentle and steady breeze
+      from the south-west, while the sun shone brightly, so that the
+      oldest seaman among us could not have foreseen what was to
+      follow.
+
+      “The three of us—my two brothers and myself—had crossed over to
+      the islands about two o’clock P. M., and had soon nearly loaded
+      the smack with fine fish, which, we all remarked, were more
+      plenty that day than we had ever known them. It was just seven,
+      _by my watch_, when we weighed and started for home, so as to
+      make the worst of the Ström at slack water, which we knew would
+      be at eight.
+
+      “We set out with a fresh wind on our starboard quarter, and for
+      some time spanked along at a great rate, never dreaming of
+      danger, for indeed we saw not the slightest reason to apprehend
+      it. All at once we were taken aback by a breeze from over
+      Helseggen. This was most unusual—something that had never
+      happened to us before—and I began to feel a little uneasy,
+      without exactly knowing why. We put the boat on the wind, but
+      could make no headway at all for the eddies, and I was upon the
+      point of proposing to return to the anchorage, when, looking
+      astern, we saw the whole horizon covered with a singular
+      copper-colored cloud that rose with the most amazing velocity.
+
+      “In the meantime the breeze that had headed us off fell away, and
+      we were dead becalmed, drifting about in every direction. This
+      state of things, however, did not last long enough to give us
+      time to think about it. In less than a minute the storm was upon
+      us—in less than two the sky was entirely overcast—and what with
+      this and the driving spray, it became suddenly so dark that we
+      could not see each other in the smack.
+
+      “Such a hurricane as then blew it is folly to attempt describing.
+      The oldest seaman in Norway never experienced any thing like it.
+      We had let our sails go by the run before it cleverly took us;
+      but, at the first puff, both our masts went by the board as if
+      they had been sawed off—the mainmast taking with it my youngest
+      brother, who had lashed himself to it for safety.
+
+      “Our boat was the lightest feather of a thing that ever sat upon
+      water. It had a complete flush deck, with only a small hatch near
+      the bow, and this hatch it had always been our custom to batten
+      down when about to cross the Ström, by way of precaution against
+      the chopping seas. But for this circumstance we should have
+      foundered at once—for we lay entirely buried for some moments.
+      How my elder brother escaped destruction I cannot say, for I
+      never had an opportunity of ascertaining. For my part, as soon as
+      I had let the foresail run, I threw myself flat on deck, with my
+      feet against the narrow gunwale of the bow, and with my hands
+      grasping a ring-bolt near the foot of the fore-mast. It was mere
+      instinct that prompted me to do this—which was undoubtedly the
+      very best thing I could have done—for I was too much flurried to
+      think.
+
+      “For some moments we were completely deluged, as I say, and all
+      this time I held my breath, and clung to the bolt. When I could
+      stand it no longer I raised myself upon my knees, still keeping
+      hold with my hands, and thus got my head clear. Presently our
+      little boat gave herself a shake, just as a dog does in coming
+      out of the water, and thus rid herself, in some measure, of the
+      seas. I was now trying to get the better of the stupor that had
+      come over me, and to collect my senses so as to see what was to
+      be done, when I felt somebody grasp my arm. It was my elder
+      brother, and my heart leaped for joy, for I had made sure that he
+      was overboard—but the next moment all this joy was turned into
+      horror—for he put his mouth close to my ear, and screamed out the
+      word ‘_Moskoe-ström!_’
+
+      “No one ever will know what my feelings were at that moment. I
+      shook from head to foot as if I had had the most violent fit of
+      the ague. I knew what he meant by that one word well enough—I
+      knew what he wished to make me understand. With the wind that now
+      drove us on, we were bound for the whirl of the Ström, and
+      nothing could save us!
+
+      “You perceive that in crossing the Ström _channel_, we always
+      went a long way up above the whirl, even in the calmest weather,
+      and then had to wait and watch carefully for the slack—but now we
+      were driving right upon the pool itself, and in such a hurricane
+      as this! ‘To be sure,’ I thought, ‘we shall get there just about
+      the slack—there is some little hope in that’—but in the next
+      moment I cursed myself for being so great a fool as to dream of
+      hope at all. I knew very well that we were doomed, had we been
+      ten times a ninety-gun ship.
+
+      “By this time the first fury of the tempest had spent itself, or
+      perhaps we did not feel it so much, as we scudded before it, but
+      at all events the seas, which at first had been kept down by the
+      wind, and lay flat and frothing, now got up into absolute
+      mountains. A singular change, too, had come over the heavens.
+      Around in every direction it was still as black as pitch, but
+      nearly overhead there burst out, all at once, a circular rift of
+      clear sky—as clear as I ever saw—and of a deep bright blue—and
+      through it there blazed forth the full moon with a lustre that I
+      never before knew her to wear. She lit up every thing about us
+      with the greatest distinctness—but, oh God, what a scene it was
+      to light up!
+
+      “I now made one or two attempts to speak to my brother—but, in
+      some manner which I could not understand, the din had so
+      increased that I could not make him hear a single word, although
+      I screamed at the top of my voice in his ear. Presently he shook
+      his head, looking as pale as death, and held up one of his
+      fingers, as if to say _‘listen! ‘_
+
+      “At first I could not make out what he meant—but soon a hideous
+      thought flashed upon me. I dragged my watch from its fob. It was
+      not going. I glanced at its face by the moonlight, and then burst
+      into tears as I flung it far away into the ocean. _It had run
+      down at seven o’clock! We were behind the time of the slack, and
+      the whirl of the Ström was in full fury!_
+
+      “When a boat is well built, properly trimmed, and not deep laden,
+      the waves in a strong gale, when she is going large, seem always
+      to slip from beneath her—which appears very strange to a
+      landsman—and this is what is called _riding_, in sea phrase.
+
+      “Well, so far we had ridden the swells very cleverly; but
+      presently a gigantic sea happened to take us right under the
+      counter, and bore us with it as it rose—up—up—as if into the sky.
+      I would not have believed that any wave could rise so high. And
+      then down we came with a sweep, a slide, and a plunge, that made
+      me feel sick and dizzy, as if I was falling from some lofty
+      mountain-top in a dream. But while we were up I had thrown a
+      quick glance around—and that one glance was all sufficient. I saw
+      our exact position in an instant. The Moskoe-Ström whirlpool was
+      about a quarter of a mile dead ahead—but no more like the
+      every-day Moskoe-Ström than the whirl as you now see it, is like
+      a mill-race. If I had not known where we were, and what we had to
+      expect, I should not have recognised the place at all. As it was,
+      I involuntarily closed my eyes in horror. The lids clenched
+      themselves together as if in a spasm.
+
+      “It could not have been more than two minutes afterward until we
+      suddenly felt the waves subside, and were enveloped in foam. The
+      boat made a sharp half turn to larboard, and then shot off in its
+      new direction like a thunderbolt. At the same moment the roaring
+      noise of the water was completely drowned in a kind of shrill
+      shriek—such a sound as you might imagine given out by the
+      waste-pipes of many thousand steam-vessels, letting off their
+      steam all together. We were now in the belt of surf that always
+      surrounds the whirl; and I thought, of course, that another
+      moment would plunge us into the abyss, down which we could only
+      see indistinctly on account of the amazing velocity with which we
+      wore borne along. The boat did not seem to sink into the water at
+      all, but to skim like an air-bubble upon the surface of the
+      surge. Her starboard side was next the whirl, and on the larboard
+      arose the world of ocean we had left. It stood like a huge
+      writhing wall between us and the horizon.
+
+      “It may appear strange, but now, when we were in the very jaws of
+      the gulf, I felt more composed than when we were only approaching
+      it. Having made up my mind to hope no more, I got rid of a great
+      deal of that terror which unmanned me at first. I suppose it was
+      despair that strung my nerves.
+
+      “It may look like boasting—but what I tell you is truth—I began
+      to reflect how magnificent a thing it was to die in such a
+      manner, and how foolish it was in me to think of so paltry a
+      consideration as my own individual life, in view of so wonderful
+      a manifestation of God’s power. I do believe that I blushed with
+      shame when this idea crossed my mind. After a little while I
+      became possessed with the keenest curiosity about the whirl
+      itself. I positively felt a _wish_ to explore its depths, even at
+      the sacrifice I was going to make; and my principal grief was
+      that I should never be able to tell my old companions on shore
+      about the mysteries I should see. These, no doubt, were singular
+      fancies to occupy a man’s mind in such extremity—and I have often
+      thought since, that the revolutions of the boat around the pool
+      might have rendered me a little light-headed.
+
+      “There was another circumstance which tended to restore my
+      self-possession; and this was the cessation of the wind, which
+      could not reach us in our present situation—for, as you saw
+      yourself, the belt of surf is considerably lower than the general
+      bed of the ocean, and this latter now towered above us, a high,
+      black, mountainous ridge. If you have never been at sea in a
+      heavy gale, you can form no idea of the confusion of mind
+      occasioned by the wind and spray together. They blind, deafen,
+      and strangle you, and take away all power of action or
+      reflection. But we were now, in a great measure, rid of these
+      annoyances—just as death-condemned felons in prison are allowed
+      petty indulgences, forbidden them while their doom is yet
+      uncertain.
+
+      “How often we made the circuit of the belt it is impossible to
+      say. We careered round and round for perhaps an hour, flying
+      rather than floating, getting gradually more and more into the
+      middle of the surge, and then nearer and nearer to its horrible
+      inner edge. All this time I had never let go of the ring-bolt. My
+      brother was at the stern, holding on to a small empty water-cask
+      which had been securely lashed under the coop of the counter, and
+      was the only thing on deck that had not been swept overboard when
+      the gale first took us. As we approached the brink of the pit he
+      let go his hold upon this, and made for the ring, from which, in
+      the agony of his terror, he endeavored to force my hands, as it
+      was not large enough to afford us both a secure grasp. I never
+      felt deeper grief than when I saw him attempt this act—although I
+      knew he was a madman when he did it—a raving maniac through sheer
+      fright. I did not care, however, to contest the point with him. I
+      knew it could make no difference whether either of us held on at
+      all; so I let him have the bolt, and went astern to the cask.
+      This there was no great difficulty in doing; for the smack flew
+      round steadily enough, and upon an even keel—only swaying to and
+      fro, with the immense sweeps and swelters of the whirl. Scarcely
+      had I secured myself in my new position, when we gave a wild
+      lurch to starboard, and rushed headlong into the abyss. I
+      muttered a hurried prayer to God, and thought all was over.
+
+      “As I felt the sickening sweep of the descent, I had
+      instinctively tightened my hold upon the barrel, and closed my
+      eyes. For some seconds I dared not open them—while I expected
+      instant destruction, and wondered that I was not already in my
+      death-struggles with the water. But moment after moment elapsed.
+      I still lived. The sense of falling had ceased; and the motion of
+      the vessel seemed much as it had been before, while in the belt
+      of foam, with the exception that she now lay more along. I took
+      courage, and looked once again upon the scene.
+
+      “Never shall I forget the sensations of awe, horror, and
+      admiration with which I gazed about me. The boat appeared to be
+      hanging, as if by magic, midway down, upon the interior surface
+      of a funnel vast in circumference, prodigious in depth, and whose
+      perfectly smooth sides might have been mistaken for ebony, but
+      for the bewildering rapidity with which they spun around, and for
+      the gleaming and ghastly radiance they shot forth, as the rays of
+      the full moon, from that circular rift amid the clouds which I
+      have already described, streamed in a flood of golden glory along
+      the black walls, and far away down into the inmost recesses of
+      the abyss.
+
+      “At first I was too much confused to observe anything accurately.
+      The general burst of terrific grandeur was all that I beheld.
+      When I recovered myself a little, however, my gaze fell
+      instinctively downward. In this direction I was able to obtain an
+      unobstructed view, from the manner in which the smack hung on the
+      inclined surface of the pool. She was quite upon an even
+      keel—that is to say, her deck lay in a plane parallel with that
+      of the water—but this latter sloped at an angle of more than
+      forty-five degrees, so that we seemed to be lying upon our
+      beam-ends. I could not help observing, nevertheless, that I had
+      scarcely more difficulty in maintaining my hold and footing in
+      this situation, than if we had been upon a dead level; and this,
+      I suppose, was owing to the speed at which we revolved.
+
+      “The rays of the moon seemed to search the very bottom of the
+      profound gulf; but still I could make out nothing distinctly, on
+      account of a thick mist in which everything there was enveloped,
+      and over which there hung a magnificent rainbow, like that narrow
+      and tottering bridge which Mussulmen say is the only pathway
+      between Time and Eternity. This mist, or spray, was no doubt
+      occasioned by the clashing of the great walls of the funnel, as
+      they all met together at the bottom—but the yell that went up to
+      the Heavens from out of that mist, I dare not attempt to
+      describe.
+
+      “Our first slide into the abyss itself, from the belt of foam
+      above, had carried us a great distance down the slope; but our
+      farther descent was by no means proportionate. Round and round we
+      swept—not with any uniform movement—but in dizzying swings and
+      jerks, that sent us sometimes only a few hundred yards—sometimes
+      nearly the complete circuit of the whirl. Our progress downward,
+      at each revolution, was slow, but very perceptible.
+
+      “Looking about me upon the wide waste of liquid ebony on which we
+      were thus borne, I perceived that our boat was not the only
+      object in the embrace of the whirl. Both above and below us were
+      visible fragments of vessels, large masses of building timber and
+      trunks of trees, with many smaller articles, such as pieces of
+      house furniture, broken boxes, barrels and staves. I have already
+      described the unnatural curiosity which had taken the place of my
+      original terrors. It appeared to grow upon me as I drew nearer
+      and nearer to my dreadful doom. I now began to watch, with a
+      strange interest, the numerous things that floated in our
+      company. I _must_ have been delirious, for I even sought
+      _amusement_ in speculating upon the relative velocities of their
+      several descents toward the foam below. ‘This fir tree,’ I found
+      myself at one time saying, ‘will certainly be the next thing that
+      takes the awful plunge and disappears,’—and then I was
+      disappointed to find that the wreck of a Dutch merchant ship
+      overtook it and went down before. At length, after making several
+      guesses of this nature, and being deceived in all—this fact—the
+      fact of my invariable miscalculation, set me upon a train of
+      reflection that made my limbs again tremble, and my heart beat
+      heavily once more.
+
+      “It was not a new terror that thus affected me, but the dawn of a
+      more exciting _hope_. This hope arose partly from memory, and
+      partly from present observation. I called to mind the great
+      variety of buoyant matter that strewed the coast of Lofoden,
+      having been absorbed and then thrown forth by the Moskoe-ström.
+      By far the greater number of the articles were shattered in the
+      most extraordinary way—so chafed and roughened as to have the
+      appearance of being stuck full of splinters—but then I distinctly
+      recollected that there were _some_ of them which were not
+      disfigured at all. Now I could not account for this difference
+      except by supposing that the roughened fragments were the only
+      ones which had been _completely absorbed_—that the others had
+      entered the whirl at so late a period of the tide, or, for some
+      reason, had descended so slowly after entering, that they did not
+      reach the bottom before the turn of the flood came, or of the
+      ebb, as the case might be. I conceived it possible, in either
+      instance, that they might thus be whirled up again to the level
+      of the ocean, without undergoing the fate of those which had been
+      drawn in more early, or absorbed more rapidly. I made, also,
+      three important observations. The first was, that, as a general
+      rule, the larger the bodies were, the more rapid their
+      descent—the second, that, between two masses of equal extent, the
+      one spherical, and the other _of any other shape_, the
+      superiority in speed of descent was with the sphere—the third,
+      that, between two masses of equal size, the one cylindrical, and
+      the other of any other shape, the cylinder was absorbed the more
+      slowly. Since my escape, I have had several conversations on this
+      subject with an old school-master of the district; and it was
+      from him that I learned the use of the words ‘cylinder’ and
+      ‘sphere.’ He explained to me—although I have forgotten the
+      explanation—how what I observed was, in fact, the natural
+      consequence of the forms of the floating fragments—and showed me
+      how it happened that a cylinder, swimming in a vortex, offered
+      more resistance to its suction, and was drawn in with greater
+      difficulty than an equally bulky body, of any form whatever. (*1)
+
+      “There was one startling circumstance which went a great way in
+      enforcing these observations, and rendering me anxious to turn
+      them to account, and this was that, at every revolution, we
+      passed something like a barrel, or else the yard or the mast of a
+      vessel, while many of these things, which had been on our level
+      when I first opened my eyes upon the wonders of the whirlpool,
+      were now high up above us, and seemed to have moved but little
+      from their original station.
+
+      “I no longer hesitated what to do. I resolved to lash myself
+      securely to the water cask upon which I now held, to cut it loose
+      from the counter, and to throw myself with it into the water. I
+      attracted my brother’s attention by signs, pointed to the
+      floating barrels that came near us, and did everything in my
+      power to make him understand what I was about to do. I thought at
+      length that he comprehended my design—but, whether this was the
+      case or not, he shook his head despairingly, and refused to move
+      from his station by the ring-bolt. It was impossible to reach
+      him; the emergency admitted of no delay; and so, with a bitter
+      struggle, I resigned him to his fate, fastened myself to the cask
+      by means of the lashings which secured it to the counter, and
+      precipitated myself with it into the sea, without another
+      moment’s hesitation.
+
+      “The result was precisely what I had hoped it might be. As it is
+      myself who now tell you this tale—as you see that I _did_
+      escape—and as you are already in possession of the mode in which
+      this escape was effected, and must therefore anticipate all that
+      I have farther to say—I will bring my story quickly to
+      conclusion. It might have been an hour, or thereabout, after my
+      quitting the smack, when, having descended to a vast distance
+      beneath me, it made three or four wild gyrations in rapid
+      succession, and, bearing my loved brother with it, plunged
+      headlong, at once and forever, into the chaos of foam below. The
+      barrel to which I was attached sunk very little farther than half
+      the distance between the bottom of the gulf and the spot at which
+      I leaped overboard, before a great change took place in the
+      character of the whirlpool. The slope of the sides of the vast
+      funnel became momently less and less steep. The gyrations of the
+      whirl grew, gradually, less and less violent. By degrees, the
+      froth and the rainbow disappeared, and the bottom of the gulf
+      seemed slowly to uprise. The sky was clear, the winds had gone
+      down, and the full moon was setting radiantly in the west, when I
+      found myself on the surface of the ocean, in full view of the
+      shores of Lofoden, and above the spot where the pool of the
+      Moskoe-ström _had been_. It was the hour of the slack—but the sea
+      still heaved in mountainous waves from the effects of the
+      hurricane. I was borne violently into the channel of the Ström,
+      and in a few minutes was hurried down the coast into the
+      ‘grounds’ of the fishermen. A boat picked me up—exhausted from
+      fatigue—and (now that the danger was removed) speechless from the
+      memory of its horror. Those who drew me on board were my old
+      mates and daily companions—but they knew me no more than they
+      would have known a traveller from the spirit-land. My hair which
+      had been raven-black the day before, was as white as you see it
+      now. They say too that the whole expression of my countenance had
+      changed. I told them my story—they did not believe it. I now tell
+      it to _you_—and I can scarcely expect you to put more faith in it
+      than did the merry fishermen of Lofoden.”
+
+
+
+
+VON KEMPELEN AND HIS DISCOVERY
+
+
+      After the very minute and elaborate paper by Arago, to say
+      nothing of the summary in ‘Silliman’s Journal,’ with the detailed
+      statement just published by Lieutenant Maury, it will not be
+      supposed, of course, that in offering a few hurried remarks in
+      reference to Von Kempelen’s discovery, I have any design to look
+      at the subject in a scientific point of view. My object is
+      simply, in the first place, to say a few words of Von Kempelen
+      himself (with whom, some years ago, I had the honor of a slight
+      personal acquaintance), since every thing which concerns him must
+      necessarily, at this moment, be of interest; and, in the second
+      place, to look in a general way, and speculatively, at the
+      results of the discovery.
+
+      It may be as well, however, to premise the cursory observations
+      which I have to offer, by denying, very decidedly, what seems to
+      be a general impression (gleaned, as usual in a case of this
+      kind, from the newspapers), viz.: that this discovery, astounding
+      as it unquestionably is, is unanticipated.
+
+      By reference to the ‘Diary of Sir Humphrey Davy’ (Cottle and
+      Munroe, London, pp. 150), it will be seen at pp. 53 and 82, that
+      this illustrious chemist had not only conceived the idea now in
+      question, but had actually made no inconsiderable progress,
+      experimentally, in the very identical analysis now so
+      triumphantly brought to an issue by Von Kempelen, who although he
+      makes not the slightest allusion to it, is, without doubt (I say
+      it unhesitatingly, and can prove it, if required), indebted to
+      the ‘Diary’ for at least the first hint of his own undertaking.
+
+      The paragraph from the ‘Courier and Enquirer,’ which is now going
+      the rounds of the press, and which purports to claim the
+      invention for a Mr. Kissam, of Brunswick, Maine, appears to me, I
+      confess, a little apocryphal, for several reasons; although there
+      is nothing either impossible or very improbable in the statement
+      made. I need not go into details. My opinion of the paragraph is
+      founded principally upon its manner. It does not look true.
+      Persons who are narrating facts, are seldom so particular as Mr.
+      Kissam seems to be, about day and date and precise location.
+      Besides, if Mr. Kissam actually did come upon the discovery he
+      says he did, at the period designated—nearly eight years ago—how
+      happens it that he took no steps, on the instant, to reap the
+      immense benefits which the merest bumpkin must have known would
+      have resulted to him individually, if not to the world at large,
+      from the discovery? It seems to me quite incredible that any man
+      of common understanding could have discovered what Mr. Kissam
+      says he did, and yet have subsequently acted so like a baby—so
+      like an owl—as Mr. Kissam admits that he did. By-the-way, who is
+      Mr. Kissam? and is not the whole paragraph in the ‘Courier and
+      Enquirer’ a fabrication got up to ‘make a talk’? It must be
+      confessed that it has an amazingly moon-hoaxy-air. Very little
+      dependence is to be placed upon it, in my humble opinion; and if
+      I were not well aware, from experience, how very easily men of
+      science are mystified, on points out of their usual range of
+      inquiry, I should be profoundly astonished at finding so eminent
+      a chemist as Professor Draper, discussing Mr. Kissam’s (or is it
+      Mr. Quizzem’s?) pretensions to the discovery, in so serious a
+      tone.
+
+      But to return to the ‘Diary’ of Sir Humphrey Davy. This pamphlet
+      was not designed for the public eye, even upon the decease of the
+      writer, as any person at all conversant with authorship may
+      satisfy himself at once by the slightest inspection of the style.
+      At page 13, for example, near the middle, we read, in reference
+      to his researches about the protoxide of azote: ‘In less than
+      half a minute the respiration being continued, diminished
+      gradually and were succeeded by analogous to gentle pressure on
+      all the muscles.’ That the respiration was not ‘diminished,’ is
+      not only clear by the subsequent context, but by the use of the
+      plural, ‘were.’ The sentence, no doubt, was thus intended: ‘In
+      less than half a minute, the respiration [being continued, these
+      feelings] diminished gradually, and were succeeded by [a
+      sensation] analogous to gentle pressure on all the muscles.’ A
+      hundred similar instances go to show that the MS. so
+      inconsiderately published, was merely a rough note-book, meant
+      only for the writer’s own eye, but an inspection of the pamphlet
+      will convince almost any thinking person of the truth of my
+      suggestion. The fact is, Sir Humphrey Davy was about the last man
+      in the world to commit himself on scientific topics. Not only had
+      he a more than ordinary dislike to quackery, but he was morbidly
+      afraid of appearing empirical; so that, however fully he might
+      have been convinced that he was on the right track in the matter
+      now in question, he would never have spoken out, until he had
+      every thing ready for the most practical demonstration. I verily
+      believe that his last moments would have been rendered wretched,
+      could he have suspected that his wishes in regard to burning this
+      ‘Diary’ (full of crude speculations) would have been unattended
+      to; as, it seems, they were. I say ‘his wishes,’ for that he
+      meant to include this note-book among the miscellaneous papers
+      directed ‘to be burnt,’ I think there can be no manner of doubt.
+      Whether it escaped the flames by good fortune or by bad, yet
+      remains to be seen. That the passages quoted above, with the
+      other similar ones referred to, gave Von Kempelen the hint, I do
+      not in the slightest degree question; but I repeat, it yet
+      remains to be seen whether this momentous discovery itself
+      (momentous under any circumstances) will be of service or
+      disservice to mankind at large. That Von Kempelen and his
+      immediate friends will reap a rich harvest, it would be folly to
+      doubt for a moment. They will scarcely be so weak as not to
+      ‘realize,’ in time, by large purchases of houses and land, with
+      other property of intrinsic value.
+
+      In the brief account of Von Kempelen which appeared in the ‘Home
+      Journal,’ and has since been extensively copied, several
+      misapprehensions of the German original seem to have been made by
+      the translator, who professes to have taken the passage from a
+      late number of the Presburg ‘Schnellpost.’ ‘Viele’ has evidently
+      been misconceived (as it often is), and what the translator
+      renders by ‘sorrows,’ is probably ‘lieden,’ which, in its true
+      version, ‘sufferings,’ would give a totally different complexion
+      to the whole account; but, of course, much of this is merely
+      guess, on my part.
+
+      Von Kempelen, however, is by no means ‘a misanthrope,’ in
+      appearance, at least, whatever he may be in fact. My acquaintance
+      with him was casual altogether; and I am scarcely warranted in
+      saying that I know him at all; but to have seen and conversed
+      with a man of so _prodigious_ a notoriety as he has attained, or
+      _will_ attain in a few days, is not a small matter, as times go.
+
+      “The Literary World” speaks of him, confidently, as a native of
+      Presburg (misled, perhaps, by the account in “The Home Journal”)
+      but I am pleased in being able to state _positively_, since I
+      have it from his own lips, that he was born in Utica, in the
+      State of New York, although both his parents, I believe, are of
+      Presburg descent. The family is connected, in some way, with
+      Mäelzel, of Automaton-chess-player memory. In person, he is short
+      and stout, with large, _fat_, blue eyes, sandy hair and whiskers,
+      a wide but pleasing mouth, fine teeth, and I think a Roman nose.
+      There is some defect in one of his feet. His address is frank,
+      and his whole manner noticeable for bonhomie. Altogether, he
+      looks, speaks, and acts as little like ‘a misanthrope’ as any man
+      I ever saw. We were fellow-sojourners for a week about six years
+      ago, at Earl’s Hotel, in Providence, Rhode Island; and I presume
+      that I conversed with him, at various times, for some three or
+      four hours altogether. His principal topics were those of the
+      day; and nothing that fell from him led me to suspect his
+      scientific attainments. He left the hotel before me, intending to
+      go to New York, and thence to Bremen; it was in the latter city
+      that his great discovery was first made public; or, rather, it
+      was there that he was first suspected of having made it. This is
+      about all that I personally know of the now immortal Von
+      Kempelen; but I have thought that even these few details would
+      have interest for the public.
+
+      There can be little question that most of the marvellous rumors
+      afloat about this affair are pure inventions, entitled to about
+      as much credit as the story of Aladdin’s lamp; and yet, in a case
+      of this kind, as in the case of the discoveries in California, it
+      is clear that the truth may be stranger than fiction. The
+      following anecdote, at least, is so well authenticated, that we
+      may receive it implicitly.
+
+      Von Kempelen had never been even tolerably well off during his
+      residence at Bremen; and often, it was well known, he had been
+      put to extreme shifts in order to raise trifling sums. When the
+      great excitement occurred about the forgery on the house of
+      Gutsmuth & Co., suspicion was directed toward Von Kempelen, on
+      account of his having purchased a considerable property in
+      Gasperitch Lane, and his refusing, when questioned, to explain
+      how he became possessed of the purchase money. He was at length
+      arrested, but nothing decisive appearing against him, was in the
+      end set at liberty. The police, however, kept a strict watch upon
+      his movements, and thus discovered that he left home frequently,
+      taking always the same road, and invariably giving his watchers
+      the slip in the neighborhood of that labyrinth of narrow and
+      crooked passages known by the flash name of the ‘Dondergat.’
+      Finally, by dint of great perseverance, they traced him to a
+      garret in an old house of seven stories, in an alley called
+      Flatzplatz,—and, coming upon him suddenly, found him, as they
+      imagined, in the midst of his counterfeiting operations. His
+      agitation is represented as so excessive that the officers had
+      not the slightest doubt of his guilt. After hand-cuffing him,
+      they searched his room, or rather rooms, for it appears he
+      occupied all the mansarde.
+
+      Opening into the garret where they caught him, was a closet, ten
+      feet by eight, fitted up with some chemical apparatus, of which
+      the object has not yet been ascertained. In one corner of the
+      closet was a very small furnace, with a glowing fire in it, and
+      on the fire a kind of duplicate crucible—two crucibles connected
+      by a tube. One of these crucibles was nearly full of lead in a
+      state of fusion, but not reaching up to the aperture of the tube,
+      which was close to the brim. The other crucible had some liquid
+      in it, which, as the officers entered, seemed to be furiously
+      dissipating in vapor. They relate that, on finding himself taken,
+      Kempelen seized the crucibles with both hands (which were encased
+      in gloves that afterwards turned out to be asbestic), and threw
+      the contents on the tiled floor. It was now that they hand-cuffed
+      him; and before proceeding to ransack the premises they searched
+      his person, but nothing unusual was found about him, excepting a
+      paper parcel, in his coat-pocket, containing what was afterward
+      ascertained to be a mixture of antimony and some unknown
+      substance, in nearly, but not quite, equal proportions. All
+      attempts at analyzing the unknown substance have, so far, failed,
+      but that it will ultimately be analyzed, is not to be doubted.
+
+      Passing out of the closet with their prisoner, the officers went
+      through a sort of ante-chamber, in which nothing material was
+      found, to the chemist’s sleeping-room. They here rummaged some
+      drawers and boxes, but discovered only a few papers, of no
+      importance, and some good coin, silver and gold. At length,
+      looking under the bed, they saw a large, common hair trunk,
+      without hinges, hasp, or lock, and with the top lying carelessly
+      across the bottom portion. Upon attempting to draw this trunk out
+      from under the bed, they found that, with their united strength
+      (there were three of them, all powerful men), they ‘could not
+      stir it one inch.’ Much astonished at this, one of them crawled
+      under the bed, and looking into the trunk, said:
+
+      ‘No wonder we couldn’t move it—why it’s full to the brim of old
+      bits of brass!’
+
+      Putting his feet, now, against the wall so as to get a good
+      purchase, and pushing with all his force, while his companions
+      pulled with all theirs, the trunk, with much difficulty, was slid
+      out from under the bed, and its contents examined. The supposed
+      brass with which it was filled was all in small, smooth pieces,
+      varying from the size of a pea to that of a dollar; but the
+      pieces were irregular in shape, although more or less
+      flat-looking, upon the whole, “very much as lead looks when
+      thrown upon the ground in a molten state, and there suffered to
+      grow cool.” Now, not one of these officers for a moment suspected
+      this metal to be anything _but_ brass. The idea of its being
+      _gold_ never entered their brains, of course; how _could_ such a
+      wild fancy have entered it? And their astonishment may be well
+      conceived, when the next day it became known, all over Bremen,
+      that the “lot of brass” which they had carted so contemptuously
+      to the police office, without putting themselves to the trouble
+      of pocketing the smallest scrap, was not only gold—real gold—but
+      gold far finer than any employed in coinage—gold, in fact,
+      absolutely pure, virgin, without the slightest appreciable alloy.
+
+      I need not go over the details of Von Kempelen’s confession (as
+      far as it went) and release, for these are familiar to the
+      public. That he has actually realized, in spirit and in effect,
+      if not to the letter, the old chimaera of the philosopher’s
+      stone, no sane person is at liberty to doubt. The opinions of
+      Arago are, of course, entitled to the greatest consideration; but
+      he is by no means infallible; and what he says of bismuth, in his
+      report to the Academy, must be taken _cum grano salis_. The
+      simple truth is, that up to this period all analysis has failed;
+      and until Von Kempelen chooses to let us have the key to his own
+      published enigma, it is more than probable that the matter will
+      remain, for years, in statu quo. All that as yet can fairly be
+      said to be known is, that ‘Pure gold can be made at will, and
+      very readily from lead in connection with certain other
+      substances, in kind and in proportions, unknown.’
+
+      Speculation, of course, is busy as to the immediate and ultimate
+      results of this discovery—a discovery which few thinking persons
+      will hesitate in referring to an increased interest in the matter
+      of gold generally, by the late developments in California; and
+      this reflection brings us inevitably to another—the exceeding
+      inopportuneness of Von Kempelen’s analysis. If many were
+      prevented from adventuring to California, by the mere
+      apprehension that gold would so materially diminish in value, on
+      account of its plentifulness in the mines there, as to render the
+      speculation of going so far in search of it a doubtful one—what
+      impression will be wrought now, upon the minds of those about to
+      emigrate, and especially upon the minds of those actually in the
+      mineral region, by the announcement of this astounding discovery
+      of Von Kempelen? a discovery which declares, in so many words,
+      that beyond its intrinsic worth for manufacturing purposes
+      (whatever that worth may be), gold now is, or at least soon will
+      be (for it cannot be supposed that Von Kempelen can long retain
+      his secret), of no greater value than lead, and of far inferior
+      value to silver. It is, indeed, exceedingly difficult to
+      speculate prospectively upon the consequences of the discovery,
+      but one thing may be positively maintained—that the announcement
+      of the discovery six months ago would have had material influence
+      in regard to the settlement of California.
+
+      In Europe, as yet, the most noticeable results have been a rise
+      of two hundred per cent. in the price of lead, and nearly
+      twenty-five per cent. that of silver.
+
+
+
+
+MESMERIC REVELATION
+
+
+Whatever doubt may still envelop the _rationale_ of mesmerism, its
+startling _facts_ are now almost universally admitted. Of these latter,
+those who doubt, are your mere doubters by profession—an unprofitable
+and disreputable tribe. There can be no more absolute waste of time
+than the attempt to _prove_, at the present day, that man, by mere
+exercise of will, can so impress his fellow, as to cast him into an
+abnormal condition, of which the phenomena resemble very closely those
+of _death_, or at least resemble them more nearly than they do the
+phenomena of any other normal condition within our cognizance; that,
+while in this state, the person so impressed employs only with effort,
+and then feebly, the external organs of sense, yet perceives, with
+keenly refined perception, and through channels supposed unknown,
+matters beyond the scope of the physical organs; that, moreover, his
+intellectual faculties are wonderfully exalted and invigorated; that
+his sympathies with the person so impressing him are profound; and,
+finally, that his susceptibility to the impression increases with its
+frequency, while, in the same proportion, the peculiar phenomena
+elicited are more extended and more _pronounced_.
+
+I say that these—which are the laws of mesmerism in its general
+features—it would be supererogation to demonstrate; nor shall I inflict
+upon my readers so needless a demonstration; to-day. My purpose at
+present is a very different one indeed. I am impelled, even in the
+teeth of a world of prejudice, to detail without comment the very
+remarkable substance of a colloquy, occurring between a sleep-waker and
+myself.
+
+I had been long in the habit of mesmerizing the person in question (Mr.
+Vankirk), and the usual acute susceptibility and exaltation of the
+mesmeric perception had supervened. For many months he had been
+laboring under confirmed phthisis, the more distressing effects of
+which had been relieved by my manipulations; and on the night of
+Wednesday, the fifteenth instant, I was summoned to his bedside.
+
+The invalid was suffering with acute pain in the region of the heart,
+and breathed with great difficulty, having all the ordinary symptoms of
+asthma. In spasms such as these he had usually found relief from the
+application of mustard to the nervous centres, but to-night this had
+been attempted in vain.
+
+As I entered his room he greeted me with a cheerful smile, and although
+evidently in much bodily pain, appeared to be, mentally, quite at ease.
+
+“I sent for you to-night,” he said, “not so much to administer to my
+bodily ailment, as to satisfy me concerning certain psychal impressions
+which, of late, have occasioned me much anxiety and surprise. I need
+not tell you how sceptical I have hitherto been on the topic of the
+soul’s immortality. I cannot deny that there has always existed, as if
+in that very soul which I have been denying, a vague half-sentiment of
+its own existence. But this half-sentiment at no time amounted to
+conviction. With it my reason had nothing to do. All attempts at
+logical inquiry resulted, indeed, in leaving me more sceptical than
+before. I had been advised to study Cousin. I studied him in his own
+works as well as in those of his European and American echoes. The
+‘Charles Elwood’ of Mr. Brownson, for example, was placed in my hands.
+I read it with profound attention. Throughout I found it logical, but
+the portions which were not _merely_ logical were unhappily the initial
+arguments of the disbelieving hero of the book. In his summing up it
+seemed evident to me that the reasoner had not even succeeded in
+convincing himself. His end had plainly forgotten his beginning, like
+the government of Trinculo. In short, I was not long in perceiving that
+if man is to be intellectually convinced of his own immortality, he
+will never be so convinced by the mere abstractions which have been so
+long the fashion of the moralists of England, of France, and of
+Germany. Abstractions may amuse and exercise, but take no hold on the
+mind. Here upon earth, at least, philosophy, I am persuaded, will
+always in vain call upon us to look upon qualities as things. The will
+may assent—the soul—the intellect, never.
+
+“I repeat, then, that I only half felt, and never intellectually
+believed. But latterly there has been a certain deepening of the
+feeling, until it has come so nearly to resemble the acquiescence of
+reason, that I find it difficult to distinguish between the two. I am
+enabled, too, plainly to trace this effect to the mesmeric influence. I
+cannot better explain my meaning than by the hypothesis that the
+mesmeric exaltation enables me to perceive a train of ratiocination
+which, in my abnormal existence, convinces, but which, in full
+accordance with the mesmeric phenomena, does not extend, except through
+its _effect_, into my normal condition. In sleep-waking, the reasoning
+and its conclusion—the cause and its effect—are present together. In my
+natural state, the cause vanishing, the effect only, and perhaps only
+partially, remains.
+
+“These considerations have led me to think that some good results might
+ensue from a series of well-directed questions propounded to me while
+mesmerized. You have often observed the profound self-cognizance
+evinced by the sleep-waker—the extensive knowledge he displays upon all
+points relating to the mesmeric condition itself; and from this
+self-cognizance may be deduced hints for the proper conduct of a
+catechism.”
+
+I consented of course to make this experiment.  A few passes threw Mr.
+Vankirk into the mesmeric sleep. His breathing became immediately more
+easy, and he seemed to suffer no physical uneasiness. The following
+conversation then ensued:—V. in the dialogue representing the patient,
+and P. myself.
+
+      _P._ Are you asleep?
+
+      _V._ Yes—no; I would rather sleep more soundly.
+
+      _P._ [_After a few more passes._] Do you sleep now?
+
+      _V._ Yes.
+
+      _P._ How do you think your present illness will result?
+
+      _V._ [_After a long hesitation and speaking as if with effort_.]
+      I must die.
+
+      _P._ Does the idea of death afflict you?
+
+      _V._ [_Very quickly_.] No—no!
+
+      _P._ Are you pleased with the prospect?
+
+      _V._ If I were awake I should like to die, but now it is no
+      matter. The mesmeric condition is so near death as to content me.
+
+      _P._ I wish you would explain yourself, Mr. Vankirk.
+
+      _V._ I am willing to do so, but it requires more effort than I
+      feel able to make. You do not question me properly.
+
+      _P._ What then shall I ask?
+
+      _V._ You must begin at the beginning.
+
+      _P._ The beginning! But where is the beginning?
+
+      _V._ You know that the beginning is GOD. [_This was said in a
+      low, fluctuating tone, and with every sign of the most profound
+      veneration_.]
+
+      _P._ What then, is God?
+
+      _V._ [_Hesitating for many minutes._] I cannot tell.
+
+      _P._ Is not God spirit?
+
+      _V._ While I was awake I knew what you meant by “spirit,” but now
+      it seems only a word—such, for instance, as truth, beauty—a
+      quality, I mean.
+
+      _P._ Is not God immaterial?
+
+      _V._ There is no immateriality—it is a mere word. That which is
+      not matter, is not at all—unless qualities are things.
+
+      _P._ Is God, then, material?
+
+      _V._ No. [_This reply startled me very much._]
+
+      _P._ What, then, is he?
+
+      _V._ [_After a long pause, and mutteringly._] I see—but it is a
+      thing difficult to tell. [_Another long pause._] He is not
+      spirit, for he exists. Nor is he matter, as _you understand it_.
+      But there are _gradations_ of matter of which man knows nothing;
+      the grosser impelling the finer, the finer pervading the grosser.
+      The atmosphere, for example, impels the electric principle, while
+      the electric principle permeates the atmosphere. These gradations
+      of matter increase in rarity or fineness, until we arrive at a
+      matter _unparticled_—without particles—indivisible—_one;_ and
+      here the law of impulsion and permeation is modified. The
+      ultimate, or unparticled matter, not only permeates all things
+      but impels all things; and thus _is_ all things within itself.
+      This matter is God. What men attempt to embody in the word
+      “thought,” is this matter in motion.
+
+      _P._ The metaphysicians maintain that all action is reducible to
+      motion and thinking, and that the latter is the origin of the
+      former.
+
+      _V._ Yes; and I now see the confusion of idea. Motion is the
+      action of _mind_, not of _thinking_. The unparticled matter, or
+      God, in quiescence, is (as nearly as we can conceive it) what men
+      call mind. And the power of self-movement (equivalent in effect
+      to human volition) is, in the unparticled matter, the result of
+      its unity and omniprevalence; _how_ I know not, and now clearly
+      see that I shall never know. But the unparticled matter, set in
+      motion by a law, or quality, existing within itself, is thinking.
+
+      _P._ Can you give me no more precise idea of what you term the
+      unparticled matter?
+
+      _V._ The matters of which man is cognizant escape the senses in
+      gradation. We have, for example, a metal, a piece of wood, a drop
+      of water, the atmosphere, a gas, caloric, electricity, the
+      luminiferous ether. Now we call all these things matter, and
+      embrace all matter in one general definition; but in spite of
+      this, there can be no two ideas more essentially distinct than
+      that which we attach to a metal, and that which we attach to the
+      luminiferous ether. When we reach the latter, we feel an almost
+      irresistible inclination to class it with spirit, or with
+      nihility. The only consideration which restrains us is our
+      conception of its atomic constitution; and here, even, we have to
+      seek aid from our notion of an atom, as something possessing in
+      infinite minuteness, solidity, palpability, weight. Destroy the
+      idea of the atomic constitution and we should no longer be able
+      to regard the ether as an entity, or at least as matter. For want
+      of a better word we might term it spirit. Take, now, a step
+      beyond the luminiferous ether—conceive a matter as much more rare
+      than the ether, as this ether is more rare than the metal, and we
+      arrive at once (in spite of all the school dogmas) at a unique
+      mass—an unparticled matter. For although we may admit infinite
+      littleness in the atoms themselves, the infinitude of littleness
+      in the spaces between them is an absurdity. There will be a
+      point—there will be a degree of rarity, at which, if the atoms
+      are sufficiently numerous, the interspaces must vanish, and the
+      mass absolutely coalesce. But the consideration of the atomic
+      constitution being now taken away, the nature of the mass
+      inevitably glides into what we conceive of spirit. It is clear,
+      however, that it is as fully matter as before. The truth is, it
+      is impossible to conceive spirit, since it is impossible to
+      imagine what is not. When we flatter ourselves that we have
+      formed its conception, we have merely deceived our understanding
+      by the consideration of infinitely rarified matter.
+
+      _P._ There seems to me an insurmountable objection to the idea of
+      absolute coalescence;—and that is the very slight resistance
+      experienced by the heavenly bodies in their revolutions through
+      space—a resistance now ascertained, it is true, to exist in
+      _some_ degree, but which is, nevertheless, so slight as to have
+      been quite overlooked by the sagacity even of Newton. We know
+      that the resistance of bodies is, chiefly, in proportion to their
+      density. Absolute coalescence is absolute density. Where there
+      are no interspaces, there can be no yielding. An ether,
+      absolutely dense, would put an infinitely more effectual stop to
+      the progress of a star than would an ether of adamant or of iron.
+
+      _V._ Your objection is answered with an ease which is nearly in
+      the ratio of its apparent unanswerability.—As regards the
+      progress of the star, it can make no difference whether the star
+      passes through the ether _or the ether through it_. There is no
+      astronomical error more unaccountable than that which reconciles
+      the known retardation of the comets with the idea of their
+      passage through an ether: for, however rare this ether be
+      supposed, it would put a stop to all sidereal revolution in a
+      very far briefer period than has been admitted by those
+      astronomers who have endeavored to slur over a point which they
+      found it impossible to comprehend. The retardation actually
+      experienced is, on the other hand, about that which might be
+      expected from the _friction_ of the ether in the instantaneous
+      passage through the orb. In the one case, the retarding force is
+      momentary and complete within itself—in the other it is endlessly
+      accumulative.
+
+      _P._ But in all this—in this identification of mere matter with
+      God—is there nothing of irreverence? [_I was forced to repeat
+      this question before the sleep-waker fully comprehended my
+      meaning_.]
+
+      _V._ Can you say _why_ matter should be less reverenced than
+      mind? But you forget that the matter of which I speak is, in all
+      respects, the very “mind” or “spirit” of the schools, so far as
+      regards its high capacities, and is, moreover, the “matter” of
+      these schools at the same time. God, with all the powers
+      attributed to spirit, is but the perfection of matter.
+
+      _P._ You assert, then, that the unparticled matter, in motion, is
+      thought?
+
+      _V._ In general, this motion is the universal thought of the
+      universal mind. This thought creates. All created things are but
+      the thoughts of God.
+
+      _P._ You say, “in general.”
+
+      _V._ Yes. The universal mind is God. For new individualities,
+      _matter_ is necessary.
+
+      _P._ But you now speak of “mind” and “matter” as do the
+      metaphysicians.
+
+      _V._ Yes—to avoid confusion. When I say “mind,” I mean the
+      unparticled or ultimate matter; by “matter,” I intend all else.
+
+      _P._ You were saying that “for new individualities matter is
+      necessary.”
+
+      _V._ Yes; for mind, existing unincorporate, is merely God. To
+      create individual, thinking beings, it was necessary to incarnate
+      portions of the divine mind. Thus man is individualized. Divested
+      of corporate investiture, he were God. Now, the particular motion
+      of the incarnated portions of the unparticled matter is the
+      thought of man; as the motion of the whole is that of God.
+
+      _P._ You say that divested of the body man will be God?
+
+      _V._ [_After much hesitation._] I could not have said this; it is
+      an absurdity.
+
+      _P._ [_Referring to my notes._] You _did_ say that “divested of
+      corporate investiture man were God.”
+
+      _V._ And this is true. Man thus divested _would be_ God—would be
+      unindividualized. But he can never be thus divested—at least
+      never _will be_—else we must imagine an action of God returning
+      upon itself—a purposeless and futile action. Man is a creature.
+      Creatures are thoughts of God. It is the nature of thought to be
+      irrevocable.
+
+      _P._ I do not comprehend. You say that man will never put off the
+      body?
+
+      _V._ I say that he will never be bodiless.
+
+      _P._ Explain.
+
+      _V._ There are two bodies—the rudimental and the complete;
+      corresponding with the two conditions of the worm and the
+      butterfly. What we call “death,” is but the painful
+      metamorphosis. Our present incarnation is progressive,
+      preparatory, temporary. Our future is perfected, ultimate,
+      immortal. The ultimate life is the full design.
+
+      _P._ But of the worm’s metamorphosis we are palpably cognizant.
+
+      _V._ _We_, certainly—but not the worm. The matter of which our
+      rudimental body is composed, is within the ken of the organs of
+      that body; or, more distinctly, our rudimental organs are adapted
+      to the matter of which is formed the rudimental body; but not to
+      that of which the ultimate is composed. The ultimate body thus
+      escapes our rudimental senses, and we perceive only the shell
+      which falls, in decaying, from the inner form; not that inner
+      form itself; but this inner form, as well as the shell, is
+      appreciable by those who have already acquired the ultimate life.
+
+      _P._ You have often said that the mesmeric state very nearly
+      resembles death. How is this?
+
+      _V._ When I say that it resembles death, I mean that it resembles
+      the ultimate life; for when I am entranced the senses of my
+      rudimental life are in abeyance, and I perceive external things
+      directly, without organs, through a medium which I shall employ
+      in the ultimate, unorganized life.
+
+      _P._ Unorganized?
+
+      _V._ Yes; organs are contrivances by which the individual is
+      brought into sensible relation with particular classes and forms
+      of matter, to the exclusion of other classes and forms. The
+      organs of man are adapted to his rudimental condition, and to
+      that only; his ultimate condition, being unorganized, is of
+      unlimited comprehension in all points but one—the nature of the
+      volition of God—that is to say, the motion of the unparticled
+      matter. You will have a distinct idea of the ultimate body by
+      conceiving it to be entire brain. This it is _not_; but a
+      conception of this nature will bring you near a comprehension of
+      what it _is_. A luminous body imparts vibration to the
+      luminiferous ether. The vibrations generate similar ones within
+      the retina; these again communicate similar ones to the optic
+      nerve. The nerve conveys similar ones to the brain; the brain,
+      also, similar ones to the unparticled matter which permeates it.
+      The motion of this latter is thought, of which perception is the
+      first undulation. This is the mode by which the mind of the
+      rudimental life communicates with the external world; and this
+      external world is, to the rudimental life, limited, through the
+      idiosyncrasy of its organs. But in the ultimate, unorganized
+      life, the external world reaches the whole body, (which is of a
+      substance having affinity to brain, as I have said,) with no
+      other intervention than that of an infinitely rarer ether than
+      even the luminiferous; and to this ether—in unison with it—the
+      whole body vibrates, setting in motion the unparticled matter
+      which permeates it. It is to the absence of idiosyncratic organs,
+      therefore, that we must attribute the nearly unlimited perception
+      of the ultimate life. To rudimental beings, organs are the cages
+      necessary to confine them until fledged.
+
+      _P._ You speak of rudimental “beings.” Are there other rudimental
+      thinking beings than man?
+
+      _V._ The multitudinous conglomeration of rare matter into nebulæ,
+      planets, suns, and other bodies which are neither nebulæ, suns,
+      nor planets, is for the sole purpose of supplying _pabulum_ for
+      the idiosyncrasy of the organs of an infinity of rudimental
+      beings. But for the necessity of the rudimental, prior to the
+      ultimate life, there would have been no bodies such as these.
+      Each of these is tenanted by a distinct variety of organic,
+      rudimental, thinking creatures. In all, the organs vary with the
+      features of the place tenanted. At death, or metamorphosis, these
+      creatures, enjoying the ultimate life—immortality—and cognizant
+      of all secrets but _the one_, act all things and pass everywhere
+      by mere volition:—indwelling, not the stars, which to us seem the
+      sole palpabilities, and for the accommodation of which we blindly
+      deem space created—but that SPACE itself—that infinity of which
+      the truly substantive vastness swallows up the
+      star-shadows—blotting them out as non-entities from the
+      perception of the angels.
+
+      _P._ You say that “but for the _necessity_ of the rudimental
+      life” there would have been no stars. But why this necessity?
+
+      _V._ In the inorganic life, as well as in the inorganic matter
+      generally, there is nothing to impede the action of one simple
+      _unique_ law—the Divine Volition. With the view of producing
+      impediment, the organic life and matter, (complex, substantial,
+      and law-encumbered,) were contrived.
+
+      _P._ But again—why need this impediment have been produced?
+
+      _V._ The result of law inviolate is perfection—right—negative
+      happiness. The result of law violate is imperfection, wrong,
+      positive pain. Through the impediments afforded by the number,
+      complexity, and substantiality of the laws of organic life and
+      matter, the violation of law is rendered, to a certain extent,
+      practicable. Thus pain, which in the inorganic life is
+      impossible, is possible in the organic.
+
+      _P._ But to what good end is pain thus rendered possible?
+
+      _V._ All things are either good or bad by comparison. A
+      sufficient analysis will show that pleasure, in all cases, is but
+      the contrast of pain. _Positive_ pleasure is a mere idea. To be
+      happy at any one point we must have suffered at the same. Never
+      to suffer would have been never to have been blessed. But it has
+      been shown that, in the inorganic life, pain cannot be thus the
+      necessity for the organic. The pain of the primitive life of
+      Earth, is the sole basis of the bliss of the ultimate life in
+      Heaven.
+
+      _P._ Still, there is one of your expressions which I find it
+      impossible to comprehend—“the truly _substantive_ vastness of
+      infinity.”
+
+      _V._ This, probably, is because you have no sufficiently generic
+      conception of the term “_substance_” itself. We must not regard
+      it as a quality, but as a sentiment:—it is the perception, in
+      thinking beings, of the adaptation of matter to their
+      organization. There are many things on the Earth, which would be
+      nihility to the inhabitants of Venus—many things visible and
+      tangible in Venus, which we could not be brought to appreciate as
+      existing at all. But to the inorganic beings—to the angels—the
+      whole of the unparticled matter is substance—that is to say, the
+      whole of what we term “space” is to them the truest
+      substantiality;—the stars, meantime, through what we consider
+      their materiality, escaping the angelic sense, just in proportion
+      as the unparticled matter, through what we consider its
+      immateriality, eludes the organic.
+
+      As the sleep-waker pronounced these latter words, in a feeble
+      tone, I observed on his countenance a singular expression, which
+      somewhat alarmed me, and induced me to awake him at once. No
+      sooner had I done this, than, with a bright smile irradiating all
+      his features, he fell back upon his pillow and expired. I noticed
+      that in less than a minute afterward his corpse had all the stern
+      rigidity of stone. His brow was of the coldness of ice. Thus,
+      ordinarily, should it have appeared, only after long pressure
+      from Azrael’s hand. Had the sleep-waker, indeed, during the
+      latter portion of his discourse, been addressing me from out the
+      region of the shadows?
+
+
+
+
+THE FACTS IN THE CASE OF M. VALDEMAR
+
+
+      Of course I shall not pretend to consider it any matter for
+      wonder, that the extraordinary case of M. Valdemar has excited
+      discussion. It would have been a miracle had it not—especially
+      under the circumstances. Through the desire of all parties
+      concerned, to keep the affair from the public, at least for the
+      present, or until we had farther opportunities for
+      investigation—through our endeavors to effect this—a garbled or
+      exaggerated account made its way into society, and became the
+      source of many unpleasant misrepresentations; and, very
+      naturally, of a great deal of disbelief.
+
+      It is now rendered necessary that I give the facts—as far as I
+      comprehend them myself. They are, succinctly, these:
+
+      My attention, for the last three years, had been repeatedly drawn
+      to the subject of Mesmerism; and, about nine months ago it
+      occurred to me, quite suddenly, that in the series of experiments
+      made hitherto, there had been a very remarkable and most
+      unaccountable omission:—no person had as yet been mesmerized in
+      articulo mortis. It remained to be seen, first, whether, in such
+      condition, there existed in the patient any susceptibility to the
+      magnetic influence; secondly, whether, if any existed, it was
+      impaired or increased by the condition; thirdly, to what extent,
+      or for how long a period, the encroachments of Death might be
+      arrested by the process. There were other points to be
+      ascertained, but these most excited my curiosity—the last in
+      especial, from the immensely important character of its
+      consequences.
+
+      In looking around me for some subject by whose means I might test
+      these particulars, I was brought to think of my friend, M. Ernest
+      Valdemar, the well-known compiler of the “Bibliotheca Forensica,”
+      and author (under the nom de plume of Issachar Marx) of the
+      Polish versions of “Wallenstein” and “Gargantua.” M. Valdemar,
+      who has resided principally at Harlem, N.Y., since the year 1839,
+      is (or was) particularly noticeable for the extreme spareness of
+      his person—his lower limbs much resembling those of John
+      Randolph; and, also, for the whiteness of his whiskers, in
+      violent contrast to the blackness of his hair—the latter, in
+      consequence, being very generally mistaken for a wig. His
+      temperament was markedly nervous, and rendered him a good subject
+      for mesmeric experiment. On two or three occasions I had put him
+      to sleep with little difficulty, but was disappointed in other
+      results which his peculiar constitution had naturally led me to
+      anticipate. His will was at no period positively, or thoroughly,
+      under my control, and in regard to clairvoyance, I could
+      accomplish with him nothing to be relied upon. I always
+      attributed my failure at these points to the disordered state of
+      his health. For some months previous to my becoming acquainted
+      with him, his physicians had declared him in a confirmed
+      phthisis. It was his custom, indeed, to speak calmly of his
+      approaching dissolution, as of a matter neither to be avoided nor
+      regretted.
+
+      When the ideas to which I have alluded first occurred to me, it
+      was of course very natural that I should think of M. Valdemar. I
+      knew the steady philosophy of the man too well to apprehend any
+      scruples from him; and he had no relatives in America who would
+      be likely to interfere. I spoke to him frankly upon the subject;
+      and, to my surprise, his interest seemed vividly excited. I say
+      to my surprise, for, although he had always yielded his person
+      freely to my experiments, he had never before given me any tokens
+      of sympathy with what I did. His disease was of that character
+      which would admit of exact calculation in respect to the epoch of
+      its termination in death; and it was finally arranged between us
+      that he would send for me about twenty-four hours before the
+      period announced by his physicians as that of his decease.
+
+      It is now rather more than seven months since I received, from M.
+      Valdemar himself, the subjoined note:
+
+      MY DEAR P——,
+
+      You may as well come now. D—— and F—— are agreed that I cannot
+      hold out beyond to-morrow midnight; and I think they have hit the
+      time very nearly.
+
+      VALDEMAR
+
+      I received this note within half an hour after it was written,
+      and in fifteen minutes more I was in the dying man’s chamber. I
+      had not seen him for ten days, and was appalled by the fearful
+      alteration which the brief interval had wrought in him. His face
+      wore a leaden hue; the eyes were utterly lustreless; and the
+      emaciation was so extreme that the skin had been broken through
+      by the cheek-bones. His expectoration was excessive. The pulse
+      was barely perceptible. He retained, nevertheless, in a very
+      remarkable manner, both his mental power and a certain degree of
+      physical strength. He spoke with distinctness—took some
+      palliative medicines without aid—and, when I entered the room,
+      was occupied in penciling memoranda in a pocket-book. He was
+      propped up in the bed by pillows. Doctors D—— and F—— were in
+      attendance.
+
+      After pressing Valdemar’s hand, I took these gentlemen aside, and
+      obtained from them a minute account of the patient’s condition.
+      The left lung had been for eighteen months in a semi-osseous or
+      cartilaginous state, and was, of course, entirely useless for all
+      purposes of vitality. The right, in its upper portion, was also
+      partially, if not thoroughly, ossified, while the lower region
+      was merely a mass of purulent tubercles, running one into
+      another. Several extensive perforations existed; and, at one
+      point, permanent adhesion to the ribs had taken place. These
+      appearances in the right lobe were of comparatively recent date.
+      The ossification had proceeded with very unusual rapidity; no
+      sign of it had been discovered a month before, and the adhesion
+      had only been observed during the three previous days.
+      Independently of the phthisis, the patient was suspected of
+      aneurism of the aorta; but on this point the osseous symptoms
+      rendered an exact diagnosis impossible. It was the opinion of
+      both physicians that M. Valdemar would die about midnight on the
+      morrow (Sunday). It was then seven o’clock on Saturday evening.
+
+      On quitting the invalid’s bed-side to hold conversation with
+      myself, Doctors D—— and F—— had bidden him a final farewell. It
+      had not been their intention to return; but, at my request, they
+      agreed to look in upon the patient about ten the next night.
+
+      When they had gone, I spoke freely with M. Valdemar on the
+      subject of his approaching dissolution, as well as, more
+      particularly, of the experiment proposed. He still professed
+      himself quite willing and even anxious to have it made, and urged
+      me to commence it at once. A male and a female nurse were in
+      attendance; but I did not feel myself altogether at liberty to
+      engage in a task of this character with no more reliable
+      witnesses than these people, in case of sudden accident, might
+      prove. I therefore postponed operations until about eight the
+      next night, when the arrival of a medical student with whom I had
+      some acquaintance, (Mr. Theodore L—l,) relieved me from farther
+      embarrassment. It had been my design, originally, to wait for the
+      physicians; but I was induced to proceed, first, by the urgent
+      entreaties of M. Valdemar, and secondly, by my conviction that I
+      had not a moment to lose, as he was evidently sinking fast.
+
+      Mr. L—l was so kind as to accede to my desire that he would take
+      notes of all that occurred, and it is from his memoranda that
+      what I now have to relate is, for the most part, either condensed
+      or copied verbatim.
+
+      It wanted about five minutes of eight when, taking the patient’s
+      hand, I begged him to state, as distinctly as he could, to Mr.
+      L—l, whether he (M. Valdemar) was entirely willing that I should
+      make the experiment of mesmerizing him in his then condition.
+
+      He replied feebly, yet quite audibly, “Yes, I wish to be. I fear
+      you have mesmerized”—adding immediately afterwards: “I fear you
+      have deferred it too long.”
+
+      While he spoke thus, I commenced the passes which I had already
+      found most effectual in subduing him. He was evidently influenced
+      with the first lateral stroke of my hand across his forehead; but
+      although I exerted all my powers, no further perceptible effect
+      was induced until some minutes after ten o’clock, when Doctors
+      D—— and F—— called, according to appointment. I explained to
+      them, in a few words, what I designed, and as they opposed no
+      objection, saying that the patient was already in the death
+      agony, I proceeded without hesitation—exchanging, however, the
+      lateral passes for downward ones, and directing my gaze entirely
+      into the right eye of the sufferer.
+
+      By this time his pulse was imperceptible and his breathing was
+      stertorous, and at intervals of half a minute.
+
+      This condition was nearly unaltered for a quarter of an hour. At
+      the expiration of this period, however, a natural although a very
+      deep sigh escaped the bosom of the dying man, and the stertorous
+      breathing ceased—that is to say, its stertorousness was no longer
+      apparent; the intervals were undiminished. The patient’s
+      extremities were of an icy coldness.
+
+      At five minutes before eleven I perceived unequivocal signs of
+      the mesmeric influence. The glassy roll of the eye was changed
+      for that expression of uneasy inward examination which is never
+      seen except in cases of sleep-waking, and which it is quite
+      impossible to mistake. With a few rapid lateral passes I made the
+      lids quiver, as in incipient sleep, and with a few more I closed
+      them altogether. I was not satisfied, however, with this, but
+      continued the manipulations vigorously, and with the fullest
+      exertion of the will, until I had completely stiffened the limbs
+      of the slumberer, after placing them in a seemingly easy
+      position. The legs were at full length; the arms were nearly so,
+      and reposed on the bed at a moderate distance from the loin. The
+      head was very slightly elevated.
+
+      When I had accomplished this, it was fully midnight, and I
+      requested the gentlemen present to examine M. Valdemar’s
+      condition. After a few experiments, they admitted him to be an
+      unusually perfect state of mesmeric trance. The curiosity of both
+      the physicians was greatly excited. Dr. D—— resolved at once to
+      remain with the patient all night, while Dr. F—— took leave with
+      a promise to return at daybreak. Mr. L—l and the nurses remained.
+
+      We left M. Valdemar entirely undisturbed until about three
+      o’clock in the morning, when I approached him and found him in
+      precisely the same condition as when Dr. F—— went away—that is to
+      say, he lay in the same position; the pulse was imperceptible;
+      the breathing was gentle (scarcely noticeable, unless through the
+      application of a mirror to the lips); the eyes were closed
+      naturally; and the limbs were as rigid and as cold as marble.
+      Still, the general appearance was certainly not that of death.
+
+      As I approached M. Valdemar I made a kind of half effort to
+      influence his right arm into pursuit of my own, as I passed the
+      latter gently to and fro above his person. In such experiments
+      with this patient, I had never perfectly succeeded before, and
+      assuredly I had little thought of succeeding now; but to my
+      astonishment, his arm very readily, although feebly, followed
+      every direction I assigned it with mine. I determined to hazard a
+      few words of conversation.
+
+      “M. Valdemar,” I said, “are you asleep?” He made no answer, but I
+      perceived a tremor about the lips, and was thus induced to repeat
+      the question, again and again. At its third repetition, his whole
+      frame was agitated by a very slight shivering; the eyelids
+      unclosed themselves so far as to display a white line of the
+      ball; the lips moved sluggishly, and from between them, in a
+      barely audible whisper, issued the words:
+
+      “Yes;—asleep now. Do not wake me!—let me die so!”
+
+      I here felt the limbs and found them as rigid as ever. The right
+      arm, as before, obeyed the direction of my hand. I questioned the
+      sleep-waker again:
+
+      “Do you still feel pain in the breast, M. Valdemar?”
+
+      The answer now was immediate, but even less audible than before:
+
+      “No pain—I am dying.”
+
+      I did not think it advisable to disturb him farther just then,
+      and nothing more was said or done until the arrival of Dr. F——,
+      who came a little before sunrise, and expressed unbounded
+      astonishment at finding the patient still alive. After feeling
+      the pulse and applying a mirror to the lips, he requested me to
+      speak to the sleep-waker again. I did so, saying:
+
+      “M. Valdemar, do you still sleep?”
+
+      As before, some minutes elapsed ere a reply was made; and during
+      the interval the dying man seemed to be collecting his energies
+      to speak. At my fourth repetition of the question, he said very
+      faintly, almost inaudibly:
+
+      “Yes; still asleep—dying.”
+
+      It was now the opinion, or rather the wish, of the physicians,
+      that M. Valdemar should be suffered to remain undisturbed in his
+      present apparently tranquil condition, until death should
+      supervene—and this, it was generally agreed, must now take place
+      within a few minutes. I concluded, however, to speak to him once
+      more, and merely repeated my previous question.
+
+      While I spoke, there came a marked change over the countenance of
+      the sleep-waker. The eyes rolled themselves slowly open, the
+      pupils disappearing upwardly; the skin generally assumed a
+      cadaverous hue, resembling not so much parchment as white paper;
+      and the circular hectic spots which, hitherto, had been strongly
+      defined in the centre of each cheek, went out at once. I use this
+      expression, because the suddenness of their departure put me in
+      mind of nothing so much as the extinguishment of a candle by a
+      puff of the breath. The upper lip, at the same time, writhed
+      itself away from the teeth, which it had previously covered
+      completely; while the lower jaw fell with an audible jerk,
+      leaving the mouth widely extended, and disclosing in full view
+      the swollen and blackened tongue. I presume that no member of the
+      party then present had been unaccustomed to death-bed horrors;
+      but so hideous beyond conception was the appearance of M.
+      Valdemar at this moment, that there was a general shrinking back
+      from the region of the bed.
+
+      I now feel that I have reached a point of this narrative at which
+      every reader will be startled into positive disbelief. It is my
+      business, however, simply to proceed.
+
+      There was no longer the faintest sign of vitality in M. Valdemar;
+      and concluding him to be dead, we were consigning him to the
+      charge of the nurses, when a strong vibratory motion was
+      observable in the tongue. This continued for perhaps a minute. At
+      the expiration of this period, there issued from the distended
+      and motionless jaws a voice—such as it would be madness in me to
+      attempt describing. There are, indeed, two or three epithets
+      which might be considered as applicable to it in part; I might
+      say, for example, that the sound was harsh, and broken and
+      hollow; but the hideous whole is indescribable, for the simple
+      reason that no similar sounds have ever jarred upon the ear of
+      humanity. There were two particulars, nevertheless, which I
+      thought then, and still think, might fairly be stated as
+      characteristic of the intonation—as well adapted to convey some
+      idea of its unearthly peculiarity. In the first place, the voice
+      seemed to reach our ears—at least mine—from a vast distance, or
+      from some deep cavern within the earth. In the second place, it
+      impressed me (I fear, indeed, that it will be impossible to make
+      myself comprehended) as gelatinous or glutinous matters impress
+      the sense of touch.
+
+      I have spoken both of “sound” and of “voice.” I mean to say that
+      the sound was one of distinct—of even wonderfully, thrillingly
+      distinct—syllabification. M. Valdemar spoke—obviously in reply to
+      the question I had propounded to him a few minutes before. I had
+      asked him, it will be remembered, if he still slept. He now said:
+
+      “Yes;—no;—I have been sleeping—and now—now—I am dead.”
+
+      No person present even affected to deny, or attempted to repress,
+      the unutterable, shuddering horror which these few words, thus
+      uttered, were so well calculated to convey. Mr. L—l (the student)
+      swooned. The nurses immediately left the chamber, and could not
+      be induced to return. My own impressions I would not pretend to
+      render intelligible to the reader. For nearly an hour, we busied
+      ourselves, silently—without the utterance of a word—in endeavors
+      to revive Mr. L—l. When he came to himself, we addressed
+      ourselves again to an investigation of M. Valdemar’s condition.
+
+      It remained in all respects as I have last described it, with the
+      exception that the mirror no longer afforded evidence of
+      respiration. An attempt to draw blood from the arm failed. I
+      should mention, too, that this limb was no farther subject to my
+      will. I endeavored in vain to make it follow the direction of my
+      hand. The only real indication, indeed, of the mesmeric
+      influence, was now found in the vibratory movement of the tongue,
+      whenever I addressed M. Valdemar a question. He seemed to be
+      making an effort to reply, but had no longer sufficient volition.
+      To queries put to him by any other person than myself he seemed
+      utterly insensible—although I endeavored to place each member of
+      the company in mesmeric rapport with him. I believe that I have
+      now related all that is necessary to an understanding of the
+      sleep-waker’s state at this epoch. Other nurses were procured;
+      and at ten o’clock I left the house in company with the two
+      physicians and Mr. L—l.
+
+      In the afternoon we all called again to see the patient. His
+      condition remained precisely the same. We had now some discussion
+      as to the propriety and feasibility of awakening him; but we had
+      little difficulty in agreeing that no good purpose would be
+      served by so doing. It was evident that, so far, death (or what
+      is usually termed death) had been arrested by the mesmeric
+      process. It seemed clear to us all that to awaken M. Valdemar
+      would be merely to insure his instant, or at least his speedy,
+      dissolution.
+
+      From this period until the close of last week—an interval of
+      nearly seven months—we continued to make daily calls at M.
+      Valdemar’s house, accompanied, now and then, by medical and other
+      friends. All this time the sleeper-waker remained _exactly_ as I
+      have last described him. The nurses’ attentions were continual.
+
+      It was on Friday last that we finally resolved to make the
+      experiment of awakening, or attempting to awaken him; and it is
+      the (perhaps) unfortunate result of this latter experiment which
+      has given rise to so much discussion in private circles—to so
+      much of what I cannot help thinking unwarranted popular feeling.
+
+      For the purpose of relieving M. Valdemar from the mesmeric
+      trance, I made use of the customary passes. These, for a time,
+      were unsuccessful. The first indication of revival was afforded
+      by a partial descent of the iris. It was observed, as especially
+      remarkable, that this lowering of the pupil was accompanied by
+      the profuse out-flowing of a yellowish ichor (from beneath the
+      lids) of a pungent and highly offensive odor.
+
+      It was now suggested that I should attempt to influence the
+      patient’s arm, as heretofore. I made the attempt and failed. Dr.
+      F—— then intimated a desire to have me put a question. I did so,
+      as follows:
+
+      “M. Valdemar, can you explain to us what are your feelings or
+      wishes now?”
+
+      There was an instant return of the hectic circles on the cheeks;
+      the tongue quivered, or rather rolled violently in the mouth
+      (although the jaws and lips remained rigid as before), and at
+      length the same hideous voice which I have already described,
+      broke forth:
+
+      “For God’s sake!—quick!—quick!—put me to sleep—or, quick!—waken
+      me!—quick!—I say to you that I am dead!”
+
+      I was thoroughly unnerved, and for an instant remained undecided
+      what to do. At first I made an endeavor to recompose the patient;
+      but, failing in this through total abeyance of the will, I
+      retraced my steps and as earnestly struggled to awaken him. In
+      this attempt I soon saw that I should be successful—or at least I
+      soon fancied that my success would be complete—and I am sure that
+      all in the room were prepared to see the patient awaken.
+
+      For what really occurred, however, it is quite impossible that
+      any human being could have been prepared.
+
+      As I rapidly made the mesmeric passes, amid ejaculations of
+      “dead! dead!” absolutely bursting from the tongue and not from
+      the lips of the sufferer, his whole frame at once—within the
+      space of a single minute, or even less,
+      shrunk—crumbled—absolutely rotted away beneath my hands. Upon the
+      bed, before that whole company, there lay a nearly liquid mass of
+      loathsome—of detestable putrescence.
+
+
+
+
+THE BLACK CAT.
+
+
+      For the most wild, yet most homely narrative which I am about to
+      pen, I neither expect nor solicit belief. Mad indeed would I be
+      to expect it, in a case where my very senses reject their own
+      evidence. Yet, mad am I not—and very surely do I not dream. But
+      to-morrow I die, and to-day I would unburthen my soul. My
+      immediate purpose is to place before the world, plainly,
+      succinctly, and without comment, a series of mere household
+      events. In their consequences, these events have terrified—have
+      tortured—have destroyed me. Yet I will not attempt to expound
+      them. To me, they have presented little but horror—to many they
+      will seem less terrible than _barroques_. Hereafter, perhaps,
+      some intellect may be found which will reduce my phantasm to the
+      common-place—some intellect more calm, more logical, and far less
+      excitable than my own, which will perceive, in the circumstances
+      I detail with awe, nothing more than an ordinary succession of
+      very natural causes and effects.
+
+      From my infancy I was noted for the docility and humanity of my
+      disposition. My tenderness of heart was even so conspicuous as to
+      make me the jest of my companions. I was especially fond of
+      animals, and was indulged by my parents with a great variety of
+      pets. With these I spent most of my time, and never was so happy
+      as when feeding and caressing them. This peculiarity of character
+      grew with my growth, and in my manhood, I derived from it one of
+      my principal sources of pleasure. To those who have cherished an
+      affection for a faithful and sagacious dog, I need hardly be at
+      the trouble of explaining the nature or the intensity of the
+      gratification thus derivable. There is something in the unselfish
+      and self-sacrificing love of a brute, which goes directly to the
+      heart of him who has had frequent occasion to test the paltry
+      friendship and gossamer fidelity of mere _Man_.
+
+      I married early, and was happy to find in my wife a disposition
+      not uncongenial with my own. Observing my partiality for domestic
+      pets, she lost no opportunity of procuring those of the most
+      agreeable kind. We had birds, gold-fish, a fine dog, rabbits, a
+      small monkey, and _a cat_.
+
+      This latter was a remarkably large and beautiful animal, entirely
+      black, and sagacious to an astonishing degree. In speaking of his
+      intelligence, my wife, who at heart was not a little tinctured
+      with superstition, made frequent allusion to the ancient popular
+      notion, which regarded all black cats as witches in disguise. Not
+      that she was ever _serious_ upon this point—and I mention the
+      matter at all for no better reason than that it happens, just
+      now, to be remembered.
+
+      Pluto—this was the cat’s name—was my favorite pet and playmate. I
+      alone fed him, and he attended me wherever I went about the
+      house. It was even with difficulty that I could prevent him from
+      following me through the streets.
+
+      Our friendship lasted, in this manner, for several years, during
+      which my general temperament and character—through the
+      instrumentality of the Fiend Intemperance—had (I blush to confess
+      it) experienced a radical alteration for the worse. I grew, day
+      by day, more moody, more irritable, more regardless of the
+      feelings of others. I suffered myself to use intemperate language
+      to my wife. At length, I even offered her personal violence. My
+      pets, of course, were made to feel the change in my disposition.
+      I not only neglected, but ill-used them. For Pluto, however, I
+      still retained sufficient regard to restrain me from maltreating
+      him, as I made no scruple of maltreating the rabbits, the monkey,
+      or even the dog, when by accident, or through affection, they
+      came in my way. But my disease grew upon me—for what disease is
+      like Alcohol!—and at length even Pluto, who was now becoming old,
+      and consequently somewhat peevish—even Pluto began to experience
+      the effects of my ill temper.
+
+      One night, returning home, much intoxicated, from one of my
+      haunts about town, I fancied that the cat avoided my presence. I
+      seized him; when, in his fright at my violence, he inflicted a
+      slight wound upon my hand with his teeth. The fury of a demon
+      instantly possessed me. I knew myself no longer. My original soul
+      seemed, at once, to take its flight from my body and a more than
+      fiendish malevolence, gin-nurtured, thrilled every fibre of my
+      frame. I took from my waistcoat-pocket a pen-knife, opened it,
+      grasped the poor beast by the throat, and deliberately cut one of
+      its eyes from the socket! I blush, I burn, I shudder, while I pen
+      the damnable atrocity.
+
+      When reason returned with the morning—when I had slept off the
+      fumes of the night’s debauch—I experienced a sentiment half of
+      horror, half of remorse, for the crime of which I had been
+      guilty; but it was, at best, a feeble and equivocal feeling, and
+      the soul remained untouched. I again plunged into excess, and
+      soon drowned in wine all memory of the deed.
+
+      In the meantime the cat slowly recovered. The socket of the lost
+      eye presented, it is true, a frightful appearance, but he no
+      longer appeared to suffer any pain. He went about the house as
+      usual, but, as might be expected, fled in extreme terror at my
+      approach. I had so much of my old heart left, as to be at first
+      grieved by this evident dislike on the part of a creature which
+      had once so loved me. But this feeling soon gave place to
+      irritation. And then came, as if to my final and irrevocable
+      overthrow, the spirit of PERVERSENESS. Of this spirit philosophy
+      takes no account. Yet I am not more sure that my soul lives, than
+      I am that perverseness is one of the primitive impulses of the
+      human heart—one of the indivisible primary faculties, or
+      sentiments, which give direction to the character of Man. Who has
+      not, a hundred times, found himself committing a vile or a silly
+      action, for no other reason than because he knows he should not?
+      Have we not a perpetual inclination, in the teeth of our best
+      judgment, to violate that which is _Law_, merely because we
+      understand it to be such? This spirit of perverseness, I say,
+      came to my final overthrow. It was this unfathomable longing of
+      the soul _to vex itself_—to offer violence to its own nature—to
+      do wrong for the wrong’s sake only—that urged me to continue and
+      finally to consummate the injury I had inflicted upon the
+      unoffending brute. One morning, in cool blood, I slipped a noose
+      about its neck and hung it to the limb of a tree;—hung it with
+      the tears streaming from my eyes, and with the bitterest remorse
+      at my heart;—hung it _because_ I knew that it had loved me, and
+      _because_ I felt it had given me no reason of offence;—hung it
+      _because_ I knew that in so doing I was committing a sin—a deadly
+      sin that would so jeopardize my immortal soul as to place it—if
+      such a thing wore possible—even beyond the reach of the infinite
+      mercy of the Most Merciful and Most Terrible God.
+
+      On the night of the day on which this cruel deed was done, I was
+      aroused from sleep by the cry of fire. The curtains of my bed
+      were in flames. The whole house was blazing. It was with great
+      difficulty that my wife, a servant, and myself, made our escape
+      from the conflagration. The destruction was complete. My entire
+      worldly wealth was swallowed up, and I resigned myself
+      thenceforward to despair.
+
+      I am above the weakness of seeking to establish a sequence of
+      cause and effect, between the disaster and the atrocity. But I am
+      detailing a chain of facts—and wish not to leave even a possible
+      link imperfect. On the day succeeding the fire, I visited the
+      ruins. The walls, with one exception, had fallen in. This
+      exception was found in a compartment wall, not very thick, which
+      stood about the middle of the house, and against which had rested
+      the head of my bed. The plastering had here, in great measure,
+      resisted the action of the fire—a fact which I attributed to its
+      having been recently spread. About this wall a dense crowd were
+      collected, and many persons seemed to be examining a particular
+      portion of it with very minute and eager attention. The words
+      “strange!” “singular!” and other similar expressions, excited my
+      curiosity. I approached and saw, as if graven in _bas relief_
+      upon the white surface, the figure of a gigantic _cat_. The
+      impression was given with an accuracy truly marvellous. There was
+      a rope about the animal’s neck.
+
+      When I first beheld this apparition—for I could scarcely regard
+      it as less—my wonder and my terror were extreme. But at length
+      reflection came to my aid. The cat, I remembered, had been hung
+      in a garden adjacent to the house. Upon the alarm of fire, this
+      garden had been immediately filled by the crowd—by some one of
+      whom the animal must have been cut from the tree and thrown,
+      through an open window, into my chamber. This had probably been
+      done with the view of arousing me from sleep. The falling of
+      other walls had compressed the victim of my cruelty into the
+      substance of the freshly-spread plaster; the lime of which, with
+      the flames, and the _ammonia_ from the carcass, had then
+      accomplished the portraiture as I saw it.
+
+      Although I thus readily accounted to my reason, if not altogether
+      to my conscience, for the startling fact just detailed, it did
+      not the less fail to make a deep impression upon my fancy. For
+      months I could not rid myself of the phantasm of the cat; and,
+      during this period, there came back into my spirit a
+      half-sentiment that seemed, but was not, remorse. I went so far
+      as to regret the loss of the animal, and to look about me, among
+      the vile haunts which I now habitually frequented, for another
+      pet of the same species, and of somewhat similar appearance, with
+      which to supply its place.
+
+      One night as I sat, half stupefied, in a den of more than infamy,
+      my attention was suddenly drawn to some black object, reposing
+      upon the head of one of the immense hogsheads of gin, or of rum,
+      which constituted the chief furniture of the apartment. I had
+      been looking steadily at the top of this hogshead for some
+      minutes, and what now caused me surprise was the fact that I had
+      not sooner perceived the object thereupon. I approached it, and
+      touched it with my hand. It was a black cat—a very large
+      one—fully as large as Pluto, and closely resembling him in every
+      respect but one. Pluto had not a white hair upon any portion of
+      his body; but this cat had a large, although indefinite splotch
+      of white, covering nearly the whole region of the breast. Upon my
+      touching him, he immediately arose, purred loudly, rubbed against
+      my hand, and appeared delighted with my notice. This, then, was
+      the very creature of which I was in search. I at once offered to
+      purchase it of the landlord; but this person made no claim to
+      it—knew nothing of it—had never seen it before.
+
+      I continued my caresses, and, when I prepared to go home, the
+      animal evinced a disposition to accompany me. I permitted it to
+      do so; occasionally stooping and patting it as I proceeded. When
+      it reached the house it domesticated itself at once, and became
+      immediately a great favorite with my wife.
+
+      For my own part, I soon found a dislike to it arising within me.
+      This was just the reverse of what I had anticipated; but—I know
+      not how or why it was—its evident fondness for myself rather
+      disgusted and annoyed. By slow degrees, these feelings of disgust
+      and annoyance rose into the bitterness of hatred. I avoided the
+      creature; a certain sense of shame, and the remembrance of my
+      former deed of cruelty, preventing me from physically abusing it.
+      I did not, for some weeks, strike, or otherwise violently ill use
+      it; but gradually—very gradually—I came to look upon it with
+      unutterable loathing, and to flee silently from its odious
+      presence, as from the breath of a pestilence.
+
+      What added, no doubt, to my hatred of the beast, was the
+      discovery, on the morning after I brought it home, that, like
+      Pluto, it also had been deprived of one of its eyes. This
+      circumstance, however, only endeared it to my wife, who, as I
+      have already said, possessed, in a high degree, that humanity of
+      feeling which had once been my distinguishing trait, and the
+      source of many of my simplest and purest pleasures.
+
+      With my aversion to this cat, however, its partiality for myself
+      seemed to increase. It followed my footsteps with a pertinacity
+      which it would be difficult to make the reader comprehend.
+      Whenever I sat, it would crouch beneath my chair, or spring upon
+      my knees, covering me with its loathsome caresses. If I arose to
+      walk it would get between my feet and thus nearly throw me down,
+      or, fastening its long and sharp claws in my dress, clamber, in
+      this manner, to my breast. At such times, although I longed to
+      destroy it with a blow, I was yet withheld from so doing, partly
+      by a memory of my former crime, but chiefly—let me confess it at
+      once—by absolute dread of the beast.
+
+      This dread was not exactly a dread of physical evil—and yet I
+      should be at a loss how otherwise to define it. I am almost
+      ashamed to own—yes, even in this felon’s cell, I am almost
+      ashamed to own—that the terror and horror with which the animal
+      inspired me, had been heightened by one of the merest chimaeras
+      it would be possible to conceive. My wife had called my
+      attention, more than once, to the character of the mark of white
+      hair, of which I have spoken, and which constituted the sole
+      visible difference between the strange beast and the one I had
+      destroyed. The reader will remember that this mark, although
+      large, had been originally very indefinite; but, by slow
+      degrees—degrees nearly imperceptible, and which for a long time
+      my reason struggled to reject as fanciful—it had, at length,
+      assumed a rigorous distinctness of outline. It was now the
+      representation of an object that I shudder to name—and for this,
+      above all, I loathed, and dreaded, and would have rid myself of
+      the monster _had I dared_—it was now, I say, the image of a
+      hideous—of a ghastly thing—of the GALLOWS!—oh, mournful and
+      terrible engine of Horror and of Crime—of Agony and of Death!
+
+      And now was I indeed wretched beyond the wretchedness of mere
+      Humanity. And _a brute beast _—whose fellow I had contemptuously
+      destroyed—_a brute beast_ to work out for _me_—for me a man,
+      fashioned in the image of the High God—so much of insufferable
+      woe! Alas! neither by day nor by night knew I the blessing of
+      rest any more! During the former the creature left me no moment
+      alone, and in the latter I started hourly from dreams of
+      unutterable fear to find the hot breath of _the thing_ upon my
+      face, and its vast weight—an incarnate nightmare that I had no
+      power to shake off—incumbent eternally upon my _heart!_
+
+      Beneath the pressure of torments such as these, the feeble
+      remnant of the good within me succumbed. Evil thoughts became my
+      sole intimates—the darkest and most evil of thoughts. The
+      moodiness of my usual temper increased to hatred of all things
+      and of all mankind; while, from the sudden, frequent, and
+      ungovernable outbursts of a fury to which I now blindly abandoned
+      myself, my uncomplaining wife, alas, was the most usual and the
+      most patient of sufferers.
+
+      One day she accompanied me, upon some household errand, into the
+      cellar of the old building which our poverty compelled us to
+      inhabit. The cat followed me down the steep stairs, and, nearly
+      throwing me headlong, exasperated me to madness. Uplifting an
+      axe, and forgetting, in my wrath, the childish dread which had
+      hitherto stayed my hand, I aimed a blow at the animal which, of
+      course, would have proved instantly fatal had it descended as I
+      wished. But this blow was arrested by the hand of my wife.
+      Goaded, by the interference, into a rage more than demoniacal, I
+      withdrew my arm from her grasp and buried the axe in her brain.
+      She fell dead upon the spot, without a groan.
+
+      This hideous murder accomplished, I set myself forthwith, and
+      with entire deliberation, to the task of concealing the body. I
+      knew that I could not remove it from the house, either by day or
+      by night, without the risk of being observed by the neighbors.
+      Many projects entered my mind. At one period I thought of cutting
+      the corpse into minute fragments, and destroying them by fire. At
+      another, I resolved to dig a grave for it in the floor of the
+      cellar. Again, I deliberated about casting it in the well in the
+      yard—about packing it in a box, as if merchandise, with the usual
+      arrangements, and so getting a porter to take it from the house.
+      Finally I hit upon what I considered a far better expedient than
+      either of these. I determined to wall it up in the cellar—as the
+      monks of the middle ages are recorded to have walled up their
+      victims.
+
+      For a purpose such as this the cellar was well adapted. Its walls
+      were loosely constructed, and had lately been plastered
+      throughout with a rough plaster, which the dampness of the
+      atmosphere had prevented from hardening. Moreover, in one of the
+      walls was a projection, caused by a false chimney, or fireplace,
+      that had been filled up, and made to resemble the red of the
+      cellar. I made no doubt that I could readily displace the bricks
+      at this point, insert the corpse, and wall the whole up as
+      before, so that no eye could detect any thing suspicious. And in
+      this calculation I was not deceived. By means of a crow-bar I
+      easily dislodged the bricks, and, having carefully deposited the
+      body against the inner wall, I propped it in that position,
+      while, with little trouble, I re-laid the whole structure as it
+      originally stood. Having procured mortar, sand, and hair, with
+      every possible precaution, I prepared a plaster which could not
+      be distinguished from the old, and with this I very carefully
+      went over the new brickwork. When I had finished, I felt
+      satisfied that all was right. The wall did not present the
+      slightest appearance of having been disturbed. The rubbish on the
+      floor was picked up with the minutest care. I looked around
+      triumphantly, and said to myself: “Here at least, then, my labor
+      has not been in vain.”
+
+      My next step was to look for the beast which had been the cause
+      of so much wretchedness; for I had, at length, firmly resolved to
+      put it to death. Had I been able to meet with it, at the moment,
+      there could have been no doubt of its fate; but it appeared that
+      the crafty animal had been alarmed at the violence of my previous
+      anger, and forebore to present itself in my present mood. It is
+      impossible to describe, or to imagine, the deep, the blissful
+      sense of relief which the absence of the detested creature
+      occasioned in my bosom. It did not make its appearance during the
+      night; and thus for one night at least, since its introduction
+      into the house, I soundly and tranquilly slept; aye, slept even
+      with the burden of murder upon my soul!
+
+      The second and the third day passed, and still my tormentor came
+      not. Once again I breathed as a freeman. The monster, in terror,
+      had fled the premises forever! I should behold it no more! My
+      happiness was supreme! The guilt of my dark deed disturbed me but
+      little. Some few inquiries had been made, but these had been
+      readily answered. Even a search had been instituted—but of course
+      nothing was to be discovered. I looked upon my future felicity as
+      secured.
+
+      Upon the fourth day of the assassination, a party of the police
+      came, very unexpectedly, into the house, and proceeded again to
+      make rigorous investigation of the premises. Secure, however, in
+      the inscrutability of my place of concealment, I felt no
+      embarrassment whatever. The officers bade me accompany them in
+      their search. They left no nook or corner unexplored. At length,
+      for the third or fourth time, they descended into the cellar. I
+      quivered not in a muscle. My heart beat calmly as that of one who
+      slumbers in innocence. I walked the cellar from end to end. I
+      folded my arms upon my bosom, and roamed easily to and fro. The
+      police were thoroughly satisfied and prepared to depart. The glee
+      at my heart was too strong to be restrained. I burned to say if
+      but one word, by way of triumph, and to render doubly sure their
+      assurance of my guiltlessness.
+
+      “Gentlemen,” I said at last, as the party ascended the steps, “I
+      delight to have allayed your suspicions. I wish you all health,
+      and a little more courtesy. By the bye, gentlemen, this—this is a
+      very well-constructed house.” (In the rabid desire to say
+      something easily, I scarcely knew what I uttered at all.)—“I may
+      say an _excellently_ well-constructed house. These walls—are you
+      going, gentlemen?—these walls are solidly put together;” and
+      here, through the mere phrenzy of bravado, I rapped heavily, with
+      a cane which I held in my hand, upon that very portion of the
+      brick-work behind which stood the corpse of the wife of my bosom.
+
+      But may God shield and deliver me from the fangs of the
+      Arch-Fiend! No sooner had the reverberation of my blows sunk into
+      silence, than I was answered by a voice from within the tomb!—by
+      a cry, at first muffled and broken, like the sobbing of a child,
+      and then quickly swelling into one long, loud, and continuous
+      scream, utterly anomalous and inhuman—a howl—a wailing shriek,
+      half of horror and half of triumph, such as might have arisen
+      only out of hell, conjointly from the throats of the damned in
+      their agony and of the demons that exult in the damnation.
+
+      Of my own thoughts it is folly to speak. Swooning, I staggered to
+      the opposite wall. For one instant the party upon the stairs
+      remained motionless, through extremity of terror and of awe. In
+      the next, a dozen stout arms were toiling at the wall. It fell
+      bodily. The corpse, already greatly decayed and clotted with
+      gore, stood erect before the eyes of the spectators. Upon its
+      head, with red extended mouth and solitary eye of fire, sat the
+      hideous beast whose craft had seduced me into murder, and whose
+      informing voice had consigned me to the hangman. I had walled the
+      monster up within the tomb!
+
+
+
+
+THE FALL OF THE HOUSE OF USHER
+
+
+     Son cœur est un luth suspendu;
+     Sitôt qu’on le touche il résonne..
+
+—_De Béranger_.
+
+      During the whole of a dull, dark, and soundless day in the autumn
+      of the year, when the clouds hung oppressively low in the
+      heavens, I had been passing alone, on horseback, through a
+      singularly dreary tract of country; and at length found myself,
+      as the shades of the evening drew on, within view of the
+      melancholy House of Usher. I know not how it was—but, with the
+      first glimpse of the building, a sense of insufferable gloom
+      pervaded my spirit. I say insufferable; for the feeling was
+      unrelieved by any of that half-pleasurable, because poetic,
+      sentiment, with which the mind usually receives even the sternest
+      natural images of the desolate or terrible. I looked upon the
+      scene before me—upon the mere house, and the simple landscape
+      features of the domain—upon the bleak walls—upon the vacant
+      eye-like windows—upon a few rank sedges—and upon a few white
+      trunks of decayed trees—with an utter depression of soul which I
+      can compare to no earthly sensation more properly than to the
+      after-dream of the reveller upon opium—the bitter lapse into
+      everyday life—the hideous dropping off of the veil. There was an
+      iciness, a sinking, a sickening of the heart—an unredeemed
+      dreariness of thought which no goading of the imagination could
+      torture into aught of the sublime. What was it—I paused to
+      think—what was it that so unnerved me in the contemplation of the
+      House of Usher? It was a mystery all insoluble; nor could I
+      grapple with the shadowy fancies that crowded upon me as I
+      pondered. I was forced to fall back upon the unsatisfactory
+      conclusion, that while, beyond doubt, there _are_ combinations of
+      very simple natural objects which have the power of thus
+      affecting us, still the analysis of this power lies among
+      considerations beyond our depth. It was possible, I reflected,
+      that a mere different arrangement of the particulars of the
+      scene, of the details of the picture, would be sufficient to
+      modify, or perhaps to annihilate its capacity for sorrowful
+      impression; and, acting upon this idea, I reined my horse to the
+      precipitous brink of a black and lurid tarn that lay in unruffled
+      lustre by the dwelling, and gazed down—but with a shudder even
+      more thrilling than before—upon the remodelled and inverted
+      images of the gray sedge, and the ghastly tree-stems, and the
+      vacant and eye-like windows.
+
+      Nevertheless, in this mansion of gloom I now proposed to myself a
+      sojourn of some weeks. Its proprietor, Roderick Usher, had been
+      one of my boon companions in boyhood; but many years had elapsed
+      since our last meeting. A letter, however, had lately reached me
+      in a distant part of the country—a letter from him—which, in its
+      wildly importunate nature, had admitted of no other than a
+      personal reply. The MS. gave evidence of nervous agitation. The
+      writer spoke of acute bodily illness—of a mental disorder which
+      oppressed him—and of an earnest desire to see me, as his best,
+      and indeed his only personal friend, with a view of attempting,
+      by the cheerfulness of my society, some alleviation of his
+      malady. It was the manner in which all this, and much more, was
+      said—it was the apparent _heart_ that went with his request—which
+      allowed me no room for hesitation; and I accordingly obeyed
+      forthwith what I still considered a very singular summons.
+
+      Although, as boys, we had been even intimate associates, yet I
+      really knew little of my friend. His reserve had been always
+      excessive and habitual. I was aware, however, that his very
+      ancient family had been noted, time out of mind, for a peculiar
+      sensibility of temperament, displaying itself, through long ages,
+      in many works of exalted art, and manifested, of late, in
+      repeated deeds of munificent yet unobtrusive charity, as well as
+      in a passionate devotion to the intricacies, perhaps even more
+      than to the orthodox and easily recognisable beauties, of musical
+      science. I had learned, too, the very remarkable fact, that the
+      stem of the Usher race, all time-honored as it was, had put
+      forth, at no period, any enduring branch; in other words, that
+      the entire family lay in the direct line of descent, and had
+      always, with very trifling and very temporary variation, so lain.
+      It was this deficiency, I considered, while running over in
+      thought the perfect keeping of the character of the premises with
+      the accredited character of the people, and while speculating
+      upon the possible influence which the one, in the long lapse of
+      centuries, might have exercised upon the other—it was this
+      deficiency, perhaps, of collateral issue, and the consequent
+      undeviating transmission, from sire to son, of the patrimony with
+      the name, which had, at length, so identified the two as to merge
+      the original title of the estate in the quaint and equivocal
+      appellation of the “House of Usher”—an appellation which seemed
+      to include, in the minds of the peasantry who used it, both the
+      family and the family mansion.
+
+      I have said that the sole effect of my somewhat childish
+      experiment—that of looking down within the tarn—had been to
+      deepen the first singular impression. There can be no doubt that
+      the consciousness of the rapid increase of my superstition—for
+      why should I not so term it?—served mainly to accelerate the
+      increase itself. Such, I have long known, is the paradoxical law
+      of all sentiments having terror as a basis. And it might have
+      been for this reason only, that, when I again uplifted my eyes to
+      the house itself, from its image in the pool, there grew in my
+      mind a strange fancy—a fancy so ridiculous, indeed, that I but
+      mention it to show the vivid force of the sensations which
+      oppressed me. I had so worked upon my imagination as really to
+      believe that about the whole mansion and domain there hung an
+      atmosphere peculiar to themselves and their immediate vicinity—an
+      atmosphere which had no affinity with the air of heaven, but
+      which had reeked up from the decayed trees, and the gray wall,
+      and the silent tarn—a pestilent and mystic vapor, dull, sluggish,
+      faintly discernible, and leaden-hued.
+
+      Shaking off from my spirit what _must_ have been a dream, I
+      scanned more narrowly the real aspect of the building. Its
+      principal feature seemed to be that of an excessive antiquity.
+      The discoloration of ages had been great. Minute fungi overspread
+      the whole exterior, hanging in a fine tangled web-work from the
+      eaves. Yet all this was apart from any extraordinary
+      dilapidation. No portion of the masonry had fallen; and there
+      appeared to be a wild inconsistency between its still perfect
+      adaptation of parts, and the crumbling condition of the
+      individual stones. In this there was much that reminded me of the
+      specious totality of old wood-work which has rotted for long
+      years in some neglected vault, with no disturbance from the
+      breath of the external air. Beyond this indication of extensive
+      decay, however, the fabric gave little token of instability.
+      Perhaps the eye of a scrutinizing observer might have discovered
+      a barely perceptible fissure, which, extending from the roof of
+      the building in front, made its way down the wall in a zigzag
+      direction, until it became lost in the sullen waters of the tarn.
+
+      Noticing these things, I rode over a short causeway to the house.
+      A servant in waiting took my horse, and I entered the Gothic
+      archway of the hall. A valet, of stealthy step, thence conducted
+      me, in silence, through many dark and intricate passages in my
+      progress to the _studio_ of his master. Much that I encountered
+      on the way contributed, I know not how, to heighten the vague
+      sentiments of which I have already spoken. While the objects
+      around me—while the carvings of the ceilings, the sombre
+      tapestries of the walls, the ebon blackness of the floors, and
+      the phantasmagoric armorial trophies which rattled as I strode,
+      were but matters to which, or to such as which, I had been
+      accustomed from my infancy—while I hesitated not to acknowledge
+      how familiar was all this—I still wondered to find how unfamiliar
+      were the fancies which ordinary images were stirring up. On one
+      of the staircases, I met the physician of the family. His
+      countenance, I thought, wore a mingled expression of low cunning
+      and perplexity. He accosted me with trepidation and passed on.
+      The valet now threw open a door and ushered me into the presence
+      of his master.
+
+      The room in which I found myself was very large and lofty. The
+      windows were long, narrow, and pointed, and at so vast a distance
+      from the black oaken floor as to be altogether inaccessible from
+      within. Feeble gleams of encrimsoned light made their way through
+      the trellissed panes, and served to render sufficiently distinct
+      the more prominent objects around; the eye, however, struggled in
+      vain to reach the remoter angles of the chamber, or the recesses
+      of the vaulted and fretted ceiling. Dark draperies hung upon the
+      walls. The general furniture was profuse, comfortless, antique,
+      and tattered. Many books and musical instruments lay scattered
+      about, but failed to give any vitality to the scene. I felt that
+      I breathed an atmosphere of sorrow. An air of stern, deep, and
+      irredeemable gloom hung over and pervaded all.
+
+      Upon my entrance, Usher arose from a sofa on which he had been
+      lying at full length, and greeted me with a vivacious warmth
+      which had much in it, I at first thought, of an overdone
+      cordiality—of the constrained effort of the _ennuyé_ man of the
+      world. A glance, however, at his countenance, convinced me of his
+      perfect sincerity. We sat down; and for some moments, while he
+      spoke not, I gazed upon him with a feeling half of pity, half of
+      awe. Surely, man had never before so terribly altered, in so
+      brief a period, as had Roderick Usher! It was with difficulty
+      that I could bring myself to admit the identity of the wan being
+      before me with the companion of my early boyhood. Yet the
+      character of his face had been at all times remarkable. A
+      cadaverousness of complexion; an eye large, liquid, and luminous
+      beyond comparison; lips somewhat thin and very pallid, but of a
+      surpassingly beautiful curve; a nose of a delicate Hebrew model,
+      but with a breadth of nostril unusual in similar formations; a
+      finely moulded chin, speaking, in its want of prominence, of a
+      want of moral energy; hair of a more than web-like softness and
+      tenuity; these features, with an inordinate expansion above the
+      regions of the temple, made up altogether a countenance not
+      easily to be forgotten. And now in the mere exaggeration of the
+      prevailing character of these features, and of the expression
+      they were wont to convey, lay so much of change that I doubted to
+      whom I spoke. The now ghastly pallor of the skin, and the now
+      miraculous lustre of the eye, above all things startled and even
+      awed me. The silken hair, too, had been suffered to grow all
+      unheeded, and as, in its wild gossamer texture, it floated rather
+      than fell about the face, I could not, even with effort, connect
+      its Arabesque expression with any idea of simple humanity.
+
+      In the manner of my friend I was at once struck with an
+      incoherence—an inconsistency; and I soon found this to arise from
+      a series of feeble and futile struggles to overcome an habitual
+      trepidancy—an excessive nervous agitation. For something of this
+      nature I had indeed been prepared, no less by his letter, than by
+      reminiscences of certain boyish traits, and by conclusions
+      deduced from his peculiar physical conformation and temperament.
+      His action was alternately vivacious and sullen. His voice varied
+      rapidly from a tremulous indecision (when the animal spirits
+      seemed utterly in abeyance) to that species of energetic
+      concision—that abrupt, weighty, unhurried, and hollow-sounding
+      enunciation—that leaden, self-balanced and perfectly modulated
+      guttural utterance, which may be observed in the lost drunkard,
+      or the irreclaimable eater of opium, during the periods of his
+      most intense excitement.
+
+      It was thus that he spoke of the object of my visit, of his
+      earnest desire to see me, and of the solace he expected me to
+      afford him. He entered, at some length, into what he conceived to
+      be the nature of his malady. It was, he said, a constitutional
+      and a family evil, and one for which he despaired to find a
+      remedy—a mere nervous affection, he immediately added, which
+      would undoubtedly soon pass off. It displayed itself in a host of
+      unnatural sensations. Some of these, as he detailed them,
+      interested and bewildered me; although, perhaps, the terms, and
+      the general manner of the narration had their weight. He suffered
+      much from a morbid acuteness of the senses; the most insipid food
+      was alone endurable; he could wear only garments of certain
+      texture; the odors of all flowers were oppressive; his eyes were
+      tortured by even a faint light; and there were but peculiar
+      sounds, and these from stringed instruments, which did not
+      inspire him with horror.
+
+      To an anomalous species of terror I found him a bounden slave. “I
+      shall perish,” said he, “I must perish in this deplorable folly.
+      Thus, thus, and not otherwise, shall I be lost. I dread the
+      events of the future, not in themselves, but in their results. I
+      shudder at the thought of any, even the most trivial, incident,
+      which may operate upon this intolerable agitation of soul. I
+      have, indeed, no abhorrence of danger, except in its absolute
+      effect—in terror. In this unnerved—in this pitiable condition—I
+      feel that the period will sooner or later arrive when I must
+      abandon life and reason together, in some struggle with the grim
+      phantasm, FEAR.”
+
+      I learned, moreover, at intervals, and through broken and
+      equivocal hints, another singular feature of his mental
+      condition. He was enchained by certain superstitious impressions
+      in regard to the dwelling which he tenanted, and whence, for many
+      years, he had never ventured forth—in regard to an influence
+      whose supposititious force was conveyed in terms too shadowy here
+      to be re-stated—an influence which some peculiarities in the mere
+      form and substance of his family mansion, had, by dint of long
+      sufferance, he said, obtained over his spirit—an effect which the
+      _physique_ of the gray walls and turrets, and of the dim tarn
+      into which they all looked down, had, at length, brought about
+      upon the _morale_ of his existence.
+
+      He admitted, however, although with hesitation, that much of the
+      peculiar gloom which thus afflicted him could be traced to a more
+      natural and far more palpable origin—to the severe and
+      long-continued illness—indeed to the evidently approaching
+      dissolution—of a tenderly beloved sister—his sole companion for
+      long years—his last and only relative on earth. “Her decease,” he
+      said, with a bitterness which I can never forget, “would leave
+      him (him the hopeless and the frail) the last of the ancient race
+      of the Ushers.” While he spoke, the lady Madeline (for so was she
+      called) passed slowly through a remote portion of the apartment,
+      and, without having noticed my presence, disappeared. I regarded
+      her with an utter astonishment not unmingled with dread—and yet I
+      found it impossible to account for such feelings. A sensation of
+      stupor oppressed me, as my eyes followed her retreating steps.
+      When a door, at length, closed upon her, my glance sought
+      instinctively and eagerly the countenance of the brother—but he
+      had buried his face in his hands, and I could only perceive that
+      a far more than ordinary wanness had overspread the emaciated
+      fingers through which trickled many passionate tears.
+
+      The disease of the lady Madeline had long baffled the skill of
+      her physicians. A settled apathy, a gradual wasting away of the
+      person, and frequent although transient affections of a partially
+      cataleptical character, were the unusual diagnosis. Hitherto she
+      had steadily borne up against the pressure of her malady, and had
+      not betaken herself finally to bed; but, on the closing in of the
+      evening of my arrival at the house, she succumbed (as her brother
+      told me at night with inexpressible agitation) to the prostrating
+      power of the destroyer; and I learned that the glimpse I had
+      obtained of her person would thus probably be the last I should
+      obtain—that the lady, at least while living, would be seen by me
+      no more.
+
+      For several days ensuing, her name was unmentioned by either
+      Usher or myself; and during this period I was busied in earnest
+      endeavors to alleviate the melancholy of my friend. We painted
+      and read together; or I listened, as if in a dream, to the wild
+      improvisations of his speaking guitar. And thus, as a closer and
+      still closer intimacy admitted me more unreservedly into the
+      recesses of his spirit, the more bitterly did I perceive the
+      futility of all attempt at cheering a mind from which darkness,
+      as if an inherent positive quality, poured forth upon all objects
+      of the moral and physical universe, in one unceasing radiation of
+      gloom.
+
+      I shall ever bear about me a memory of the many solemn hours I
+      thus spent alone with the master of the House of Usher. Yet I
+      should fail in any attempt to convey an idea of the exact
+      character of the studies, or of the occupations, in which he
+      involved me, or led me the way. An excited and highly distempered
+      ideality threw a sulphureous lustre over all. His long improvised
+      dirges will ring forever in my ears. Among other things, I hold
+      painfully in mind a certain singular perversion and amplification
+      of the wild air of the last waltz of Von Weber. From the
+      paintings over which his elaborate fancy brooded, and which grew,
+      touch by touch, into vaguenesses at which I shuddered the more
+      thrillingly, because I shuddered knowing not why—from these
+      paintings (vivid as their images now are before me) I would in
+      vain endeavor to educe more than a small portion which should lie
+      within the compass of merely written words. By the utter
+      simplicity, by the nakedness of his designs, he arrested and
+      overawed attention. If ever mortal painted an idea, that mortal
+      was Roderick Usher. For me at least—in the circumstances then
+      surrounding me—there arose out of the pure abstractions which the
+      hypochondriac contrived to throw upon his canvass, an intensity
+      of intolerable awe, no shadow of which felt I ever yet in the
+      contemplation of the certainly glowing yet too concrete reveries
+      of Fuseli.
+
+      One of the phantasmagoric conceptions of my friend, partaking not
+      so rigidly of the spirit of abstraction, may be shadowed forth,
+      although feebly, in words. A small picture presented the interior
+      of an immensely long and rectangular vault or tunnel, with low
+      walls, smooth, white, and without interruption or device. Certain
+      accessory points of the design served well to convey the idea
+      that this excavation lay at an exceeding depth below the surface
+      of the earth. No outlet was observed in any portion of its vast
+      extent, and no torch, or other artificial source of light was
+      discernible; yet a flood of intense rays rolled throughout, and
+      bathed the whole in a ghastly and inappropriate splendor.
+
+      I have just spoken of that morbid condition of the auditory nerve
+      which rendered all music intolerable to the sufferer, with the
+      exception of certain effects of stringed instruments. It was,
+      perhaps, the narrow limits to which he thus confined himself upon
+      the guitar, which gave birth, in great measure, to the fantastic
+      character of his performances. But the fervid _facility_ of his
+      _impromptus_ could not be so accounted for. They must have been,
+      and were, in the notes, as well as in the words of his wild
+      fantasias (for he not unfrequently accompanied himself with
+      rhymed verbal improvisations), the result of that intense mental
+      collectedness and concentration to which I have previously
+      alluded as observable only in particular moments of the highest
+      artificial excitement. The words of one of these rhapsodies I
+      have easily remembered. I was, perhaps, the more forcibly
+      impressed with it, as he gave it, because, in the under or mystic
+      current of its meaning, I fancied that I perceived, and for the
+      first time, a full consciousness on the part of Usher of the
+      tottering of his lofty reason upon her throne. The verses, which
+      were entitled “The Haunted Palace,” ran very nearly, if not
+      accurately, thus:
+
+                        I.
+     In the greenest of our valleys,
+    By good angels tenanted,
+     Once a fair and stately palace—
+    Radiant palace—reared its head.
+     In the monarch Thought’s dominion—
+    It stood there!
+     Never seraph spread a pinion
+    Over fabric half so fair.
+
+                        II.
+     Banners yellow, glorious, golden,
+    On its roof did float and flow;
+     (This—all this—was in the olden
+    Time long ago)
+     And every gentle air that dallied,
+    In that sweet day,
+     Along the ramparts plumed and pallid,
+    A winged odor went away.
+
+                        III.
+     Wanderers in that happy valley
+    Through two luminous windows saw
+     Spirits moving musically
+    To a lute’s well-tunéd law,
+     Round about a throne, where sitting
+    (Porphyrogene!)
+     In state his glory well befitting,
+    The ruler of the realm was seen.
+
+                        IV.
+     And all with pearl and ruby glowing
+    Was the fair palace door,
+     Through which came flowing, flowing, flowing,
+    And sparkling evermore,
+     A troop of Echoes whose sweet duty
+    Was but to sing,
+     In voices of surpassing beauty,
+    The wit and wisdom of their king.
+
+                        V.
+     But evil things, in robes of sorrow,
+    Assailed the monarch’s high estate;
+     (Ah, let us mourn, for never morrow
+    Shall dawn upon him, desolate!)
+     And, round about his home, the glory
+    That blushed and bloomed
+     Is but a dim-remembered story
+    Of the old time entombed.
+
+                        VI.
+     And travellers now within that valley,
+    Through the red-litten windows, see
+     Vast forms that move fantastically
+    To a discordant melody;
+     While, like a rapid ghastly river,
+    Through the pale door,
+     A hideous throng rush out forever,
+    And laugh—but smile no more.
+
+      I well remember that suggestions arising from this ballad, led us
+      into a train of thought wherein there became manifest an opinion
+      of Usher’s which I mention not so much on account of its novelty,
+      (for other men * have thought thus,) as on account of the
+      pertinacity with which he maintained it. This opinion, in its
+      general form, was that of the sentience of all vegetable things.
+      But, in his disordered fancy, the idea had assumed a more daring
+      character, and trespassed, under certain conditions, upon the
+      kingdom of inorganization. I lack words to express the full
+      extent, or the earnest _abandon_ of his persuasion. The belief,
+      however, was connected (as I have previously hinted) with the
+      gray stones of the home of his forefathers. The conditions of the
+      sentience had been here, he imagined, fulfilled in the method of
+      collocation of these stones—in the order of their arrangement, as
+      well as in that of the many _fungi_ which overspread them, and of
+      the decayed trees which stood around—above all, in the long
+      undisturbed endurance of this arrangement, and in its
+      reduplication in the still waters of the tarn. Its evidence—the
+      evidence of the sentience—was to be seen, he said, (and I here
+      started as he spoke,) in the gradual yet certain condensation of
+      an atmosphere of their own about the waters and the walls. The
+      result was discoverable, he added, in that silent, yet
+      importunate and terrible influence which for centuries had
+      moulded the destinies of his family, and which made _him_ what I
+      now saw him—what he was. Such opinions need no comment, and I
+      will make none.
+
+      * Watson, Dr. Percival, Spallanzani, and especially the Bishop of
+      Landaff.—See “Chemical Essays,” vol v.
+
+      Our books—the books which, for years, had formed no small portion
+      of the mental existence of the invalid—were, as might be
+      supposed, in strict keeping with this character of phantasm. We
+      pored together over such works as the Ververt et Chartreuse of
+      Gresset; the Belphegor of Machiavelli; the Heaven and Hell of
+      Swedenborg; the Subterranean Voyage of Nicholas Klimm by Holberg;
+      the Chiromancy of Robert Flud, of Jean D’Indaginé, and of De la
+      Chambre; the Journey into the Blue Distance of Tieck; and the
+      City of the Sun of Campanella. One favorite volume was a small
+      octavo edition of the _Directorium Inquisitorium_, by the
+      Dominican Eymeric de Gironne; and there were passages in
+      Pomponius Mela, about the old African Satyrs and OEgipans, over
+      which Usher would sit dreaming for hours. His chief delight,
+      however, was found in the perusal of an exceedingly rare and
+      curious book in quarto Gothic—the manual of a forgotten
+      church—the _Vigiliae Mortuorum secundum Chorum Ecclesiae
+      Maguntinae_.
+
+      I could not help thinking of the wild ritual of this work, and of
+      its probable influence upon the hypochondriac, when, one evening,
+      having informed me abruptly that the lady Madeline was no more,
+      he stated his intention of preserving her corpse for a fortnight,
+      (previously to its final interment,) in one of the numerous
+      vaults within the main walls of the building. The worldly reason,
+      however, assigned for this singular proceeding, was one which I
+      did not feel at liberty to dispute. The brother had been led to
+      his resolution (so he told me) by consideration of the unusual
+      character of the malady of the deceased, of certain obtrusive and
+      eager inquiries on the part of her medical men, and of the remote
+      and exposed situation of the burial-ground of the family. I will
+      not deny that when I called to mind the sinister countenance of
+      the person whom I met upon the staircase, on the day of my
+      arrival at the house, I had no desire to oppose what I regarded
+      as at best but a harmless, and by no means an unnatural,
+      precaution.
+
+      At the request of Usher, I personally aided him in the
+      arrangements for the temporary entombment. The body having been
+      encoffined, we two alone bore it to its rest. The vault in which
+      we placed it (and which had been so long unopened that our
+      torches, half smothered in its oppressive atmosphere, gave us
+      little opportunity for investigation) was small, damp, and
+      entirely without means of admission for light; lying, at great
+      depth, immediately beneath that portion of the building in which
+      was my own sleeping apartment. It had been used, apparently, in
+      remote feudal times, for the worst purposes of a donjon-keep,
+      and, in later days, as a place of deposit for powder, or some
+      other highly combustible substance, as a portion of its floor,
+      and the whole interior of a long archway through which we reached
+      it, were carefully sheathed with copper. The door, of massive
+      iron, had been, also, similarly protected. Its immense weight
+      caused an unusually sharp grating sound, as it moved upon its
+      hinges.
+
+      Having deposited our mournful burden upon tressels within this
+      region of horror, we partially turned aside the yet unscrewed lid
+      of the coffin, and looked upon the face of the tenant. A striking
+      similitude between the brother and sister now first arrested my
+      attention; and Usher, divining, perhaps, my thoughts, murmured
+      out some few words from which I learned that the deceased and
+      himself had been twins, and that sympathies of a scarcely
+      intelligible nature had always existed between them. Our glances,
+      however, rested not long upon the dead—for we could not regard
+      her unawed. The disease which had thus entombed the lady in the
+      maturity of youth, had left, as usual in all maladies of a
+      strictly cataleptical character, the mockery of a faint blush
+      upon the bosom and the face, and that suspiciously lingering
+      smile upon the lip which is so terrible in death. We replaced and
+      screwed down the lid, and, having secured the door of iron, made
+      our way, with toil, into the scarcely less gloomy apartments of
+      the upper portion of the house.
+
+      And now, some days of bitter grief having elapsed, an observable
+      change came over the features of the mental disorder of my
+      friend. His ordinary manner had vanished. His ordinary
+      occupations were neglected or forgotten. He roamed from chamber
+      to chamber with hurried, unequal, and objectless step. The pallor
+      of his countenance had assumed, if possible, a more ghastly
+      hue—but the luminousness of his eye had utterly gone out. The
+      once occasional huskiness of his tone was heard no more; and a
+      tremulous quaver, as if of extreme terror, habitually
+      characterized his utterance. There were times, indeed, when I
+      thought his unceasingly agitated mind was laboring with some
+      oppressive secret, to divulge which he struggled for the
+      necessary courage. At times, again, I was obliged to resolve all
+      into the mere inexplicable vagaries of madness, for I beheld him
+      gazing upon vacancy for long hours, in an attitude of the
+      profoundest attention, as if listening to some imaginary sound.
+      It was no wonder that his condition terrified—that it infected
+      me. I felt creeping upon me, by slow yet certain degrees, the
+      wild influences of his own fantastic yet impressive
+      superstitions.
+
+      It was, especially, upon retiring to bed late in the night of the
+      seventh or eighth day after the placing of the lady Madeline
+      within the donjon, that I experienced the full power of such
+      feelings. Sleep came not near my couch—while the hours waned and
+      waned away. I struggled to reason off the nervousness which had
+      dominion over me. I endeavored to believe that much, if not all
+      of what I felt, was due to the bewildering influence of the
+      gloomy furniture of the room—of the dark and tattered draperies,
+      which, tortured into motion by the breath of a rising tempest,
+      swayed fitfully to and fro upon the walls, and rustled uneasily
+      about the decorations of the bed. But my efforts were fruitless.
+      An irrepressible tremor gradually pervaded my frame; and, at
+      length, there sat upon my very heart an incubus of utterly
+      causeless alarm. Shaking this off with a gasp and a struggle, I
+      uplifted myself upon the pillows, and, peering earnestly within
+      the intense darkness of the chamber, harkened—I know not why,
+      except that an instinctive spirit prompted me—to certain low and
+      indefinite sounds which came, through the pauses of the storm, at
+      long intervals, I knew not whence. Overpowered by an intense
+      sentiment of horror, unaccountable yet unendurable, I threw on my
+      clothes with haste (for I felt that I should sleep no more during
+      the night), and endeavored to arouse myself from the pitiable
+      condition into which I had fallen, by pacing rapidly to and fro
+      through the apartment.
+
+      I had taken but few turns in this manner, when a light step on an
+      adjoining staircase arrested my attention. I presently recognised
+      it as that of Usher. In an instant afterward he rapped, with a
+      gentle touch, at my door, and entered, bearing a lamp. His
+      countenance was, as usual, cadaverously wan—but, moreover, there
+      was a species of mad hilarity in his eyes—an evidently restrained
+      _hysteria_ in his whole demeanor. His air appalled me—but
+      anything was preferable to the solitude which I had so long
+      endured, and I even welcomed his presence as a relief.
+
+      “And you have not seen it?” he said abruptly, after having stared
+      about him for some moments in silence—“you have not then seen
+      it?—but, stay! you shall.” Thus speaking, and having carefully
+      shaded his lamp, he hurried to one of the casements, and threw it
+      freely open to the storm.
+
+      The impetuous fury of the entering gust nearly lifted us from our
+      feet. It was, indeed, a tempestuous yet sternly beautiful night,
+      and one wildly singular in its terror and its beauty. A whirlwind
+      had apparently collected its force in our vicinity; for there
+      were frequent and violent alterations in the direction of the
+      wind; and the exceeding density of the clouds (which hung so low
+      as to press upon the turrets of the house) did not prevent our
+      perceiving the life-like velocity with which they flew careering
+      from all points against each other, without passing away into the
+      distance. I say that even their exceeding density did not prevent
+      our perceiving this—yet we had no glimpse of the moon or
+      stars—nor was there any flashing forth of the lightning. But the
+      under surfaces of the huge masses of agitated vapor, as well as
+      all terrestrial objects immediately around us, were glowing in
+      the unnatural light of a faintly luminous and distinctly visible
+      gaseous exhalation which hung about and enshrouded the mansion.
+
+      “You must not—you shall not behold this!” said I, shudderingly,
+      to Usher, as I led him, with a gentle violence, from the window
+      to a seat. “These appearances, which bewilder you, are merely
+      electrical phenomena not uncommon—or it may be that they have
+      their ghastly origin in the rank miasma of the tarn. Let us close
+      this casement;—the air is chilling and dangerous to your frame.
+      Here is one of your favorite romances. I will read, and you shall
+      listen;—and so we will pass away this terrible night together.”
+
+      The antique volume which I had taken up was the “Mad Trist” of
+      Sir Launcelot Canning; but I had called it a favorite of Usher’s
+      more in sad jest than in earnest; for, in truth, there is little
+      in its uncouth and unimaginative prolixity which could have had
+      interest for the lofty and spiritual ideality of my friend. It
+      was, however, the only book immediately at hand; and I indulged a
+      vague hope that the excitement which now agitated the
+      hypochondriac, might find relief (for the history of mental
+      disorder is full of similar anomalies) even in the extremeness of
+      the folly which I should read. Could I have judged, indeed, by
+      the wild overstrained air of vivacity with which he harkened, or
+      apparently harkened, to the words of the tale, I might well have
+      congratulated myself upon the success of my design.
+
+      I had arrived at that well-known portion of the story where
+      Ethelred, the hero of the Trist, having sought in vain for
+      peaceable admission into the dwelling of the hermit, proceeds to
+      make good an entrance by force. Here, it will be remembered, the
+      words of the narrative run thus:
+
+      “And Ethelred, who was by nature of a doughty heart, and who was
+      now mighty withal, on account of the powerfulness of the wine
+      which he had drunken, waited no longer to hold parley with the
+      hermit, who, in sooth, was of an obstinate and maliceful turn,
+      but, feeling the rain upon his shoulders, and fearing the rising
+      of the tempest, uplifted his mace outright, and, with blows, made
+      quickly room in the plankings of the door for his gauntleted
+      hand; and now pulling therewith sturdily, he so cracked, and
+      ripped, and tore all asunder, that the noise of the dry and
+      hollow-sounding wood alarummed and reverberated throughout the
+      forest.”
+
+      At the termination of this sentence I started, and for a moment,
+      paused; for it appeared to me (although I at once concluded that
+      my excited fancy had deceived me)—it appeared to me that, from
+      some very remote portion of the mansion, there came,
+      indistinctly, to my ears, what might have been, in its exact
+      similarity of character, the echo (but a stifled and dull one
+      certainly) of the very cracking and ripping sound which Sir
+      Launcelot had so particularly described. It was, beyond doubt,
+      the coincidence alone which had arrested my attention; for, amid
+      the rattling of the sashes of the casements, and the ordinary
+      commingled noises of the still increasing storm, the sound, in
+      itself, had nothing, surely, which should have interested or
+      disturbed me. I continued the story:
+
+      “But the good champion Ethelred, now entering within the door,
+      was sore enraged and amazed to perceive no signal of the
+      maliceful hermit; but, in the stead thereof, a dragon of a scaly
+      and prodigious demeanor, and of a fiery tongue, which sate in
+      guard before a palace of gold, with a floor of silver; and upon
+      the wall there hung a shield of shining brass with this legend
+      enwritten—
+
+     Who entereth herein, a conqueror hath bin;
+     Who slayeth the dragon, the shield he shall win;
+
+      And Ethelred uplifted his mace, and struck upon the head of the
+      dragon, which fell before him, and gave up his pesty breath, with
+      a shriek so horrid and harsh, and withal so piercing, that
+      Ethelred had fain to close his ears with his hands against the
+      dreadful noise of it, the like whereof was never before heard.”
+
+      Here again I paused abruptly, and now with a feeling of wild
+      amazement—for there could be no doubt whatever that, in this
+      instance, I did actually hear (although from what direction it
+      proceeded I found it impossible to say) a low and apparently
+      distant, but harsh, protracted, and most unusual screaming or
+      grating sound—the exact counterpart of what my fancy had already
+      conjured up for the dragon’s unnatural shriek as described by the
+      romancer.
+
+      Oppressed, as I certainly was, upon the occurrence of this second
+      and most extraordinary coincidence, by a thousand conflicting
+      sensations, in which wonder and extreme terror were predominant,
+      I still retained sufficient presence of mind to avoid exciting,
+      by any observation, the sensitive nervousness of my companion. I
+      was by no means certain that he had noticed the sounds in
+      question; although, assuredly, a strange alteration had, during
+      the last few minutes, taken place in his demeanor. From a
+      position fronting my own, he had gradually brought round his
+      chair, so as to sit with his face to the door of the chamber; and
+      thus I could but partially perceive his features, although I saw
+      that his lips trembled as if he were murmuring inaudibly. His
+      head had dropped upon his breast—yet I knew that he was not
+      asleep, from the wide and rigid opening of the eye as I caught a
+      glance of it in profile. The motion of his body, too, was at
+      variance with this idea—for he rocked from side to side with a
+      gentle yet constant and uniform sway. Having rapidly taken notice
+      of all this, I resumed the narrative of Sir Launcelot, which thus
+      proceeded:
+
+      “And now, the champion, having escaped from the terrible fury of
+      the dragon, bethinking himself of the brazen shield, and of the
+      breaking up of the enchantment which was upon it, removed the
+      carcass from out of the way before him, and approached valorously
+      over the silver pavement of the castle to where the shield was
+      upon the wall; which in sooth tarried not for his full coming,
+      but fell down at his feet upon the silver floor, with a mighty
+      great and terrible ringing sound.”
+
+      No sooner had these syllables passed my lips, than—as if a shield
+      of brass had indeed, at the moment, fallen heavily upon a floor
+      of silver—I became aware of a distinct, hollow, metallic, and
+      clangorous, yet apparently muffled reverberation. Completely
+      unnerved, I leaped to my feet; but the measured rocking movement
+      of Usher was undisturbed. I rushed to the chair in which he sat.
+      His eyes were bent fixedly before him, and throughout his whole
+      countenance there reigned a stony rigidity. But, as I placed my
+      hand upon his shoulder, there came a strong shudder over his
+      whole person; a sickly smile quivered about his lips; and I saw
+      that he spoke in a low, hurried, and gibbering murmur, as if
+      unconscious of my presence. Bending closely over him, I at length
+      drank in the hideous import of his words.
+
+      “Not hear it?—yes, I hear it, and _have_ heard it.
+      Long—long—long—many minutes, many hours, many days, have I heard
+      it—yet I dared not—oh, pity me, miserable wretch that I am!—I
+      dared not—I _dared_ not speak! _We have put her living in the
+      tomb!_ Said I not that my senses were acute? I _now_ tell you
+      that I heard her first feeble movements in the hollow coffin. I
+      heard them—many, many days ago—yet I dared not—_I dared not
+      speak!_ And now—to-night—Ethelred—ha! ha!—the breaking of the
+      hermit’s door, and the death-cry of the dragon, and the clangor
+      of the shield!—say, rather, the rending of her coffin, and the
+      grating of the iron hinges of her prison, and her struggles
+      within the coppered archway of the vault! Oh whither shall I fly?
+      Will she not be here anon? Is she not hurrying to upbraid me for
+      my haste? Have I not heard her footstep on the stair? Do I not
+      distinguish that heavy and horrible beating of her heart?
+      Madman!”—here he sprang furiously to his feet, and shrieked out
+      his syllables, as if in the effort he were giving up his
+      soul—“_Madman! I tell you that she now stands without the door!_”
+
+      As if in the superhuman energy of his utterance there had been
+      found the potency of a spell—the huge antique pannels to which
+      the speaker pointed, threw slowly back, upon the instant, their
+      ponderous and ebony jaws. It was the work of the rushing gust—but
+      then without those doors there _did_ stand the lofty and
+      enshrouded figure of the lady Madeline of Usher. There was blood
+      upon her white robes, and the evidence of some bitter struggle
+      upon every portion of her emaciated frame. For a moment she
+      remained trembling and reeling to and fro upon the
+      threshold—then, with a low moaning cry, fell heavily inward upon
+      the person of her brother, and in her violent and now final
+      death-agonies, bore him to the floor a corpse, and a victim to
+      the terrors he had anticipated.
+
+      From that chamber, and from that mansion, I fled aghast. The
+      storm was still abroad in all its wrath as I found myself
+      crossing the old causeway. Suddenly there shot along the path a
+      wild light, and I turned to see whence a gleam so unusual could
+      have issued; for the vast house and its shadows were alone behind
+      me. The radiance was that of the full, setting, and blood-red
+      moon, which now shone vividly through that once
+      barely-discernible fissure, of which I have before spoken as
+      extending from the roof of the building, in a zigzag direction,
+      to the base. While I gazed, this fissure rapidly widened—there
+      came a fierce breath of the whirlwind—the entire orb of the
+      satellite burst at once upon my sight—my brain reeled as I saw
+      the mighty walls rushing asunder—there was a long tumultuous
+      shouting sound like the voice of a thousand waters—and the deep
+      and dank tarn at my feet closed sullenly and silently over the
+      fragments of the “_House of Usher_.”
+
+
+
+
+SILENCE—A FABLE
+
+
+     “The mountain pinnacles slumber; valleys, crags and caves _are
+     silent_.”
+
+      “Listen to me,” said the Demon as he placed his hand upon my
+      head. “The region of which I speak is a dreary region in Libya,
+      by the borders of the river Zaire. And there is no quiet there,
+      nor silence.
+
+      “The waters of the river have a saffron and sickly hue; and they
+      flow not onwards to the sea, but palpitate forever and forever
+      beneath the red eye of the sun with a tumultuous and convulsive
+      motion. For many miles on either side of the river’s oozy bed is
+      a pale desert of gigantic water-lilies. They sigh one unto the
+      other in that solitude, and stretch towards the heaven their long
+      and ghastly necks, and nod to and fro their everlasting heads.
+      And there is an indistinct murmur which cometh out from among
+      them like the rushing of subterrene water. And they sigh one unto
+      the other.
+
+      “But there is a boundary to their realm—the boundary of the dark,
+      horrible, lofty forest. There, like the waves about the Hebrides,
+      the low underwood is agitated continually. But there is no wind
+      throughout the heaven. And the tall primeval trees rock eternally
+      hither and thither with a crashing and mighty sound. And from
+      their high summits, one by one, drop everlasting dews. And at the
+      roots strange poisonous flowers lie writhing in perturbed
+      slumber. And overhead, with a rustling and loud noise, the gray
+      clouds rush westwardly forever, until they roll, a cataract, over
+      the fiery wall of the horizon. But there is no wind throughout
+      the heaven. And by the shores of the river Zaire there is neither
+      quiet nor silence.
+
+      “It was night, and the rain fell; and falling, it was rain, but,
+      having fallen, it was blood. And I stood in the morass among the
+      tall and the rain fell upon my head—and the lilies sighed one
+      unto the other in the solemnity of their desolation.
+
+      “And, all at once, the moon arose through the thin ghastly mist,
+      and was crimson in color. And mine eyes fell upon a huge gray
+      rock which stood by the shore of the river, and was lighted by
+      the light of the moon. And the rock was gray, and ghastly, and
+      tall,—and the rock was gray. Upon its front were characters
+      engraven in the stone; and I walked through the morass of
+      water-lilies, until I came close unto the shore, that I might
+      read the characters upon the stone. But I could not decypher
+      them. And I was going back into the morass, when the moon shone
+      with a fuller red, and I turned and looked again upon the rock,
+      and upon the characters, and the characters were DESOLATION.
+
+      “And I looked upwards, and there stood a man upon the summit of
+      the rock; and I hid myself among the water-lilies that I might
+      discover the actions of the man. And the man was tall and stately
+      in form, and was wrapped up from his shoulders to his feet in the
+      toga of old Rome. And the outlines of his figure were
+      indistinct—but his features were the features of a deity; for the
+      mantle of the night, and of the mist, and of the moon, and of the
+      dew, had left uncovered the features of his face. And his brow
+      was lofty with thought, and his eye wild with care; and, in the
+      few furrows upon his cheek I read the fables of sorrow, and
+      weariness, and disgust with mankind, and a longing after
+      solitude.
+
+      “And the man sat upon the rock, and leaned his head upon his
+      hand, and looked out upon the desolation. He looked down into the
+      low unquiet shrubbery, and up into the tall primeval trees, and
+      up higher at the rustling heaven, and into the crimson moon. And
+      I lay close within shelter of the lilies, and observed the
+      actions of the man. And the man trembled in the solitude;—but the
+      night waned, and he sat upon the rock.
+
+      “And the man turned his attention from the heaven, and looked out
+      upon the dreary river Zaire, and upon the yellow ghastly waters,
+      and upon the pale legions of the water-lilies. And the man
+      listened to the sighs of the water-lilies, and to the murmur that
+      came up from among them. And I lay close within my covert and
+      observed the actions of the man. And the man trembled in the
+      solitude;—but the night waned and he sat upon the rock.
+
+      “Then I went down into the recesses of the morass, and waded afar
+      in among the wilderness of the lilies, and called unto the
+      hippopotami which dwelt among the fens in the recesses of the
+      morass. And the hippopotami heard my call, and came, with the
+      behemoth, unto the foot of the rock, and roared loudly and
+      fearfully beneath the moon. And I lay close within my covert and
+      observed the actions of the man. And the man trembled in the
+      solitude;—but the night waned and he sat upon the rock.
+
+      “Then I cursed the elements with the curse of tumult; and a
+      frightful tempest gathered in the heaven where, before, there had
+      been no wind. And the heaven became livid with the violence of
+      the tempest—and the rain beat upon the head of the man—and the
+      floods of the river came down—and the river was tormented into
+      foam—and the water-lilies shrieked within their beds—and the
+      forest crumbled before the wind—and the thunder rolled—and the
+      lightning fell—and the rock rocked to its foundation. And I lay
+      close within my covert and observed the actions of the man. And
+      the man trembled in the solitude;—but the night waned and he sat
+      upon the rock.
+
+      “Then I grew angry and cursed, with the curse of silence, the
+      river, and the lilies, and the wind, and the forest, and the
+      heaven, and the thunder, and the sighs of the water-lilies. And
+      they became accursed, and were still. And the moon ceased to
+      totter up its pathway to heaven—and the thunder died away—and the
+      lightning did not flash—and the clouds hung motionless—and the
+      waters sunk to their level and remained—and the trees ceased to
+      rock—and the water-lilies sighed no more—and the murmur was heard
+      no longer from among them, nor any shadow of sound throughout the
+      vast illimitable desert. And I looked upon the characters of the
+      rock, and they were changed; and the characters were SILENCE.
+
+      “And mine eyes fell upon the countenance of the man, and his
+      countenance was wan with terror. And, hurriedly, he raised his
+      head from his hand, and stood forth upon the rock and listened.
+      But there was no voice throughout the vast illimitable desert,
+      and the characters upon the rock were SILENCE. And the man
+      shuddered, and turned his face away, and fled afar off, in haste,
+      so that I beheld him no more.”
+
+      Now there are fine tales in the volumes of the Magi—in the
+      iron-bound, melancholy volumes of the Magi. Therein, I say, are
+      glorious histories of the Heaven, and of the Earth, and of the
+      mighty sea—and of the Genii that over-ruled the sea, and the
+      earth, and the lofty heaven. There was much lore too in the
+      sayings which were said by the Sybils; and holy, holy things were
+      heard of old by the dim leaves that trembled around Dodona—but,
+      as Allah liveth, that fable which the Demon told me as he sat by
+      my side in the shadow of the tomb, I hold to be the most
+      wonderful of all! And as the Demon made an end of his story, he
+      fell back within the cavity of the tomb and laughed. And I could
+      not laugh with the Demon, and he cursed me because I could not
+      laugh. And the lynx which dwelleth forever in the tomb, came out
+      therefrom, and lay down at the feet of the Demon, and looked at
+      him steadily in the face.
+
+
+
+
+THE MASQUE OF THE RED DEATH.
+
+
+      The “Red Death” had long devastated the country. No pestilence
+      had ever been so fatal, or so hideous. Blood was its Avatar and
+      its seal—the redness and the horror of blood. There were sharp
+      pains, and sudden dizziness, and then profuse bleeding at the
+      pores, with dissolution. The scarlet stains upon the body and
+      especially upon the face of the victim, were the pest ban which
+      shut him out from the aid and from the sympathy of his
+      fellow-men. And the whole seizure, progress and termination of
+      the disease, were the incidents of half an hour.
+
+      But the Prince Prospero was happy and dauntless and sagacious.
+      When his dominions were half depopulated, he summoned to his
+      presence a thousand hale and light-hearted friends from among the
+      knights and dames of his court, and with these retired to the
+      deep seclusion of one of his castellated abbeys. This was an
+      extensive and magnificent structure, the creation of the prince’s
+      own eccentric yet august taste. A strong and lofty wall girdled
+      it in. This wall had gates of iron. The courtiers, having
+      entered, brought furnaces and massy hammers and welded the bolts.
+      They resolved to leave means neither of ingress or egress to the
+      sudden impulses of despair or of frenzy from within. The abbey
+      was amply provisioned. With such precautions the courtiers might
+      bid defiance to contagion. The external world could take care of
+      itself. In the meantime it was folly to grieve, or to think. The
+      prince had provided all the appliances of pleasure. There were
+      buffoons, there were improvisatori, there were ballet-dancers,
+      there were musicians, there was Beauty, there was wine. All these
+      and security were within. Without was the “Red Death.”
+
+      It was toward the close of the fifth or sixth month of his
+      seclusion, and while the pestilence raged most furiously abroad,
+      that the Prince Prospero entertained his thousand friends at a
+      masked ball of the most unusual magnificence.
+
+      It was a voluptuous scene, that masquerade. But first let me tell
+      of the rooms in which it was held. There were seven—an imperial
+      suite. In many palaces, however, such suites form a long and
+      straight vista, while the folding doors slide back nearly to the
+      walls on either hand, so that the view of the whole extent is
+      scarcely impeded. Here the case was very different; as might have
+      been expected from the duke’s love of the bizarre. The apartments
+      were so irregularly disposed that the vision embraced but little
+      more than one at a time. There was a sharp turn at every twenty
+      or thirty yards, and at each turn a novel effect. To the right
+      and left, in the middle of each wall, a tall and narrow Gothic
+      window looked out upon a closed corridor which pursued the
+      windings of the suite. These windows were of stained glass whose
+      color varied in accordance with the prevailing hue of the
+      decorations of the chamber into which it opened. That at the
+      eastern extremity was hung, for example, in blue—and vividly blue
+      were its windows. The second chamber was purple in its ornaments
+      and tapestries, and here the panes were purple. The third was
+      green throughout, and so were the casements. The fourth was
+      furnished and lighted with orange—the fifth with white—the sixth
+      with violet. The seventh apartment was closely shrouded in black
+      velvet tapestries that hung all over the ceiling and down the
+      walls, falling in heavy folds upon a carpet of the same material
+      and hue. But in this chamber only, the color of the windows
+      failed to correspond with the decorations. The panes here were
+      scarlet—a deep blood color. Now in no one of the seven apartments
+      was there any lamp or candelabrum, amid the profusion of golden
+      ornaments that lay scattered to and fro or depended from the
+      roof. There was no light of any kind emanating from lamp or
+      candle within the suite of chambers. But in the corridors that
+      followed the suite, there stood, opposite to each window, a heavy
+      tripod, bearing a brazier of fire that projected its rays through
+      the tinted glass and so glaringly illumined the room. And thus
+      were produced a multitude of gaudy and fantastic appearances. But
+      in the western or black chamber the effect of the fire-light that
+      streamed upon the dark hangings through the blood-tinted panes,
+      was ghastly in the extreme, and produced so wild a look upon the
+      countenances of those who entered, that there were few of the
+      company bold enough to set foot within its precincts at all.
+
+      It was in this apartment, also, that there stood against the
+      western wall, a gigantic clock of ebony. Its pendulum swung to
+      and fro with a dull, heavy, monotonous clang; and when the
+      minute-hand made the circuit of the face, and the hour was to be
+      stricken, there came from the brazen lungs of the clock a sound
+      which was clear and loud and deep and exceedingly musical, but of
+      so peculiar a note and emphasis that, at each lapse of an hour,
+      the musicians of the orchestra were constrained to pause,
+      momentarily, in their performance, to hearken to the sound; and
+      thus the waltzers perforce ceased their evolutions; and there was
+      a brief disconcert of the whole gay company; and, while the
+      chimes of the clock yet rang, it was observed that the giddiest
+      grew pale, and the more aged and sedate passed their hands over
+      their brows as if in confused reverie or meditation. But when the
+      echoes had fully ceased, a light laughter at once pervaded the
+      assembly; the musicians looked at each other and smiled as if at
+      their own nervousness and folly, and made whispering vows, each
+      to the other, that the next chiming of the clock should produce
+      in them no similar emotion; and then, after the lapse of sixty
+      minutes (which embrace three thousand and six hundred seconds of
+      the Time that flies), there came yet another chiming of the
+      clock, and then were the same disconcert and tremulousness and
+      meditation as before.
+
+      But, in spite of these things, it was a gay and magnificent
+      revel. The tastes of the duke were peculiar. He had a fine eye
+      for colors and effects. He disregarded the decora of mere
+      fashion. His plans were bold and fiery, and his conceptions
+      glowed with barbaric lustre. There are some who would have
+      thought him mad. His followers felt that he was not. It was
+      necessary to hear and see and touch him to be sure that he was
+      not.
+
+      He had directed, in great part, the moveable embellishments of
+      the seven chambers, upon occasion of this great fête; and it was
+      his own guiding taste which had given character to the
+      masqueraders. Be sure they were grotesque. There were much glare
+      and glitter and piquancy and phantasm—much of what has been since
+      seen in “Hernani.” There were arabesque figures with unsuited
+      limbs and appointments. There were delirious fancies such as the
+      madman fashions. There was much of the beautiful, much of the
+      wanton, much of the bizarre, something of the terrible, and not a
+      little of that which might have excited disgust. To and fro in
+      the seven chambers there stalked, in fact, a multitude of dreams.
+      And these—the dreams—writhed in and about, taking hue from the
+      rooms, and causing the wild music of the orchestra to seem as the
+      echo of their steps. And, anon, there strikes the ebony clock
+      which stands in the hall of the velvet. And then, for a moment,
+      all is still, and all is silent save the voice of the clock. The
+      dreams are stiff-frozen as they stand. But the echoes of the
+      chime die away—they have endured but an instant—and a light,
+      half-subdued laughter floats after them as they depart. And now
+      again the music swells, and the dreams live, and writhe to and
+      fro more merrily than ever, taking hue from the many-tinted
+      windows through which stream the rays from the tripods. But to
+      the chamber which lies most westwardly of the seven, there are
+      now none of the maskers who venture; for the night is waning
+      away; and there flows a ruddier light through the blood-colored
+      panes; and the blackness of the sable drapery appals; and to him
+      whose foot falls upon the sable carpet, there comes from the near
+      clock of ebony a muffled peal more solemnly emphatic than any
+      which reaches their ears who indulge in the more remote gaieties
+      of the other apartments.
+
+      But these other apartments were densely crowded, and in them beat
+      feverishly the heart of life. And the revel went whirlingly on,
+      until at length there commenced the sounding of midnight upon the
+      clock. And then the music ceased, as I have told; and the
+      evolutions of the waltzers were quieted; and there was an uneasy
+      cessation of all things as before. But now there were twelve
+      strokes to be sounded by the bell of the clock; and thus it
+      happened, perhaps, that more of thought crept, with more of time,
+      into the meditations of the thoughtful among those who revelled.
+      And thus, too, it happened, perhaps, that before the last echoes
+      of the last chime had utterly sunk into silence, there were many
+      individuals in the crowd who had found leisure to become aware of
+      the presence of a masked figure which had arrested the attention
+      of no single individual before. And the rumor of this new
+      presence having spread itself whisperingly around, there arose at
+      length from the whole company a buzz, or murmur, expressive of
+      disapprobation and surprise—then, finally, of terror, of horror,
+      and of disgust.
+
+      In an assembly of phantasms such as I have painted, it may well
+      be supposed that no ordinary appearance could have excited such
+      sensation. In truth the masquerade license of the night was
+      nearly unlimited; but the figure in question had out-Heroded
+      Herod, and gone beyond the bounds of even the prince’s indefinite
+      decorum. There are chords in the hearts of the most reckless
+      which cannot be touched without emotion. Even with the utterly
+      lost, to whom life and death are equally jests, there are matters
+      of which no jest can be made. The whole company, indeed, seemed
+      now deeply to feel that in the costume and bearing of the
+      stranger neither wit nor propriety existed. The figure was tall
+      and gaunt, and shrouded from head to foot in the habiliments of
+      the grave. The mask which concealed the visage was made so nearly
+      to resemble the countenance of a stiffened corpse that the
+      closest scrutiny must have had difficulty in detecting the cheat.
+      And yet all this might have been endured, if not approved, by the
+      mad revellers around. But the mummer had gone so far as to assume
+      the type of the Red Death. His vesture was dabbled in blood—and
+      his broad brow, with all the features of the face, was
+      besprinkled with the scarlet horror.
+
+      When the eyes of Prince Prospero fell upon this spectral image
+      (which with a slow and solemn movement, as if more fully to
+      sustain its role, stalked to and fro among the waltzers) he was
+      seen to be convulsed, in the first moment with a strong shudder
+      either of terror or distaste; but, in the next, his brow reddened
+      with rage.
+
+      “Who dares?” he demanded hoarsely of the courtiers who stood near
+      him—“who dares insult us with this blasphemous mockery? Seize him
+      and unmask him—that we may know whom we have to hang at sunrise,
+      from the battlements!”
+
+      It was in the eastern or blue chamber in which stood the Prince
+      Prospero as he uttered these words. They rang throughout the
+      seven rooms loudly and clearly—for the prince was a bold and
+      robust man, and the music had become hushed at the waving of his
+      hand.
+
+      It was in the blue room where stood the prince, with a group of
+      pale courtiers by his side. At first, as he spoke, there was a
+      slight rushing movement of this group in the direction of the
+      intruder, who at the moment was also near at hand, and now, with
+      deliberate and stately step, made closer approach to the speaker.
+      But from a certain nameless awe with which the mad assumptions of
+      the mummer had inspired the whole party, there were found none
+      who put forth hand to seize him; so that, unimpeded, he passed
+      within a yard of the prince’s person; and, while the vast
+      assembly, as if with one impulse, shrank from the centres of the
+      rooms to the walls, he made his way uninterruptedly, but with the
+      same solemn and measured step which had distinguished him from
+      the first, through the blue chamber to the purple—through the
+      purple to the green—through the green to the orange—through this
+      again to the white—and even thence to the violet, ere a decided
+      movement had been made to arrest him. It was then, however, that
+      the Prince Prospero, maddening with rage and the shame of his own
+      momentary cowardice, rushed hurriedly through the six chambers,
+      while none followed him on account of a deadly terror that had
+      seized upon all. He bore aloft a drawn dagger, and had
+      approached, in rapid impetuosity, to within three or four feet of
+      the retreating figure, when the latter, having attained the
+      extremity of the velvet apartment, turned suddenly and confronted
+      his pursuer. There was a sharp cry—and the dagger dropped
+      gleaming upon the sable carpet, upon which, instantly afterwards,
+      fell prostrate in death the Prince Prospero. Then, summoning the
+      wild courage of despair, a throng of the revellers at once threw
+      themselves into the black apartment, and, seizing the mummer,
+      whose tall figure stood erect and motionless within the shadow of
+      the ebony clock, gasped in unutterable horror at finding the
+      grave-cerements and corpse-like mask which they handled with so
+      violent a rudeness, untenanted by any tangible form.
+
+      And now was acknowledged the presence of the Red Death. He had
+      come like a thief in the night. And one by one dropped the
+      revellers in the blood-bedewed halls of their revel, and died
+      each in the despairing posture of his fall. And the life of the
+      ebony clock went out with that of the last of the gay. And the
+      flames of the tripods expired. And Darkness and Decay and the Red
+      Death held illimitable dominion over all.
+
+
+
+
+THE CASK OF AMONTILLADO.
+
+
+      The thousand injuries of Fortunato I had borne as I best could;
+      but when he ventured upon insult, I vowed revenge. You, who so
+      well know the nature of my soul, will not suppose, however, that
+      I gave utterance to a threat. _At length_ I would be avenged;
+      this was a point definitively settled—but the very definitiveness
+      with which it was resolved, precluded the idea of risk. I must
+      not only punish, but punish with impunity. A wrong is unredressed
+      when retribution overtakes its redresser. It is equally
+      unredressed when the avenger fails to make himself felt as such
+      to him who has done the wrong.
+
+      It must be understood, that neither by word nor deed had I given
+      Fortunato cause to doubt my good will. I continued, as was my
+      wont, to smile in his face, and he did not perceive that my smile
+      _now_ was at the thought of his immolation.
+
+      He had a weak point—this Fortunato—although in other regards he
+      was a man to be respected and even feared. He prided himself on
+      his connoisseurship in wine. Few Italians have the true virtuoso
+      spirit. For the most part their enthusiasm is adopted to suit the
+      time and opportunity—to practise imposture upon the British and
+      Austrian _millionaires_. In painting and gemmary, Fortunato, like
+      his countrymen, was a quack—but in the matter of old wines he was
+      sincere. In this respect I did not differ from him materially: I
+      was skilful in the Italian vintages myself, and bought largely
+      whenever I could.
+
+      It was about dusk, one evening during the supreme madness of the
+      carnival season, that I encountered my friend. He accosted me
+      with excessive warmth, for he had been drinking much. The man
+      wore motley. He had on a tight-fitting parti-striped dress, and
+      his head was surmounted by the conical cap and bells. I was so
+      pleased to see him, that I thought I should never have done
+      wringing his hand.
+
+      I said to him: “My dear Fortunato, you are luckily met. How
+      remarkably well you are looking to-day! But I have received a
+      pipe of what passes for Amontillado, and I have my doubts.”
+
+      “How?” said he. “Amontillado? A pipe? Impossible! And in the
+      middle of the carnival!”
+
+      “I have my doubts,” I replied; “and I was silly enough to pay the
+      full Amontillado price without consulting you in the matter. You
+      were not to be found, and I was fearful of losing a bargain.”
+
+      “Amontillado!”
+
+      “I have my doubts.”
+
+      “Amontillado!”
+
+      “And I must satisfy them.”
+
+      “Amontillado!”
+
+      “As you are engaged, I am on my way to Luchesi. If any one has a
+      critical turn, it is he. He will tell me—”
+
+      “Luchesi cannot tell Amontillado from Sherry.”
+
+      “And yet some fools will have it that his taste is a match for
+      your own.”
+
+      “Come, let us go.”
+
+      “Whither?”
+
+      “To your vaults.”
+
+      “My friend, no; I will not impose upon your good nature. I
+      perceive you have an engagement. Luchesi—”
+
+      “I have no engagement;—come.”
+
+      “My friend, no. It is not the engagement, but the severe cold
+      with which I perceive you are afflicted. The vaults are
+      insufferably damp. They are encrusted with nitre.”
+
+      “Let us go, nevertheless. The cold is merely nothing.
+      Amontillado! You have been imposed upon. And as for Luchesi, he
+      cannot distinguish Sherry from Amontillado.”
+
+      Thus speaking, Fortunato possessed himself of my arm. Putting on
+      a mask of black silk, and drawing a _roquelaire_ closely about my
+      person, I suffered him to hurry me to my palazzo.
+
+      There were no attendants at home; they had absconded to make
+      merry in honor of the time. I had told them that I should not
+      return until the morning, and had given them explicit orders not
+      to stir from the house. These orders were sufficient, I well
+      knew, to insure their immediate disappearance, one and all, as
+      soon as my back was turned.
+
+      I took from their sconces two flambeaux, and giving one to
+      Fortunato, bowed him through several suites of rooms to the
+      archway that led into the vaults. I passed down a long and
+      winding staircase, requesting him to be cautious as he followed.
+      We came at length to the foot of the descent, and stood together
+      on the damp ground of the catacombs of the Montresors.
+
+      The gait of my friend was unsteady, and the bells upon his cap
+      jingled as he strode.
+
+      “The pipe,” said he.
+
+      “It is farther on,” said I; “but observe the white web-work which
+      gleams from these cavern walls.”
+
+      He turned towards me, and looked into my eyes with two filmy orbs
+      that distilled the rheum of intoxication.
+
+      “Nitre?” he asked, at length.
+
+      “Nitre,” I replied. “How long have you had that cough?”
+
+      “Ugh! ugh! ugh!—ugh! ugh! ugh!—ugh! ugh! ugh!—ugh! ugh! ugh!—ugh!
+      ugh! ugh!”
+
+      My poor friend found it impossible to reply for many minutes.
+
+      “It is nothing,” he said, at last.
+
+      “Come,” I said, with decision, “we will go back; your health is
+      precious. You are rich, respected, admired, beloved; you are
+      happy, as once I was. You are a man to be missed. For me it is no
+      matter. We will go back; you will be ill, and I cannot be
+      responsible. Besides, there is Luchesi—”
+
+      “Enough,” he said; “the cough is a mere nothing; it will not kill
+      me. I shall not die of a cough.”
+
+      “True—true,” I replied; “and, indeed, I had no intention of
+      alarming you unnecessarily—but you should use all proper caution.
+      A draught of this Medoc will defend us from the damps.”
+
+      Here I knocked off the neck of a bottle which I drew from a long
+      row of its fellows that lay upon the mould.
+
+      “Drink,” I said, presenting him the wine.
+
+      He raised it to his lips with a leer. He paused and nodded to me
+      familiarly, while his bells jingled.
+
+      “I drink,” he said, “to the buried that repose around us.”
+
+      “And I to your long life.”
+
+      He again took my arm, and we proceeded.
+
+      “These vaults,” he said, “are extensive.”
+
+      “The Montresors,” I replied, “were a great and numerous family.”
+
+      “I forget your arms.”
+
+      “A huge human foot d’or, in a field azure; the foot crushes a
+      serpent rampant whose fangs are imbedded in the heel.”
+
+      “And the motto?”
+
+      “_Nemo me impune lacessit_.”
+
+      “Good!” he said.
+
+      The wine sparkled in his eyes and the bells jingled. My own fancy
+      grew warm with the Medoc. We had passed through walls of piled
+      bones, with casks and puncheons intermingling, into the inmost
+      recesses of the catacombs. I paused again, and this time I made
+      bold to seize Fortunato by an arm above the elbow.
+
+      “The nitre!” I said: “see, it increases. It hangs like moss upon
+      the vaults. We are below the river’s bed. The drops of moisture
+      trickle among the bones. Come, we will go back ere it is too
+      late. Your cough—”
+
+      “It is nothing,” he said; “let us go on. But first, another
+      draught of the Medoc.”
+
+      I broke and reached him a flagon of De Grâve. He emptied it at a
+      breath. His eyes flashed with a fierce light. He laughed and
+      threw the bottle upwards with a gesticulation I did not
+      understand.
+
+      I looked at him in surprise. He repeated the movement—a grotesque
+      one.
+
+      “You do not comprehend?” he said.
+
+      “Not I,” I replied.
+
+      “Then you are not of the brotherhood.”
+
+      “How?”
+
+      “You are not of the masons.”
+
+      “Yes, yes,” I said, “yes, yes.”
+
+      “You? Impossible! A mason?”
+
+      “A mason,” I replied.
+
+      “A sign,” he said.
+
+      “It is this,” I answered, producing a trowel from beneath the
+      folds of my _roquelaire_.
+
+      “You jest,” he exclaimed, recoiling a few paces. “But let us
+      proceed to the Amontillado.”
+
+      “Be it so,” I said, replacing the tool beneath the cloak, and
+      again offering him my arm. He leaned upon it heavily. We
+      continued our route in search of the Amontillado. We passed
+      through a range of low arches, descended, passed on, and
+      descending again, arrived at a deep crypt, in which the foulness
+      of the air caused our flambeaux rather to glow than flame.
+
+      At the most remote end of the crypt there appeared another less
+      spacious. Its walls had been lined with human remains, piled to
+      the vault overhead, in the fashion of the great catacombs of
+      Paris. Three sides of this interior crypt were still ornamented
+      in this manner. From the fourth the bones had been thrown down,
+      and lay promiscuously upon the earth, forming at one point a
+      mound of some size. Within the wall thus exposed by the
+      displacing of the bones, we perceived a still interior recess, in
+      depth about four feet, in width three, in height six or seven. It
+      seemed to have been constructed for no especial use in itself,
+      but formed merely the interval between two of the colossal
+      supports of the roof of the catacombs, and was backed by one of
+      their circumscribing walls of solid granite.
+
+      It was in vain that Fortunato, uplifting his dull torch,
+      endeavored to pry into the depths of the recess. Its termination
+      the feeble light did not enable us to see.
+
+      “Proceed,” I said; “herein is the Amontillado. As for Luchesi—”
+
+      “He is an ignoramus,” interrupted my friend, as he stepped
+      unsteadily forward, while I followed immediately at his heels. In
+      an instant he had reached the extremity of the niche, and finding
+      his progress arrested by the rock, stood stupidly bewildered. A
+      moment more and I had fettered him to the granite. In its surface
+      were two iron staples, distant from each other about two feet,
+      horizontally. From one of these depended a short chain, from the
+      other a padlock. Throwing the links about his waist, it was but
+      the work of a few seconds to secure it. He was too much astounded
+      to resist. Withdrawing the key I stepped back from the recess.
+
+      “Pass your hand,” I said, “over the wall; you cannot help feeling
+      the nitre. Indeed it is _very_ damp. Once more let me _implore_
+      you to return. No? Then I must positively leave you. But I must
+      first render you all the little attentions in my power.”
+
+      “The Amontillado!” ejaculated my friend, not yet recovered from
+      his astonishment.
+
+      “True,” I replied; “the Amontillado.”
+
+      As I said these words I busied myself among the pile of bones of
+      which I have before spoken. Throwing them aside, I soon uncovered
+      a quantity of building stone and mortar. With these materials and
+      with the aid of my trowel, I began vigorously to wall up the
+      entrance of the niche.
+
+      I had scarcely laid the first tier of my masonry when I
+      discovered that the intoxication of Fortunato had in a great
+      measure worn off. The earliest indication I had of this was a low
+      moaning cry from the depth of the recess. It was _not_ the cry of
+      a drunken man. There was then a long and obstinate silence. I
+      laid the second tier, and the third, and the fourth; and then I
+      heard the furious vibrations of the chain. The noise lasted for
+      several minutes, during which, that I might hearken to it with
+      the more satisfaction, I ceased my labors and sat down upon the
+      bones. When at last the clanking subsided, I resumed the trowel,
+      and finished without interruption the fifth, the sixth, and the
+      seventh tier. The wall was now nearly upon a level with my
+      breast. I again paused, and holding the flambeaux over the
+      mason-work, threw a few feeble rays upon the figure within.
+
+      A succession of loud and shrill screams, bursting suddenly from
+      the throat of the chained form, seemed to thrust me violently
+      back. For a brief moment I hesitated—I trembled. Unsheathing my
+      rapier, I began to grope with it about the recess; but the
+      thought of an instant reassured me. I placed my hand upon the
+      solid fabric of the catacombs, and felt satisfied. I reapproached
+      the wall. I replied to the yells of him who clamored. I
+      re-echoed—I aided—I surpassed them in volume and in strength. I
+      did this, and the clamorer grew still.
+
+      It was now midnight, and my task was drawing to a close. I had
+      completed the eighth, the ninth, and the tenth tier. I had
+      finished a portion of the last and the eleventh; there remained
+      but a single stone to be fitted and plastered in. I struggled
+      with its weight; I placed it partially in its destined position.
+      But now there came from out the niche a low laugh that erected
+      the hairs upon my head. It was succeeded by a sad voice, which I
+      had difficulty in recognising as that of the noble Fortunato. The
+      voice said—
+
+      “Ha! ha! ha!—he! he!—a very good joke indeed—an excellent jest.
+      We will have many a rich laugh about it at the palazzo—he! he!
+      he!—over our wine—he! he! he!”
+
+      “The Amontillado!” I said.
+
+      “He! he! he!—he! he! he!—yes, the Amontillado. But is it not
+      getting late? Will not they be awaiting us at the palazzo, the
+      Lady Fortunato and the rest? Let us be gone.”
+
+      “Yes,” I said, “let us be gone.”
+
+      “_For the love of God, Montressor!_”
+
+      “Yes,” I said, “for the love of God!”
+
+      But to these words I hearkened in vain for a reply. I grew
+      impatient. I called aloud—
+
+      “Fortunato!”
+
+      No answer. I called again—
+
+      “Fortunato!”
+
+      No answer still. I thrust a torch through the remaining aperture
+      and let it fall within. There came forth in return only a
+      jingling of the bells. My heart grew sick—on account of the
+      dampness of the catacombs. I hastened to make an end of my labor.
+      I forced the last stone into its position; I plastered it up.
+      Against the new masonry I re-erected the old rampart of bones.
+      For the half of a century no mortal has disturbed them. _In pace
+      requiescat!_
+
+
+
+
+THE IMP OF THE PERVERSE
+
+
+      In the consideration of the faculties and impulses—of the prima
+      mobilia of the human soul, the phrenologists have failed to make
+      room for a propensity which, although obviously existing as a
+      radical, primitive, irreducible sentiment, has been equally
+      overlooked by all the moralists who have preceded them. In the
+      pure arrogance of the reason, we have all overlooked it. We have
+      suffered its existence to escape our senses, solely through want
+      of belief—of faith;—whether it be faith in Revelation, or faith
+      in the Kabbala. The idea of it has never occurred to us, simply
+      because of its supererogation. We saw no need of the impulse—for
+      the propensity. We could not perceive its necessity. We could not
+      understand, that is to say, we could not have understood, had the
+      notion of this primum mobile ever obtruded itself;—we could not
+      have understood in what manner it might be made to further the
+      objects of humanity, either temporal or eternal. It cannot be
+      denied that phrenology and, in great measure, all
+      metaphysicianism have been concocted a priori. The intellectual
+      or logical man, rather than the understanding or observant man,
+      set himself to imagine designs—to dictate purposes to God. Having
+      thus fathomed, to his satisfaction, the intentions of Jehovah,
+      out of these intentions he built his innumerable systems of mind.
+      In the matter of phrenology, for example, we first determined,
+      naturally enough, that it was the design of the Deity that man
+      should eat. We then assigned to man an organ of alimentiveness,
+      and this organ is the scourge with which the Deity compels man,
+      will-I nill-I, into eating. Secondly, having settled it to be
+      God’s will that man should continue his species, we discovered an
+      organ of amativeness, forthwith. And so with combativeness, with
+      ideality, with causality, with constructiveness,—so, in short,
+      with every organ, whether representing a propensity, a moral
+      sentiment, or a faculty of the pure intellect. And in these
+      arrangements of the Principia of human action, the Spurzheimites,
+      whether right or wrong, in part, or upon the whole, have but
+      followed, in principle, the footsteps of their predecessors;
+      deducing and establishing every thing from the preconceived
+      destiny of man, and upon the ground of the objects of his
+      Creator.
+
+      It would have been wiser, it would have been safer, to classify
+      (if classify we must) upon the basis of what man usually or
+      occasionally did, and was always occasionally doing, rather than
+      upon the basis of what we took it for granted the Deity intended
+      him to do. If we cannot comprehend God in his visible works, how
+      then in his inconceivable thoughts, that call the works into
+      being? If we cannot understand him in his objective creatures,
+      how then in his substantive moods and phases of creation?
+
+      Induction, _a posteriori_, would have brought phrenology to
+      admit, as an innate and primitive principle of human action, a
+      paradoxical something, which we may call _perverseness_, for want
+      of a more characteristic term. In the sense I intend, it is, in
+      fact, a _mobile_ without motive, a motive not _motivirt_. Through
+      its promptings we act without comprehensible object; or, if this
+      shall be understood as a contradiction in terms, we may so far
+      modify the proposition as to say, that through its promptings we
+      act, for the reason that we should _not_. In theory, no reason
+      can be more unreasonable, but, in fact, there is none more
+      strong. With certain minds, under certain conditions, it becomes
+      absolutely irresistible. I am not more certain that I breathe,
+      than that the assurance of the wrong or error of any action is
+      often the one unconquerable _force_ which impels us, and alone
+      impels us to its prosecution. Nor will this overwhelming tendency
+      to do wrong for the wrong’s sake, admit of analysis, or
+      resolution into ulterior elements. It is a radical, a primitive
+      impulse—elementary. It will be said, I am aware, that when we
+      persist in acts because we feel we should not persist in them,
+      our conduct is but a modification of that which ordinarily
+      springs from the combativeness of phrenology. But a glance will
+      show the fallacy of this idea. The phrenological combativeness
+      has for its essence, the necessity of self-defence. It is our
+      safeguard against injury. Its principle regards our well-being;
+      and thus the desire to be well is excited simultaneously with its
+      development. It follows, that the desire to be well must be
+      excited simultaneously with any principle which shall be merely a
+      modification of combativeness, but in the case of that something
+      which I term perverseness, the desire to be well is not only not
+      aroused, but a strongly antagonistical sentiment exists.
+
+      An appeal to one’s own heart is, after all, the best reply to the
+      sophistry just noticed. No one who trustingly consults and
+      thoroughly questions his own soul, will be disposed to deny the
+      entire radicalness of the propensity in question. It is not more
+      incomprehensible than distinctive. There lives no man who at some
+      period has not been tormented, for example, by an earnest desire
+      to tantalize a listener by circumlocution. The speaker is aware
+      that he displeases; he has every intention to please, he is
+      usually curt, precise, and clear; the most laconic and luminous
+      language is struggling for utterance upon his tongue; it is only
+      with difficulty that he restrains himself from giving it flow; he
+      dreads and deprecates the anger of him whom he addresses; yet,
+      the thought strikes him, that by certain involutions and
+      parentheses this anger may be engendered. That single thought is
+      enough. The impulse increases to a wish, the wish to a desire,
+      the desire to an uncontrollable longing, and the longing (to the
+      deep regret and mortification of the speaker, and in defiance of
+      all consequences) is indulged.
+
+      We have a task before us which must be speedily performed. We
+      know that it will be ruinous to make delay. The most important
+      crisis of our life calls, trumpet-tongued, for immediate energy
+      and action. We glow, we are consumed with eagerness to commence
+      the work, with the anticipation of whose glorious result our
+      whole souls are on fire. It must, it shall be undertaken to-day,
+      and yet we put it off until to-morrow; and why? There is no
+      answer, except that we feel perverse, using the word with no
+      comprehension of the principle. To-morrow arrives, and with it a
+      more impatient anxiety to do our duty, but with this very
+      increase of anxiety arrives, also, a nameless, a positively
+      fearful, because unfathomable, craving for delay. This craving
+      gathers strength as the moments fly. The last hour for action is
+      at hand. We tremble with the violence of the conflict within
+      us,—of the definite with the indefinite—of the substance with the
+      shadow. But, if the contest have proceeded thus far, it is the
+      shadow which prevails,—we struggle in vain. The clock strikes,
+      and is the knell of our welfare. At the same time, it is the
+      chanticleer-note to the ghost that has so long overawed us. It
+      flies—it disappears—we are free. The old energy returns. We will
+      labor now. Alas, it is too late!
+
+      We stand upon the brink of a precipice. We peer into the abyss—we
+      grow sick and dizzy. Our first impulse is to shrink from the
+      danger. Unaccountably we remain. By slow degrees our sickness and
+      dizziness and horror become merged in a cloud of unnamable
+      feeling. By gradations, still more imperceptible, this cloud
+      assumes shape, as did the vapor from the bottle out of which
+      arose the genius in the Arabian Nights. But out of this our cloud
+      upon the precipice’s edge, there grows into palpability, a shape,
+      far more terrible than any genius or any demon of a tale, and yet
+      it is but a thought, although a fearful one, and one which chills
+      the very marrow of our bones with the fierceness of the delight
+      of its horror. It is merely the idea of what would be our
+      sensations during the sweeping precipitancy of a fall from such a
+      height. And this fall—this rushing annihilation—for the very
+      reason that it involves that one most ghastly and loathsome of
+      all the most ghastly and loathsome images of death and suffering
+      which have ever presented themselves to our imagination—for this
+      very cause do we now the most vividly desire it. And because our
+      reason violently deters us from the brink, therefore do we the
+      most impetuously approach it. There is no passion in nature so
+      demoniacally impatient, as that of him who, shuddering upon the
+      edge of a precipice, thus meditates a plunge. To indulge, for a
+      moment, in any attempt at thought, is to be inevitably lost; for
+      reflection but urges us to forbear, and therefore it is, I say,
+      that we cannot. If there be no friendly arm to check us, or if we
+      fail in a sudden effort to prostrate ourselves backward from the
+      abyss, we plunge, and are destroyed.
+
+      Examine these similar actions as we will, we shall find them
+      resulting solely from the spirit of the Perverse. We perpetrate
+      them because we feel that we should not. Beyond or behind this
+      there is no intelligible principle; and we might, indeed, deem
+      this perverseness a direct instigation of the Arch-Fiend, were it
+      not occasionally known to operate in furtherance of good.
+
+      I have said thus much, that in some measure I may answer your
+      question—that I may explain to you why I am here—that I may
+      assign to you something that shall have at least the faint aspect
+      of a cause for my wearing these fetters, and for my tenanting
+      this cell of the condemned. Had I not been thus prolix, you might
+      either have misunderstood me altogether, or, with the rabble,
+      have fancied me mad. As it is, you will easily perceive that I am
+      one of the many uncounted victims of the Imp of the Perverse.
+
+      It is impossible that any deed could have been wrought with a
+      more thorough deliberation. For weeks, for months, I pondered
+      upon the means of the murder. I rejected a thousand schemes,
+      because their accomplishment involved a _chance_ of detection. At
+      length, in reading some French memoirs, I found an account of a
+      nearly fatal illness that occurred to Madame Pilau, through the
+      agency of a candle accidentally poisoned. The idea struck my
+      fancy at once. I knew my victim’s habit of reading in bed. I
+      knew, too, that his apartment was narrow and ill-ventilated. But
+      I need not vex you with impertinent details. I need not describe
+      the easy artifices by which I substituted, in his bed-room
+      candle-stand, a wax-light of my own making for the one which I
+      there found. The next morning he was discovered dead in his bed,
+      and the coroner’s verdict was—“Death by the visitation of God.”
+
+      Having inherited his estate, all went well with me for years. The
+      idea of detection never once entered my brain. Of the remains of
+      the fatal taper I had myself carefully disposed. I had left no
+      shadow of a clew by which it would be possible to convict, or
+      even to suspect me of the crime. It is inconceivable how rich a
+      sentiment of satisfaction arose in my bosom as I reflected upon
+      my absolute security. For a very long period of time I was
+      accustomed to revel in this sentiment. It afforded me more real
+      delight than all the mere worldly advantages accruing from my
+      sin. But there arrived at length an epoch, from which the
+      pleasurable feeling grew, by scarcely perceptible gradations,
+      into a haunting and harassing thought. It harassed because it
+      haunted. I could scarcely get rid of it for an instant. It is
+      quite a common thing to be thus annoyed with the ringing in our
+      ears, or rather in our memories, of the burthen of some ordinary
+      song, or some unimpressive snatches from an opera. Nor will we be
+      the less tormented if the song in itself be good, or the opera
+      air meritorious. In this manner, at last, I would perpetually
+      catch myself pondering upon my security, and repeating, in a low
+      undertone, the phrase, “I am safe.”
+
+      One day, whilst sauntering along the streets, I arrested myself
+      in the act of murmuring, half aloud, these customary syllables.
+      In a fit of petulance, I remodelled them thus: “I am safe—I am
+      safe—yes—if I be not fool enough to make open confession!”
+
+      No sooner had I spoken these words, than I felt an icy chill
+      creep to my heart. I had had some experience in these fits of
+      perversity (whose nature I have been at some trouble to explain),
+      and I remembered well that in no instance I had successfully
+      resisted their attacks. And now my own casual self-suggestion
+      that I might possibly be fool enough to confess the murder of
+      which I had been guilty, confronted me, as if the very ghost of
+      him whom I had murdered—and beckoned me on to death.
+
+      At first, I made an effort to shake off this nightmare of the
+      soul. I walked vigorously—faster—still faster—at length I ran. I
+      felt a maddening desire to shriek aloud. Every succeeding wave of
+      thought overwhelmed me with new terror, for, alas! I well, too
+      well understood that to think, in my situation, was to be lost. I
+      still quickened my pace. I bounded like a madman through the
+      crowded thoroughfares. At length, the populace took the alarm,
+      and pursued me. I felt then the consummation of my fate. Could I
+      have torn out my tongue, I would have done it, but a rough voice
+      resounded in my ears—a rougher grasp seized me by the shoulder. I
+      turned—I gasped for breath. For a moment I experienced all the
+      pangs of suffocation; I became blind, and deaf, and giddy; and
+      then some invisible fiend, I thought, struck me with his broad
+      palm upon the back. The long imprisoned secret burst forth from
+      my soul.
+
+      They say that I spoke with a distinct enunciation, but with
+      marked emphasis and passionate hurry, as if in dread of
+      interruption before concluding the brief but pregnant sentences
+      that consigned me to the hangman and to hell.
+
+      Having related all that was necessary for the fullest judicial
+      conviction, I fell prostrate in a swoon.
+
+      But why shall I say more? To-day I wear these chains, and am
+      _here!_ To-morrow I shall be fetterless!—_but where?_
+
+
+
+
+THE ISLAND OF THE FAY
+
+
+Nullus enim locus sine genio est.—_Servius_.
+
+      “La musique,” says Marmontel, in those “Contes Moraux” (*1) which
+      in all our translations, we have insisted upon calling “Moral
+      Tales,” as if in mockery of their spirit—“la musique est le seul
+      des talents qui jouissent de lui-même; tous les autres veulent
+      des temoins.” He here confounds the pleasure derivable from sweet
+      sounds with the capacity for creating them. No more than any
+      other talent, is that for music susceptible of complete
+      enjoyment, where there is no second party to appreciate its
+      exercise. And it is only in common with other talents that it
+      produces effects which may be fully enjoyed in solitude. The idea
+      which the raconteur has either failed to entertain clearly, or
+      has sacrificed in its expression to his national love of point,
+      is, doubtless, the very tenable one that the higher order of
+      music is the most thoroughly estimated when we are exclusively
+      alone. The proposition, in this form, will be admitted at once by
+      those who love the lyre for its own sake, and for its spiritual
+      uses. But there is one pleasure still within the reach of fallen
+      mortality and perhaps only one—which owes even more than does
+      music to the accessory sentiment of seclusion. I mean the
+      happiness experienced in the contemplation of natural scenery. In
+      truth, the man who would behold aright the glory of God upon
+      earth must in solitude behold that glory. To me, at least, the
+      presence—not of human life only, but of life in any other form
+      than that of the green things which grow upon the soil and are
+      voiceless—is a stain upon the landscape—is at war with the genius
+      of the scene. I love, indeed, to regard the dark valleys, and the
+      gray rocks, and the waters that silently smile, and the forests
+      that sigh in uneasy slumbers, and the proud watchful mountains
+      that look down upon all,—I love to regard these as themselves but
+      the colossal members of one vast animate and sentient whole—a
+      whole whose form (that of the sphere) is the most perfect and
+      most inclusive of all; whose path is among associate planets;
+      whose meek handmaiden is the moon, whose mediate sovereign is the
+      sun; whose life is eternity, whose thought is that of a God;
+      whose enjoyment is knowledge; whose destinies are lost in
+      immensity, whose cognizance of ourselves is akin with our own
+      cognizance of the animalculae which infest the brain—a being
+      which we, in consequence, regard as purely inanimate and material
+      much in the same manner as these animalculae must thus regard us.
+
+      Our telescopes and our mathematical investigations assure us on
+      every hand—notwithstanding the cant of the more ignorant of the
+      priesthood—that space, and therefore that bulk, is an important
+      consideration in the eyes of the Almighty. The cycles in which
+      the stars move are those best adapted for the evolution, without
+      collision, of the greatest possible number of bodies. The forms
+      of those bodies are accurately such as, within a given surface,
+      to include the greatest possible amount of matter;—while the
+      surfaces themselves are so disposed as to accommodate a denser
+      population than could be accommodated on the same surfaces
+      otherwise arranged. Nor is it any argument against bulk being an
+      object with God, that space itself is infinite; for there may be
+      an infinity of matter to fill it. And since we see clearly that
+      the endowment of matter with vitality is a principle—indeed, as
+      far as our judgments extend, the leading principle in the
+      operations of Deity,—it is scarcely logical to imagine it
+      confined to the regions of the minute, where we daily trace it,
+      and not extending to those of the august. As we find cycle within
+      cycle without end,—yet all revolving around one far-distant
+      centre which is the God-head, may we not analogically suppose in
+      the same manner, life within life, the less within the greater,
+      and all within the Spirit Divine? In short, we are madly erring,
+      through self-esteem, in believing man, in either his temporal or
+      future destinies, to be of more moment in the universe than that
+      vast “clod of the valley” which he tills and contemns, and to
+      which he denies a soul for no more profound reason than that he
+      does not behold it in operation. (*2)
+
+      These fancies, and such as these, have always given to my
+      meditations among the mountains and the forests, by the rivers
+      and the ocean, a tinge of what the everyday world would not fail
+      to term fantastic. My wanderings amid such scenes have been many,
+      and far-searching, and often solitary; and the interest with
+      which I have strayed through many a dim, deep valley, or gazed
+      into the reflected Heaven of many a bright lake, has been an
+      interest greatly deepened by the thought that I have strayed and
+      gazed alone. What flippant Frenchman was it who said in allusion
+      to the well-known work of Zimmerman, that, “la solitude est une
+      belle chose; mais il faut quelqu’un pour vous dire que la
+      solitude est une belle chose?” The epigram cannot be gainsayed;
+      but the necessity is a thing that does not exist.
+
+      It was during one of my lonely journeyings, amid a far distant
+      region of mountain locked within mountain, and sad rivers and
+      melancholy tarn writhing or sleeping within all—that I chanced
+      upon a certain rivulet and island. I came upon them suddenly in
+      the leafy June, and threw myself upon the turf, beneath the
+      branches of an unknown odorous shrub, that I might doze as I
+      contemplated the scene. I felt that thus only should I look upon
+      it—such was the character of phantasm which it wore.
+
+      On all sides—save to the west, where the sun was about
+      sinking—arose the verdant walls of the forest. The little river
+      which turned sharply in its course, and was thus immediately lost
+      to sight, seemed to have no exit from its prison, but to be
+      absorbed by the deep green foliage of the trees to the east—while
+      in the opposite quarter (so it appeared to me as I lay at length
+      and glanced upward) there poured down noiselessly and
+      continuously into the valley, a rich golden and crimson waterfall
+      from the sunset fountains of the sky.
+
+      About midway in the short vista which my dreamy vision took in,
+      one small circular island, profusely verdured, reposed upon the
+      bosom of the stream.
+
+      So blended bank and shadow there
+      That each seemed pendulous in air—
+
+      so mirror-like was the glassy water, that it was scarcely
+      possible to say at what point upon the slope of the emerald turf
+      its crystal dominion began.
+
+      My position enabled me to include in a single view both the
+      eastern and western extremities of the islet; and I observed a
+      singularly-marked difference in their aspects. The latter was all
+      one radiant harem of garden beauties. It glowed and blushed
+      beneath the eyes of the slant sunlight, and fairly laughed with
+      flowers. The grass was short, springy, sweet-scented, and
+      asphodel-interspersed. The trees were lithe, mirthful,
+      erect—bright, slender, and graceful,—of Eastern figure and
+      foliage, with bark smooth, glossy, and parti-colored. There
+      seemed a deep sense of life and joy about all; and although no
+      airs blew from out the heavens, yet every thing had motion
+      through the gentle sweepings to and fro of innumerable
+      butterflies, that might have been mistaken for tulips with wings.
+      (*4)
+
+      The other or eastern end of the isle was whelmed in the blackest
+      shade. A sombre, yet beautiful and peaceful gloom here pervaded
+      all things. The trees were dark in color, and mournful in form
+      and attitude, wreathing themselves into sad, solemn, and spectral
+      shapes that conveyed ideas of mortal sorrow and untimely death.
+      The grass wore the deep tint of the cypress, and the heads of its
+      blades hung droopingly, and hither and thither among it were many
+      small unsightly hillocks, low and narrow, and not very long, that
+      had the aspect of graves, but were not; although over and all
+      about them the rue and the rosemary clambered. The shade of the
+      trees fell heavily upon the water, and seemed to bury itself
+      therein, impregnating the depths of the element with darkness. I
+      fancied that each shadow, as the sun descended lower and lower,
+      separated itself sullenly from the trunk that gave it birth, and
+      thus became absorbed by the stream; while other shadows issued
+      momently from the trees, taking the place of their predecessors
+      thus entombed.
+
+      This idea, having once seized upon my fancy, greatly excited it,
+      and I lost myself forthwith in revery. “If ever island were
+      enchanted,” said I to myself, “this is it. This is the haunt of
+      the few gentle Fays who remain from the wreck of the race. Are
+      these green tombs theirs?—or do they yield up their sweet lives
+      as mankind yield up their own? In dying, do they not rather waste
+      away mournfully, rendering unto God, little by little, their
+      existence, as these trees render up shadow after shadow,
+      exhausting their substance unto dissolution? What the wasting
+      tree is to the water that imbibes its shade, growing thus blacker
+      by what it preys upon, may not the life of the Fay be to the
+      death which engulfs it?”
+
+      As I thus mused, with half-shut eyes, while the sun sank rapidly
+      to rest, and eddying currents careered round and round the
+      island, bearing upon their bosom large, dazzling, white flakes of
+      the bark of the sycamore—flakes which, in their multiform
+      positions upon the water, a quick imagination might have
+      converted into anything it pleased—while I thus mused, it
+      appeared to me that the form of one of those very Fays about whom
+      I had been pondering made its way slowly into the darkness from
+      out the light at the western end of the island. She stood erect
+      in a singularly fragile canoe, and urged it with the mere phantom
+      of an oar. While within the influence of the lingering sunbeams,
+      her attitude seemed indicative of joy—but sorrow deformed it as
+      she passed within the shade. Slowly she glided along, and at
+      length rounded the islet and re-entered the region of light. “The
+      revolution which has just been made by the Fay,” continued I,
+      musingly, “is the cycle of the brief year of her life. She has
+      floated through her winter and through her summer. She is a year
+      nearer unto Death; for I did not fail to see that, as she came
+      into the shade, her shadow fell from her, and was swallowed up in
+      the dark water, making its blackness more black.”
+
+      And again the boat appeared and the Fay; but about the attitude
+      of the latter there was more of care and uncertainty and less of
+      elastic joy. She floated again from out the light and into the
+      gloom (which deepened momently) and again her shadow fell from
+      her into the ebony water, and became absorbed into its blackness.
+      And again and again she made the circuit of the island, (while
+      the sun rushed down to his slumbers), and at each issuing into
+      the light there was more sorrow about her person, while it grew
+      feebler and far fainter and more indistinct, and at each passage
+      into the gloom there fell from her a darker shade, which became
+      whelmed in a shadow more black. But at length when the sun had
+      utterly departed, the Fay, now the mere ghost of her former self,
+      went disconsolately with her boat into the region of the ebony
+      flood—and that she issued thence at all I cannot say, for
+      darkness fell over all things and I beheld her magical figure no
+      more.
+
+
+
+
+THE ASSIGNATION
+
+
+     Stay for me there! I will not fail.
+     To meet thee in that hollow vale.
+
+(_Exequy on the death of his wife, by Henry King, Bishop of
+Chichester_.)
+
+      Ill-fated and mysterious man!—bewildered in the brilliancy of
+      thine own imagination, and fallen in the flames of thine own
+      youth! Again in fancy I behold thee! Once more thy form hath
+      risen before me!—not—oh! not as thou art—in the cold valley and
+      shadow—but as thou _shouldst be_—squandering away a life of
+      magnificent meditation in that city of dim visions, thine own
+      Venice—which is a star-beloved Elysium of the sea, and the wide
+      windows of whose Palladian palaces look down with a deep and
+      bitter meaning upon the secrets of her silent waters. Yes! I
+      repeat it—as thou _shouldst be_. There are surely other worlds
+      than this—other thoughts than the thoughts of the multitude—other
+      speculations than the speculations of the sophist. Who then shall
+      call thy conduct into question? who blame thee for thy visionary
+      hours, or denounce those occupations as a wasting away of life,
+      which were but the overflowings of thine everlasting energies?
+
+      It was at Venice, beneath the covered archway there called the
+      _Ponte di Sospiri_, that I met for the third or fourth time the
+      person of whom I speak. It is with a confused recollection that I
+      bring to mind the circumstances of that meeting. Yet I
+      remember—ah! how should I forget?—the deep midnight, the Bridge
+      of Sighs, the beauty of woman, and the Genius of Romance that
+      stalked up and down the narrow canal.
+
+      It was a night of unusual gloom. The great clock of the Piazza
+      had sounded the fifth hour of the Italian evening. The square of
+      the Campanile lay silent and deserted, and the lights in the old
+      Ducal Palace were dying fast away. I was returning home from the
+      Piazetta, by way of the Grand Canal. But as my gondola arrived
+      opposite the mouth of the canal San Marco, a female voice from
+      its recesses broke suddenly upon the night, in one wild,
+      hysterical, and long continued shriek. Startled at the sound, I
+      sprang upon my feet: while the gondolier, letting slip his single
+      oar, lost it in the pitchy darkness beyond a chance of recovery,
+      and we were consequently left to the guidance of the current
+      which here sets from the greater into the smaller channel. Like
+      some huge and sable-feathered condor, we were slowly drifting
+      down towards the Bridge of Sighs, when a thousand flambeaux
+      flashing from the windows, and down the staircases of the Ducal
+      Palace, turned all at once that deep gloom into a livid and
+      preternatural day.
+
+      A child, slipping from the arms of its own mother, had fallen
+      from an upper window of the lofty structure into the deep and dim
+      canal. The quiet waters had closed placidly over their victim;
+      and, although my own gondola was the only one in sight, many a
+      stout swimmer, already in the stream, was seeking in vain upon
+      the surface, the treasure which was to be found, alas! only
+      within the abyss. Upon the broad black marble flagstones at the
+      entrance of the palace, and a few steps above the water, stood a
+      figure which none who then saw can have ever since forgotten. It
+      was the Marchesa Aphrodite—the adoration of all Venice—the gayest
+      of the gay—the most lovely where all were beautiful—but still the
+      young wife of the old and intriguing Mentoni, and the mother of
+      that fair child, her first and only one, who now, deep beneath
+      the murky water, was thinking in bitterness of heart upon her
+      sweet caresses, and exhausting its little life in struggles to
+      call upon her name.
+
+      She stood alone. Her small, bare, and silvery feet gleamed in the
+      black mirror of marble beneath her. Her hair, not as yet more
+      than half loosened for the night from its ball-room array,
+      clustered, amid a shower of diamonds, round and round her
+      classical head, in curls like those of the young hyacinth. A
+      snowy-white and gauze-like drapery seemed to be nearly the sole
+      covering to her delicate form; but the mid-summer and midnight
+      air was hot, sullen, and still, and no motion in the statue-like
+      form itself, stirred even the folds of that raiment of very vapor
+      which hung around it as the heavy marble hangs around the Niobe.
+      Yet—strange to say!—her large lustrous eyes were not turned
+      downwards upon that grave wherein her brightest hope lay
+      buried—but riveted in a widely different direction! The prison of
+      the Old Republic is, I think, the stateliest building in all
+      Venice—but how could that lady gaze so fixedly upon it, when
+      beneath her lay stifling her only child? Yon dark, gloomy niche,
+      too, yawns right opposite her chamber window—what, then, _could_
+      there be in its shadows—in its architecture—in its ivy-wreathed
+      and solemn cornices—that the Marchesa di Mentoni had not wondered
+      at a thousand times before? Nonsense!—Who does not remember that,
+      at such a time as this, the eye, like a shattered mirror,
+      multiplies the images of its sorrow, and sees in innumerable
+      far-off places, the woe which is close at hand?
+
+      Many steps above the Marchesa, and within the arch of the
+      water-gate, stood, in full dress, the Satyr-like figure of
+      Mentoni himself. He was occasionally occupied in thrumming a
+      guitar, and seemed _ennuye_ to the very death, as at intervals he
+      gave directions for the recovery of his child. Stupefied and
+      aghast, I had myself no power to move from the upright position I
+      had assumed upon first hearing the shriek, and must have
+      presented to the eyes of the agitated group a spectral and
+      ominous appearance, as with pale countenance and rigid limbs, I
+      floated down among them in that funereal gondola.
+
+      All efforts proved in vain. Many of the most energetic in the
+      search were relaxing their exertions, and yielding to a gloomy
+      sorrow. There seemed but little hope for the child; (how much
+      less than for the mother!) but now, from the interior of that
+      dark niche which has been already mentioned as forming a part of
+      the Old Republican prison, and as fronting the lattice of the
+      Marchesa, a figure muffled in a cloak, stepped out within reach
+      of the light, and, pausing a moment upon the verge of the giddy
+      descent, plunged headlong into the canal. As, in an instant
+      afterwards, he stood with the still living and breathing child
+      within his grasp, upon the marble flagstones by the side of the
+      Marchesa, his cloak, heavy with the drenching water, became
+      unfastened, and, falling in folds about his feet, discovered to
+      the wonder-stricken spectators the graceful person of a very
+      young man, with the sound of whose name the greater part of
+      Europe was then ringing.
+
+      No word spoke the deliverer. But the Marchesa! She will now
+      receive her child—she will press it to her heart—she will cling
+      to its little form, and smother it with her caresses. Alas!
+      _another’s_ arms have taken it from the stranger—_another’s_ arms
+      have taken it away, and borne it afar off, unnoticed, into the
+      palace! And the Marchesa! Her lip—her beautiful lip trembles;
+      tears are gathering in her eyes—those eyes which, like Pliny’s
+      acanthus, are “soft and almost liquid.” Yes! tears are gathering
+      in those eyes—and see! the entire woman thrills throughout the
+      soul, and the statue has started into life! The pallor of the
+      marble countenance, the swelling of the marble bosom, the very
+      purity of the marble feet, we behold suddenly flushed over with a
+      tide of ungovernable crimson; and a slight shudder quivers about
+      her delicate frame, as a gentle air at Napoli about the rich
+      silver lilies in the grass.
+
+      Why _should_ that lady blush! To this demand there is no
+      answer—except that, having left, in the eager haste and terror of
+      a mother’s heart, the privacy of her own _boudoir_, she has
+      neglected to enthral her tiny feet in their slippers, and utterly
+      forgotten to throw over her Venetian shoulders that drapery which
+      is their due. What other possible reason could there have been
+      for her so blushing?—for the glance of those wild appealing
+      eyes?—for the unusual tumult of that throbbing bosom?—for the
+      convulsive pressure of that trembling hand?—that hand which fell,
+      as Mentoni turned into the palace, accidentally, upon the hand of
+      the stranger. What reason could there have been for the low—the
+      singularly low tone of those unmeaning words which the lady
+      uttered hurriedly in bidding him adieu? “Thou hast conquered,”
+      she said, or the murmurs of the water deceived me; “thou hast
+      conquered—one hour after sunrise—we shall meet—so let it be!”
+
+      The tumult had subsided, the lights had died away within the
+      palace, and the stranger, whom I now recognized, stood alone upon
+      the flags. He shook with inconceivable agitation, and his eye
+      glanced around in search of a gondola. I could not do less than
+      offer him the service of my own; and he accepted the civility.
+      Having obtained an oar at the water-gate, we proceeded together
+      to his residence, while he rapidly recovered his self-possession,
+      and spoke of our former slight acquaintance in terms of great
+      apparent cordiality.
+
+      There are some subjects upon which I take pleasure in being
+      minute. The person of the stranger—let me call him by this title,
+      who to all the world was still a stranger—the person of the
+      stranger is one of these subjects. In height he might have been
+      below rather than above the medium size: although there were
+      moments of intense passion when his frame actually _expanded_ and
+      belied the assertion. The light, almost slender symmetry of his
+      figure, promised more of that ready activity which he evinced at
+      the Bridge of Sighs, than of that Herculean strength which he has
+      been known to wield without an effort, upon occasions of more
+      dangerous emergency. With the mouth and chin of a deity—singular,
+      wild, full, liquid eyes, whose shadows varied from pure hazel to
+      intense and brilliant jet—and a profusion of curling, black hair,
+      from which a forehead of unusual breadth gleamed forth at
+      intervals all light and ivory—his were features than which I have
+      seen none more classically regular, except, perhaps, the marble
+      ones of the Emperor Commodus. Yet his countenance was,
+      nevertheless, one of those which all men have seen at some period
+      of their lives, and have never afterwards seen again. It had no
+      peculiar, it had no settled predominant expression to be fastened
+      upon the memory; a countenance seen and instantly forgotten, but
+      forgotten with a vague and never-ceasing desire of recalling it
+      to mind. Not that the spirit of each rapid passion failed, at any
+      time, to throw its own distinct image upon the mirror of that
+      face—but that the mirror, mirror-like, retained no vestige of the
+      passion, when the passion had departed.
+
+      Upon leaving him on the night of our adventure, he solicited me,
+      in what I thought an urgent manner, to call upon him _very_ early
+      the next morning. Shortly after sunrise, I found myself
+      accordingly at his Palazzo, one of those huge structures of
+      gloomy, yet fantastic pomp, which tower above the waters of the
+      Grand Canal in the vicinity of the Rialto. I was shown up a broad
+      winding staircase of mosaics, into an apartment whose
+      unparalleled splendor burst through the opening door with an
+      actual glare, making me blind and dizzy with luxuriousness.
+
+      I knew my acquaintance to be wealthy. Report had spoken of his
+      possessions in terms which I had even ventured to call terms of
+      ridiculous exaggeration. But as I gazed about me, I could not
+      bring myself to believe that the wealth of any subject in Europe
+      could have supplied the princely magnificence which burned and
+      blazed around.
+
+      Although, as I say, the sun had arisen, yet the room was still
+      brilliantly lighted up. I judge from this circumstance, as well
+      as from an air of exhaustion in the countenance of my friend,
+      that he had not retired to bed during the whole of the preceding
+      night. In the architecture and embellishments of the chamber, the
+      evident design had been to dazzle and astound. Little attention
+      had been paid to the _decora_ of what is technically called
+      _keeping_, or to the proprieties of nationality. The eye wandered
+      from object to object, and rested upon none—neither the
+      _grotesques_ of the Greek painters, nor the sculptures of the
+      best Italian days, nor the huge carvings of untutored Egypt. Rich
+      draperies in every part of the room trembled to the vibration of
+      low, melancholy music, whose origin was not to be discovered. The
+      senses were oppressed by mingled and conflicting perfumes,
+      reeking up from strange convolute censers, together with
+      multitudinous flaring and flickering tongues of emerald and
+      violet fire. The rays of the newly risen sun poured in upon the
+      whole, through windows, formed each of a single pane of
+      crimson-tinted glass. Glancing to and fro, in a thousand
+      reflections, from curtains which rolled from their cornices like
+      cataracts of molten silver, the beams of natural glory mingled at
+      length fitfully with the artificial light, and lay weltering in
+      subdued masses upon a carpet of rich, liquid-looking cloth of
+      Chili gold.
+
+      “Ha! ha! ha!—ha! ha! ha!”—laughed the proprietor, motioning me to
+      a seat as I entered the room, and throwing himself back at
+      full-length upon an ottoman. “I see,” said he, perceiving that I
+      could not immediately reconcile myself to the _bienseance_ of so
+      singular a welcome—“I see you are astonished at my apartment—at
+      my statues—my pictures—my originality of conception in
+      architecture and upholstery! absolutely drunk, eh, with my
+      magnificence? But pardon me, my dear sir, (here his tone of voice
+      dropped to the very spirit of cordiality,) pardon me for my
+      uncharitable laughter. You appeared so _utterly_ astonished.
+      Besides, some things are so completely ludicrous, that a man
+      _must_ laugh or die. To die laughing, must be the most glorious
+      of all glorious deaths! Sir Thomas More—a very fine man was Sir
+      Thomas More—Sir Thomas More died laughing, you remember. Also in
+      the _Absurdities_ of Ravisius Textor, there is a long list of
+      characters who came to the same magnificent end. Do you know,
+      however,” continued he musingly, “that at Sparta (which is now
+      Palæochori,) at Sparta, I say, to the west of the citadel, among
+      a chaos of scarcely visible ruins, is a kind of _socle_, upon
+      which are still legible the letters ΛΑΞΜ. They are undoubtedly
+      part of ΓΕΛΑΞΜΑ. Now, at Sparta were a thousand temples and
+      shrines to a thousand different divinities. How exceedingly
+      strange that the altar of Laughter should have survived all the
+      others! But in the present instance,” he resumed, with a singular
+      alteration of voice and manner, “I have no right to be merry at
+      your expense. You might well have been amazed. Europe cannot
+      produce anything so fine as this, my little regal cabinet. My
+      other apartments are by no means of the same order—mere _ultras_
+      of fashionable insipidity. This is better than fashion—is it not?
+      Yet this has but to be seen to become the rage—that is, with
+      those who could afford it at the cost of their entire patrimony.
+      I have guarded, however, against any such profanation. With one
+      exception, you are the only human being besides myself and my
+      _valet_, who has been admitted within the mysteries of these
+      imperial precincts, since they have been bedizened as you see!”
+
+      I bowed in acknowledgment—for the overpowering sense of splendor
+      and perfume, and music, together with the unexpected eccentricity
+      of his address and manner, prevented me from expressing, in
+      words, my appreciation of what I might have construed into a
+      compliment.
+
+      “Here,” he resumed, arising and leaning on my arm as he sauntered
+      around the apartment, “here are paintings from the Greeks to
+      Cimabue, and from Cimabue to the present hour. Many are chosen,
+      as you see, with little deference to the opinions of Virtu. They
+      are all, however, fitting tapestry for a chamber such as this.
+      Here, too, are some _chefs d’oeuvre_ of the unknown great; and
+      here, unfinished designs by men, celebrated in their day, whose
+      very names the perspicacity of the academies has left to silence
+      and to me. What think you,” said he, turning abruptly as he
+      spoke—“what think you of this Madonna della Pieta?”
+
+      “It is Guido’s own!” I said, with all the enthusiasm of my
+      nature, for I had been poring intently over its surpassing
+      loveliness. “It is Guido’s own!—how _could_ you have obtained
+      it?—she is undoubtedly in painting what the Venus is in
+      sculpture.”
+
+      “Ha!” said he thoughtfully, “the Venus—the beautiful Venus?—the
+      Venus of the Medici?—she of the diminutive head and the gilded
+      hair? Part of the left arm (here his voice dropped so as to be
+      heard with difficulty,) and all the right, are restorations; and
+      in the coquetry of that right arm lies, I think, the quintessence
+      of all affectation. Give _me_ the Canova! The Apollo, too, is a
+      copy—there can be no doubt of it—blind fool that I am, who cannot
+      behold the boasted inspiration of the Apollo! I cannot help—pity
+      me!—I cannot help preferring the Antinous. Was it not Socrates
+      who said that the statuary found his statue in the block of
+      marble? Then Michael Angelo was by no means original in his
+      couplet—
+
+     ‘Non ha l’ottimo artista alcun concetto
+     Che un marmo solo in se non circunscriva.’”
+
+      It has been, or should be remarked, that, in the manner of the
+      true gentleman, we are always aware of a difference from the
+      bearing of the vulgar, without being at once precisely able to
+      determine in what such difference consists. Allowing the remark
+      to have applied in its full force to the outward demeanor of my
+      acquaintance, I felt it, on that eventful morning, still more
+      fully applicable to his moral temperament and character. Nor can
+      I better define that peculiarity of spirit which seemed to place
+      him so essentially apart from all other human beings, than by
+      calling it a _habit_ of intense and continual thought, pervading
+      even his most trivial actions—intruding upon his moments of
+      dalliance—and interweaving itself with his very flashes of
+      merriment—like adders which writhe from out the eyes of the
+      grinning masks in the cornices around the temples of Persepolis.
+
+      I could not help, however, repeatedly observing, through the
+      mingled tone of levity and solemnity with which he rapidly
+      descanted upon matters of little importance, a certain air of
+      trepidation—a degree of nervous _unction_ in action and in
+      speech—an unquiet excitability of manner which appeared to me at
+      all times unaccountable, and upon some occasions even filled me
+      with alarm. Frequently, too, pausing in the middle of a sentence
+      whose commencement he had apparently forgotten, he seemed to be
+      listening in the deepest attention, as if either in momentary
+      expectation of a visitor, or to sounds which must have had
+      existence in his imagination alone.
+
+      It was during one of these reveries or pauses of apparent
+      abstraction, that, in turning over a page of the poet and scholar
+      Politian’s beautiful tragedy “The Orfeo,” (the first native
+      Italian tragedy,) which lay near me upon an ottoman, I discovered
+      a passage underlined in pencil. It was a passage towards the end
+      of the third act—a passage of the most heart-stirring
+      excitement—a passage which, although tainted with impurity, no
+      man shall read without a thrill of novel emotion—no woman without
+      a sigh. The whole page was blotted with fresh tears; and, upon
+      the opposite interleaf, were the following English lines, written
+      in a hand so very different from the peculiar characters of my
+      acquaintance, that I had some difficulty in recognising it as his
+      own:—
+
+Thou wast that all to me, love,
+    For which my soul did pine—
+A green isle in the sea, love,
+    A fountain and a shrine,
+All wreathed with fairy fruits and flowers;
+    And all the flowers were mine.
+
+Ah, dream too bright to last!
+    Ah, starry Hope, that didst arise
+But to be overcast!
+    A voice from out the Future cries,
+“Onward!”—but o’er the Past
+    (Dim gulf!) my spirit hovering lies,
+Mute—motionless—aghast!
+
+For alas!  alas!  with me
+    The light of life is o’er.
+“No more—no more—no more,”
+    (Such language holds the solemn sea
+To the sands upon the shore,)
+    Shall bloom the thunder-blasted tree,
+Or the stricken eagle soar!
+
+Now all my hours are trances;
+    And all my nightly dreams
+Are where the dark eye glances,
+    And where thy footstep gleams,
+In what ethereal dances,
+    By what Italian streams.
+
+Alas!  for that accursed time
+    They bore thee o’er the billow,
+From Love to titled age and crime,
+    And an unholy pillow!—
+From me, and from our misty clime,
+    Where weeps the silver willow!
+
+      That these lines were written in English—a language with which I
+      had not believed their author acquainted—afforded me little
+      matter for surprise. I was too well aware of the extent of his
+      acquirements, and of the singular pleasure he took in concealing
+      them from observation, to be astonished at any similar discovery;
+      but the place of date, I must confess, occasioned me no little
+      amazement. It had been originally written _London_, and
+      afterwards carefully overscored—not, however, so effectually as
+      to conceal the word from a scrutinizing eye. I say, this
+      occasioned me no little amazement; for I well remember that, in a
+      former conversation with a friend, I particularly inquired if he
+      had at any time met in London the Marchesa di Mentoni, (who for
+      some years previous to her marriage had resided in that city,)
+      when his answer, if I mistake not, gave me to understand that he
+      had never visited the metropolis of Great Britain. I might as
+      well here mention, that I have more than once heard, (without, of
+      course, giving credit to a report involving so many
+      improbabilities,) that the person of whom I speak, was not only
+      by birth, but in education, an _Englishman_.
+
+“There is one painting,” said he, without being aware of my notice of
+the tragedy—“there is still one painting which you have not seen.” And
+throwing aside a drapery, he discovered a full-length portrait of the
+Marchesa Aphrodite.
+
+Human art could have done no more in the delineation of her superhuman
+beauty. The same ethereal figure which stood before me the preceding
+night upon the steps of the Ducal Palace, stood before me once again.
+But in the expression of the countenance, which was beaming all over
+with smiles, there still lurked (incomprehensible anomaly!) that fitful
+stain of melancholy which will ever be found inseparable from the
+perfection of the beautiful. Her right arm lay folded over her bosom.
+With her left she pointed downward to a curiously fashioned vase. One
+small, fairy foot, alone visible, barely touched the earth; and,
+scarcely discernible in the brilliant atmosphere which seemed to
+encircle and enshrine her loveliness, floated a pair of the most
+delicately imagined wings. My glance fell from the painting to the
+figure of my friend, and the vigorous words of Chapman’s _Bussy
+D’Ambois_, quivered instinctively upon my lips:
+
+    “He is up
+There like a Roman statue!  He will stand
+Till Death hath made him marble!”
+
+      “Come,” he said at length, turning towards a table of richly
+      enamelled and massive silver, upon which were a few goblets
+      fantastically stained, together with two large Etruscan vases,
+      fashioned in the same extraordinary model as that in the
+      foreground of the portrait, and filled with what I supposed to be
+      Johannisberger. “Come,” he said, abruptly, “let us drink! It is
+      early—but let us drink. It is _indeed_ early,” he continued,
+      musingly, as a cherub with a heavy golden hammer made the
+      apartment ring with the first hour after sunrise: “It is _indeed_
+      early—but what matters it? let us drink! Let us pour out an
+      offering to yon solemn sun which these gaudy lamps and censers
+      are so eager to subdue!” And, having made me pledge him in a
+      bumper, he swallowed in rapid succession several goblets of the
+      wine.
+
+      “To dream,” he continued, resuming the tone of his desultory
+      conversation, as he held up to the rich light of a censer one of
+      the magnificent vases—“to dream has been the business of my life.
+      I have therefore framed for myself, as you see, a bower of
+      dreams. In the heart of Venice could I have erected a better? You
+      behold around you, it is true, a medley of architectural
+      embellishments. The chastity of Ionia is offended by antediluvian
+      devices, and the sphynxes of Egypt are outstretched upon carpets
+      of gold. Yet the effect is incongruous to the timid alone.
+      Proprieties of place, and especially of time, are the bugbears
+      which terrify mankind from the contemplation of the magnificent.
+      Once I was myself a decorist; but that sublimation of folly has
+      palled upon my soul. All this is now the fitter for my purpose.
+      Like these arabesque censers, my spirit is writhing in fire, and
+      the delirium of this scene is fashioning me for the wilder
+      visions of that land of real dreams whither I am now rapidly
+      departing.” He here paused abruptly, bent his head to his bosom,
+      and seemed to listen to a sound which I could not hear. At
+      length, erecting his frame, he looked upwards, and ejaculated the
+      lines of the Bishop of Chichester:
+
+     _“Stay for me there!  I will not fail_
+     _To meet thee in that hollow vale.”_
+
+      In the next instant, confessing the power of the wine, he threw
+      himself at full-length upon an ottoman.
+
+      A quick step was now heard upon the staircase, and a loud knock
+      at the door rapidly succeeded. I was hastening to anticipate a
+      second disturbance, when a page of Mentoni’s household burst into
+      the room, and faltered out, in a voice choking with emotion, the
+      incoherent words, “My mistress!—my mistress!—Poisoned!—poisoned!
+      Oh, beautiful—oh, beautiful Aphrodite!”
+
+      Bewildered, I flew to the ottoman, and endeavored to arouse the
+      sleeper to a sense of the startling intelligence. But his limbs
+      were rigid—his lips were livid—his lately beaming eyes were
+      riveted in _death_. I staggered back towards the table—my hand
+      fell upon a cracked and blackened goblet—and a consciousness of
+      the entire and terrible truth flashed suddenly over my soul.
+
+
+
+
+THE PIT AND THE PENDULUM
+
+
+     Impia tortorum longos hic turba furores
+     Sanguinis innocui, non satiata, aluit.
+     Sospite nunc patria, fracto nunc funeris antro,
+     Mors ubi dira fuit vita salusque patent.
+
+[_Quatrain composed for the gates of a market to be erected upon the
+site of the Jacobin Club House at Paris_.]
+
+      I was sick—sick unto death with that long agony; and when they at
+      length unbound me, and I was permitted to sit, I felt that my
+      senses were leaving me. The sentence—the dread sentence of
+      death—was the last of distinct accentuation which reached my
+      ears. After that, the sound of the inquisitorial voices seemed
+      merged in one dreamy indeterminate hum. It conveyed to my soul
+      the idea of _revolution_—perhaps from its association in fancy
+      with the burr of a mill wheel. This only for a brief period, for
+      presently I heard no more. Yet, for a while, I saw—but with how
+      terrible an exaggeration! I saw the lips of the black-robed
+      judges. They appeared to me white—whiter than the sheet upon
+      which I trace these words—and thin even to grotesqueness; thin
+      with the intensity of their expression of firmness—of immoveable
+      resolution—of stern contempt of human torture. I saw that the
+      decrees of what to me was Fate, were still issuing from those
+      lips. I saw them writhe with a deadly locution. I saw them
+      fashion the syllables of my name; and I shuddered because no
+      sound succeeded. I saw, too, for a few moments of delirious
+      horror, the soft and nearly imperceptible waving of the sable
+      draperies which enwrapped the walls of the apartment. And then my
+      vision fell upon the seven tall candles upon the table. At first
+      they wore the aspect of charity, and seemed white and slender
+      angels who would save me; but then, all at once, there came a
+      most deadly nausea over my spirit, and I felt every fibre in my
+      frame thrill as if I had touched the wire of a galvanic battery,
+      while the angel forms became meaningless spectres, with heads of
+      flame, and I saw that from them there would be no help. And then
+      there stole into my fancy, like a rich musical note, the thought
+      of what sweet rest there must be in the grave. The thought came
+      gently and stealthily, and it seemed long before it attained full
+      appreciation; but just as my spirit came at length properly to
+      feel and entertain it, the figures of the judges vanished, as if
+      magically, from before me; the tall candles sank into
+      nothingness; their flames went out utterly; the blackness of
+      darkness supervened; all sensations appeared swallowed up in a
+      mad rushing descent as of the soul into Hades. Then silence, and
+      stillness, night were the universe.
+
+      I had swooned; but still will not say that all of consciousness
+      was lost. What of it there remained I will not attempt to define,
+      or even to describe; yet all was not lost. In the deepest
+      slumber—no! In delirium—no! In a swoon—no! In death—no! even in
+      the grave all is not lost. Else there is no immortality for man.
+      Arousing from the most profound of slumbers, we break the
+      gossamer web of some dream. Yet in a second afterward, (so frail
+      may that web have been) we remember not that we have dreamed. In
+      the return to life from the swoon there are two stages; first,
+      that of the sense of mental or spiritual; secondly, that of the
+      sense of physical, existence. It seems probable that if, upon
+      reaching the second stage, we could recall the impressions of the
+      first, we should find these impressions eloquent in memories of
+      the gulf beyond. And that gulf is—what? How at least shall we
+      distinguish its shadows from those of the tomb? But if the
+      impressions of what I have termed the first stage are not, at
+      will, recalled, yet, after long interval, do they not come
+      unbidden, while we marvel whence they come? He who has never
+      swooned, is not he who finds strange palaces and wildly familiar
+      faces in coals that glow; is not he who beholds floating in
+      mid-air the sad visions that the many may not view; is not he who
+      ponders over the perfume of some novel flower; is not he whose
+      brain grows bewildered with the meaning of some musical cadence
+      which has never before arrested his attention.
+
+      Amid frequent and thoughtful endeavors to remember; amid earnest
+      struggles to regather some token of the state of seeming
+      nothingness into which my soul had lapsed, there have been
+      moments when I have dreamed of success; there have been brief,
+      very brief periods when I have conjured up remembrances which the
+      lucid reason of a later epoch assures me could have had reference
+      only to that condition of seeming unconsciousness. These shadows
+      of memory tell, indistinctly, of tall figures that lifted and
+      bore me in silence down—down—still down—till a hideous dizziness
+      oppressed me at the mere idea of the interminableness of the
+      descent. They tell also of a vague horror at my heart, on account
+      of that heart’s unnatural stillness. Then comes a sense of sudden
+      motionlessness throughout all things; as if those who bore me (a
+      ghastly train!) had outrun, in their descent, the limits of the
+      limitless, and paused from the wearisomeness of their toil. After
+      this I call to mind flatness and dampness; and then all is
+      madness—the madness of a memory which busies itself among
+      forbidden things.
+
+      Very suddenly there came back to my soul motion and sound—the
+      tumultuous motion of the heart, and, in my ears, the sound of its
+      beating. Then a pause in which all is blank. Then again sound,
+      and motion, and touch—a tingling sensation pervading my frame.
+      Then the mere consciousness of existence, without thought—a
+      condition which lasted long. Then, very suddenly, thought, and
+      shuddering terror, and earnest endeavor to comprehend my true
+      state. Then a strong desire to lapse into insensibility. Then a
+      rushing revival of soul and a successful effort to move. And now
+      a full memory of the trial, of the judges, of the sable
+      draperies, of the sentence, of the sickness, of the swoon. Then
+      entire forgetfulness of all that followed; of all that a later
+      day and much earnestness of endeavor have enabled me vaguely to
+      recall.
+
+      So far, I had not opened my eyes. I felt that I lay upon my back,
+      unbound. I reached out my hand, and it fell heavily upon
+      something damp and hard. There I suffered it to remain for many
+      minutes, while I strove to imagine where and what I could be. I
+      longed, yet dared not to employ my vision. I dreaded the first
+      glance at objects around me. It was not that I feared to look
+      upon things horrible, but that I grew aghast lest there should be
+      nothing to see. At length, with a wild desperation at heart, I
+      quickly unclosed my eyes. My worst thoughts, then, were
+      confirmed. The blackness of eternal night encompassed me. I
+      struggled for breath. The intensity of the darkness seemed to
+      oppress and stifle me. The atmosphere was intolerably close. I
+      still lay quietly, and made effort to exercise my reason. I
+      brought to mind the inquisitorial proceedings, and attempted from
+      that point to deduce my real condition. The sentence had passed;
+      and it appeared to me that a very long interval of time had since
+      elapsed. Yet not for a moment did I suppose myself actually dead.
+      Such a supposition, notwithstanding what we read in fiction, is
+      altogether inconsistent with real existence;—but where and in
+      what state was I? The condemned to death, I knew, perished
+      usually at the autos-da-fe, and one of these had been held on the
+      very night of the day of my trial. Had I been remanded to my
+      dungeon, to await the next sacrifice, which would not take place
+      for many months? This I at once saw could not be. Victims had
+      been in immediate demand. Moreover, my dungeon, as well as all
+      the condemned cells at Toledo, had stone floors, and light was
+      not altogether excluded.
+
+      A fearful idea now suddenly drove the blood in torrents upon my
+      heart, and for a brief period, I once more relapsed into
+      insensibility. Upon recovering, I at once started to my feet,
+      trembling convulsively in every fibre. I thrust my arms wildly
+      above and around me in all directions. I felt nothing; yet
+      dreaded to move a step, lest I should be impeded by the walls of
+      a tomb. Perspiration burst from every pore, and stood in cold big
+      beads upon my forehead. The agony of suspense grew at length
+      intolerable, and I cautiously moved forward, with my arms
+      extended, and my eyes straining from their sockets, in the hope
+      of catching some faint ray of light. I proceeded for many paces;
+      but still all was blackness and vacancy. I breathed more freely.
+      It seemed evident that mine was not, at least, the most hideous
+      of fates.
+
+      And now, as I still continued to step cautiously onward, there
+      came thronging upon my recollection a thousand vague rumors of
+      the horrors of Toledo. Of the dungeons there had been strange
+      things narrated—fables I had always deemed them—but yet strange,
+      and too ghastly to repeat, save in a whisper. Was I left to
+      perish of starvation in this subterranean world of darkness; or
+      what fate, perhaps even more fearful, awaited me? That the result
+      would be death, and a death of more than customary bitterness, I
+      knew too well the character of my judges to doubt. The mode and
+      the hour were all that occupied or distracted me.
+
+      My outstretched hands at length encountered some solid
+      obstruction. It was a wall, seemingly of stone masonry—very
+      smooth, slimy, and cold. I followed it up; stepping with all the
+      careful distrust with which certain antique narratives had
+      inspired me. This process, however, afforded me no means of
+      ascertaining the dimensions of my dungeon; as I might make its
+      circuit, and return to the point whence I set out, without being
+      aware of the fact; so perfectly uniform seemed the wall. I
+      therefore sought the knife which had been in my pocket, when led
+      into the inquisitorial chamber; but it was gone; my clothes had
+      been exchanged for a wrapper of coarse serge. I had thought of
+      forcing the blade in some minute crevice of the masonry, so as to
+      identify my point of departure. The difficulty, nevertheless, was
+      but trivial; although, in the disorder of my fancy, it seemed at
+      first insuperable. I tore a part of the hem from the robe and
+      placed the fragment at full length, and at right angles to the
+      wall. In groping my way around the prison, I could not fail to
+      encounter this rag upon completing the circuit. So, at least I
+      thought: but I had not counted upon the extent of the dungeon, or
+      upon my own weakness. The ground was moist and slippery. I
+      staggered onward for some time, when I stumbled and fell. My
+      excessive fatigue induced me to remain prostrate; and sleep soon
+      overtook me as I lay.
+
+      Upon awaking, and stretching forth an arm, I found beside me a
+      loaf and a pitcher with water. I was too much exhausted to
+      reflect upon this circumstance, but ate and drank with avidity.
+      Shortly afterward, I resumed my tour around the prison, and with
+      much toil came at last upon the fragment of the serge. Up to the
+      period when I fell I had counted fifty-two paces, and upon
+      resuming my walk, I had counted forty-eight more—when I arrived
+      at the rag. There were in all, then, a hundred paces; and,
+      admitting two paces to the yard, I presumed the dungeon to be
+      fifty yards in circuit. I had met, however, with many angles in
+      the wall, and thus I could form no guess at the shape of the
+      vault, for vault I could not help supposing it to be.
+
+      I had little object—certainly no hope—in these researches; but a
+      vague curiosity prompted me to continue them. Quitting the wall,
+      I resolved to cross the area of the enclosure. At first I
+      proceeded with extreme caution, for the floor, although seemingly
+      of solid material, was treacherous with slime. At length,
+      however, I took courage, and did not hesitate to step firmly;
+      endeavoring to cross in as direct a line as possible. I had
+      advanced some ten or twelve paces in this manner, when the
+      remnant of the torn hem of my robe became entangled between my
+      legs. I stepped on it, and fell violently on my face.
+
+      In the confusion attending my fall, I did not immediately
+      apprehend a somewhat startling circumstance, which yet, in a few
+      seconds afterward, and while I still lay prostrate, arrested my
+      attention. It was this: my chin rested upon the floor of the
+      prison, but my lips and the upper portion of my head, although
+      seemingly at a less elevation than the chin, touched nothing. At
+      the same time my forehead seemed bathed in a clammy vapor, and
+      the peculiar smell of decayed fungus arose to my nostrils. I put
+      forward my arm, and shuddered to find that I had fallen at the
+      very brink of a circular pit, whose extent, of course, I had no
+      means of ascertaining at the moment. Groping about the masonry
+      just below the margin, I succeeded in dislodging a small
+      fragment, and let it fall into the abyss. For many seconds I
+      hearkened to its reverberations as it dashed against the sides of
+      the chasm in its descent; at length there was a sullen plunge
+      into water, succeeded by loud echoes. At the same moment there
+      came a sound resembling the quick opening, and as rapid closing
+      of a door overhead, while a faint gleam of light flashed suddenly
+      through the gloom, and as suddenly faded away.
+
+      I saw clearly the doom which had been prepared for me, and
+      congratulated myself upon the timely accident by which I had
+      escaped. Another step before my fall, and the world had seen me
+      no more. And the death just avoided, was of that very character
+      which I had regarded as fabulous and frivolous in the tales
+      respecting the Inquisition. To the victims of its tyranny, there
+      was the choice of death with its direst physical agonies, or
+      death with its most hideous moral horrors. I had been reserved
+      for the latter. By long suffering my nerves had been unstrung,
+      until I trembled at the sound of my own voice, and had become in
+      every respect a fitting subject for the species of torture which
+      awaited me.
+
+      Shaking in every limb, I groped my way back to the wall—resolving
+      there to perish rather than risk the terrors of the wells, of
+      which my imagination now pictured many in various positions about
+      the dungeon. In other conditions of mind I might have had courage
+      to end my misery at once by a plunge into one of these abysses;
+      but now I was the veriest of cowards. Neither could I forget what
+      I had read of these pits—that the sudden extinction of life
+      formed no part of their most horrible plan.
+
+      Agitation of spirit kept me awake for many long hours, but at
+      length I again slumbered. Upon arousing, I found by my side, as
+      before, a loaf and a pitcher of water. A burning thirst consumed
+      me, and I emptied the vessel at a draught. It must have been
+      drugged—for scarcely had I drunk, before I became irresistibly
+      drowsy. A deep sleep fell upon me—a sleep like that of death. How
+      long it lasted of course, I know not; but when, once again, I
+      unclosed my eyes, the objects around me were visible. By a wild
+      sulphurous lustre, the origin of which I could not at first
+      determine, I was enabled to see the extent and aspect of the
+      prison.
+
+      In its size I had been greatly mistaken. The whole circuit of its
+      walls did not exceed twenty-five yards. For some minutes this
+      fact occasioned me a world of vain trouble; vain indeed! for what
+      could be of less importance, under the terrible circumstances
+      which environed me, then the mere dimensions of my dungeon? But
+      my soul took a wild interest in trifles, and I busied myself in
+      endeavors to account for the error I had committed in my
+      measurement. The truth at length flashed upon me. In my first
+      attempt at exploration I had counted fifty-two paces, up to the
+      period when I fell; I must then have been within a pace or two of
+      the fragment of serge; in fact, I had nearly performed the
+      circuit of the vault. I then slept—and, upon awaking, I must have
+      returned upon my steps—thus supposing the circuit nearly double
+      what it actually was. My confusion of mind prevented me from
+      observing that I began my tour with the wall to the left, and
+      ended it with the wall to the right.
+
+      I had been deceived, too, in respect to the shape of the
+      enclosure. In feeling my way I had found many angles, and thus
+      deduced an idea of great irregularity; so potent is the effect of
+      total darkness upon one arousing from lethargy or sleep! The
+      angles were simply those of a few slight depressions, or niches,
+      at odd intervals. The general shape of the prison was square.
+      What I had taken for masonry seemed now to be iron, or some other
+      metal, in huge plates, whose sutures or joints occasioned the
+      depression. The entire surface of this metallic enclosure was
+      rudely daubed in all the hideous and repulsive devices to which
+      the charnel superstition of the monks has given rise. The figures
+      of fiends in aspects of menace, with skeleton forms, and other
+      more really fearful images, overspread and disfigured the walls.
+      I observed that the outlines of these monstrosities were
+      sufficiently distinct, but that the colors seemed faded and
+      blurred, as if from the effects of a damp atmosphere. I now
+      noticed the floor, too, which was of stone. In the centre yawned
+      the circular pit from whose jaws I had escaped; but it was the
+      only one in the dungeon.
+
+      All this I saw indistinctly and by much effort—for my personal
+      condition had been greatly changed during slumber. I now lay upon
+      my back, and at full length, on a species of low framework of
+      wood. To this I was securely bound by a long strap resembling a
+      surcingle. It passed in many convolutions about my limbs and
+      body, leaving at liberty only my head, and my left arm to such
+      extent that I could, by dint of much exertion, supply myself with
+      food from an earthen dish which lay by my side on the floor. I
+      saw, to my horror, that the pitcher had been removed. I say to my
+      horror—for I was consumed with intolerable thirst. This thirst it
+      appeared to be the design of my persecutors to stimulate—for the
+      food in the dish was meat pungently seasoned.
+
+      Looking upward, I surveyed the ceiling of my prison. It was some
+      thirty or forty feet overhead, and constructed much as the side
+      walls. In one of its panels a very singular figure riveted my
+      whole attention. It was the painted figure of Time as he is
+      commonly represented, save that, in lieu of a scythe, he held
+      what, at a casual glance, I supposed to be the pictured image of
+      a huge pendulum such as we see on antique clocks. There was
+      something, however, in the appearance of this machine which
+      caused me to regard it more attentively. While I gazed directly
+      upward at it (for its position was immediately over my own) I
+      fancied that I saw it in motion. In an instant afterward the
+      fancy was confirmed. Its sweep was brief, and of course slow. I
+      watched it for some minutes, somewhat in fear, but more in
+      wonder. Wearied at length with observing its dull movement, I
+      turned my eyes upon the other objects in the cell.
+
+      A slight noise attracted my notice, and, looking to the floor, I
+      saw several enormous rats traversing it. They had issued from the
+      well, which lay just within view to my right. Even then, while I
+      gazed, they came up in troops, hurriedly, with ravenous eyes,
+      allured by the scent of the meat. From this it required much
+      effort and attention to scare them away.
+
+      It might have been half an hour, perhaps even an hour, (for I
+      could take but imperfect note of time) before I again cast my
+      eyes upward. What I then saw confounded and amazed me. The sweep
+      of the pendulum had increased in extent by nearly a yard. As a
+      natural consequence, its velocity was also much greater. But what
+      mainly disturbed me was the idea that had perceptibly descended.
+      I now observed—with what horror it is needless to say—that its
+      nether extremity was formed of a crescent of glittering steel,
+      about a foot in length from horn to horn; the horns upward, and
+      the under edge evidently as keen as that of a razor. Like a razor
+      also, it seemed massy and heavy, tapering from the edge into a
+      solid and broad structure above. It was appended to a weighty rod
+      of brass, and the whole hissed as it swung through the air.
+
+      I could no longer doubt the doom prepared for me by monkish
+      ingenuity in torture. My cognizance of the pit had become known
+      to the inquisitorial agents—_the pit_, whose horrors had been
+      destined for so bold a recusant as myself—the pit, typical of
+      hell, and regarded by rumor as the Ultima Thule of all their
+      punishments. The plunge into this pit I had avoided by the merest
+      of accidents, I knew that surprise, or entrapment into torment,
+      formed an important portion of all the grotesquerie of these
+      dungeon deaths. Having failed to fall, it was no part of the
+      demon plan to hurl me into the abyss; and thus (there being no
+      alternative) a different and a milder destruction awaited me.
+      Milder! I half smiled in my agony as I thought of such
+      application of such a term.
+
+      What boots it to tell of the long, long hours of horror more than
+      mortal, during which I counted the rushing vibrations of the
+      steel! Inch by inch—line by line—with a descent only appreciable
+      at intervals that seemed ages—down and still down it came! Days
+      passed—it might have been that many days passed—ere it swept so
+      closely over me as to fan me with its acrid breath. The odor of
+      the sharp steel forced itself into my nostrils. I prayed—I
+      wearied heaven with my prayer for its more speedy descent. I grew
+      frantically mad, and struggled to force myself upward against the
+      sweep of the fearful scimitar. And then I fell suddenly calm, and
+      lay smiling at the glittering death, as a child at some rare
+      bauble.
+
+      There was another interval of utter insensibility; it was brief;
+      for, upon again lapsing into life there had been no perceptible
+      descent in the pendulum. But it might have been long; for I knew
+      there were demons who took note of my swoon, and who could have
+      arrested the vibration at pleasure. Upon my recovery, too, I felt
+      very—oh! inexpressibly—sick and weak, as if through long
+      inanition. Even amid the agonies of that period, the human nature
+      craved food. With painful effort I outstretched my left arm as
+      far as my bonds permitted, and took possession of the small
+      remnant which had been spared me by the rats. As I put a portion
+      of it within my lips, there rushed to my mind a half formed
+      thought of joy—of hope. Yet what business had _I_ with hope? It
+      was, as I say, a half formed thought—man has many such, which are
+      never completed. I felt that it was of joy—of hope; but felt also
+      that it had perished in its formation. In vain I struggled to
+      perfect—to regain it. Long suffering had nearly annihilated all
+      my ordinary powers of mind. I was an imbecile—an idiot.
+
+      The vibration of the pendulum was at right angles to my length. I
+      saw that the crescent was designed to cross the region of the
+      heart. It would fray the serge of my robe—it would return and
+      repeat its operations—again—and again. Notwithstanding its
+      terrifically wide sweep (some thirty feet or more) and the
+      hissing vigor of its descent, sufficient to sunder these very
+      walls of iron, still the fraying of my robe would be all that,
+      for several minutes, it would accomplish. And at this thought I
+      paused. I dared not go farther than this reflection. I dwelt upon
+      it with a pertinacity of attention—as if, in so dwelling, I could
+      arrest here the descent of the steel. I forced myself to ponder
+      upon the sound of the crescent as it should pass across the
+      garment—upon the peculiar thrilling sensation which the friction
+      of cloth produces on the nerves. I pondered upon all this
+      frivolity until my teeth were on edge.
+
+      Down—steadily down it crept. I took a frenzied pleasure in
+      contrasting its downward with its lateral velocity. To the
+      right—to the left—far and wide—with the shriek of a damned
+      spirit! to my heart with the stealthy pace of the tiger! I
+      alternately laughed and howled as the one or the other idea grew
+      predominant.
+
+      Down—certainly, relentlessly down! It vibrated within three
+      inches of my bosom! I struggled violently, furiously, to free my
+      left arm. This was free only from the elbow to the hand. I could
+      reach the latter, from the platter beside me, to my mouth, with
+      great effort, but no farther. Could I have broken the fastenings
+      above the elbow, I would have seized and attempted to arrest the
+      pendulum. I might as well have attempted to arrest an avalanche!
+
+      Down—still unceasingly—still inevitably down! I gasped and
+      struggled at each vibration. I shrunk convulsively at its every
+      sweep. My eyes followed its outward or upward whirls with the
+      eagerness of the most unmeaning despair; they closed themselves
+      spasmodically at the descent, although death would have been a
+      relief, oh, how unspeakable! Still I quivered in every nerve to
+      think how slight a sinking of the machinery would precipitate
+      that keen, glistening axe upon my bosom. It was hope that
+      prompted the nerve to quiver—the frame to shrink. It was hope—the
+      hope that triumphs on the rack—that whispers to the
+      death-condemned even in the dungeons of the Inquisition.
+
+      I saw that some ten or twelve vibrations would bring the steel in
+      actual contact with my robe, and with this observation there
+      suddenly came over my spirit all the keen, collected calmness of
+      despair. For the first time during many hours—or perhaps days—I
+      thought. It now occurred to me that the bandage, or surcingle,
+      which enveloped me, was unique. I was tied by no separate cord.
+      The first stroke of the razorlike crescent athwart any portion of
+      the band, would so detach it that it might be unwound from my
+      person by means of my left hand. But how fearful, in that case,
+      the proximity of the steel! The result of the slightest struggle
+      how deadly! Was it likely, moreover, that the minions of the
+      torturer had not foreseen and provided for this possibility? Was
+      it probable that the bandage crossed my bosom in the track of the
+      pendulum? Dreading to find my faint, and, as it seemed, my last
+      hope frustrated, I so far elevated my head as to obtain a
+      distinct view of my breast. The surcingle enveloped my limbs and
+      body close in all directions—save in the path of the destroying
+      crescent.
+
+      Scarcely had I dropped my head back into its original position,
+      when there flashed upon my mind what I cannot better describe
+      than as the unformed half of that idea of deliverance to which I
+      have previously alluded, and of which a moiety only floated
+      indeterminately through my brain when I raised food to my burning
+      lips. The whole thought was now present—feeble, scarcely sane,
+      scarcely definite,—but still entire. I proceeded at once, with
+      the nervous energy of despair, to attempt its execution.
+
+      For many hours the immediate vicinity of the low framework upon
+      which I lay had been literally swarming with rats. They were
+      wild, bold, ravenous—their red eyes glaring upon me as if they
+      waited but for motionlessness on my part to make me their prey.
+      “To what food,” I thought, “have they been accustomed in the
+      well?”
+
+      They had devoured, in spite of all my efforts to prevent them,
+      all but a small remnant of the contents of the dish. I had fallen
+      into an habitual see-saw, or wave of the hand about the platter;
+      and, at length, the unconscious uniformity of the movement
+      deprived it of effect. In their voracity the vermin frequently
+      fastened their sharp fangs in my fingers. With the particles of
+      the oily and spicy viand which now remained, I thoroughly rubbed
+      the bandage wherever I could reach it; then, raising my hand from
+      the floor, I lay breathlessly still.
+
+      At first the ravenous animals were startled and terrified at the
+      change—at the cessation of movement. They shrank alarmedly back;
+      many sought the well. But this was only for a moment. I had not
+      counted in vain upon their voracity. Observing that I remained
+      without motion, one or two of the boldest leaped upon the
+      frame-work, and smelt at the surcingle. This seemed the signal
+      for a general rush. Forth from the well they hurried in fresh
+      troops. They clung to the wood—they overran it, and leaped in
+      hundreds upon my person. The measured movement of the pendulum
+      disturbed them not at all. Avoiding its strokes they busied
+      themselves with the anointed bandage. They pressed—they swarmed
+      upon me in ever accumulating heaps. They writhed upon my throat;
+      their cold lips sought my own; I was half stifled by their
+      thronging pressure; disgust, for which the world has no name,
+      swelled my bosom, and chilled, with a heavy clamminess, my heart.
+      Yet one minute, and I felt that the struggle would be over.
+      Plainly I perceived the loosening of the bandage. I knew that in
+      more than one place it must be already severed. With a more than
+      human resolution I lay still.
+
+      Nor had I erred in my calculations—nor had I endured in vain. I
+      at length felt that I was free. The surcingle hung in ribands
+      from my body. But the stroke of the pendulum already pressed upon
+      my bosom. It had divided the serge of the robe. It had cut
+      through the linen beneath. Twice again it swung, and a sharp
+      sense of pain shot through every nerve. But the moment of escape
+      had arrived. At a wave of my hand my deliverers hurried
+      tumultuously away. With a steady movement—cautious, sidelong,
+      shrinking, and slow—I slid from the embrace of the bandage and
+      beyond the reach of the scimitar. For the moment, at least, I was
+      free.
+
+      Free!—and in the grasp of the Inquisition! I had scarcely stepped
+      from my wooden bed of horror upon the stone floor of the prison,
+      when the motion of the hellish machine ceased and I beheld it
+      drawn up, by some invisible force, through the ceiling. This was
+      a lesson which I took desperately to heart. My every motion was
+      undoubtedly watched. Free!—I had but escaped death in one form of
+      agony, to be delivered unto worse than death in some other. With
+      that thought I rolled my eves nervously around on the barriers of
+      iron that hemmed me in. Something unusual—some change which, at
+      first, I could not appreciate distinctly—it was obvious, had
+      taken place in the apartment. For many minutes of a dreamy and
+      trembling abstraction, I busied myself in vain, unconnected
+      conjecture. During this period, I became aware, for the first
+      time, of the origin of the sulphurous light which illumined the
+      cell. It proceeded from a fissure, about half an inch in width,
+      extending entirely around the prison at the base of the walls,
+      which thus appeared, and were, completely separated from the
+      floor. I endeavored, but of course in vain, to look through the
+      aperture.
+
+      As I arose from the attempt, the mystery of the alteration in the
+      chamber broke at once upon my understanding. I have observed
+      that, although the outlines of the figures upon the walls were
+      sufficiently distinct, yet the colors seemed blurred and
+      indefinite. These colors had now assumed, and were momentarily
+      assuming, a startling and most intense brilliancy, that gave to
+      the spectral and fiendish portraitures an aspect that might have
+      thrilled even firmer nerves than my own. Demon eyes, of a wild
+      and ghastly vivacity, glared upon me in a thousand directions,
+      where none had been visible before, and gleamed with the lurid
+      lustre of a fire that I could not force my imagination to regard
+      as unreal.
+
+      _Unreal!_—Even while I breathed there came to my nostrils the
+      breath of the vapour of heated iron! A suffocating odour pervaded
+      the prison! A deeper glow settled each moment in the eyes that
+      glared at my agonies! A richer tint of crimson diffused itself
+      over the pictured horrors of blood. I panted! I gasped for
+      breath! There could be no doubt of the design of my
+      tormentors—oh! most unrelenting! oh! most demoniac of men! I
+      shrank from the glowing metal to the centre of the cell. Amid the
+      thought of the fiery destruction that impended, the idea of the
+      coolness of the well came over my soul like balm. I rushed to its
+      deadly brink. I threw my straining vision below. The glare from
+      the enkindled roof illumined its inmost recesses. Yet, for a wild
+      moment, did my spirit refuse to comprehend the meaning of what I
+      saw. At length it forced—it wrestled its way into my soul—it
+      burned itself in upon my shuddering reason. Oh! for a voice to
+      speak!—oh! horror!—oh! any horror but this! With a shriek, I
+      rushed from the margin, and buried my face in my hands—weeping
+      bitterly.
+
+      The heat rapidly increased, and once again I looked up,
+      shuddering as with a fit of the ague. There had been a second
+      change in the cell—and now the change was obviously in the form.
+      As before, it was in vain that I, at first, endeavoured to
+      appreciate or understand what was taking place. But not long was
+      I left in doubt. The Inquisitorial vengeance had been hurried by
+      my two-fold escape, and there was to be no more dallying with the
+      King of Terrors. The room had been square. I saw that two of its
+      iron angles were now acute—two, consequently, obtuse. The fearful
+      difference quickly increased with a low rumbling or moaning
+      sound. In an instant the apartment had shifted its form into that
+      of a lozenge. But the alteration stopped not here—I neither hoped
+      nor desired it to stop. I could have clasped the red walls to my
+      bosom as a garment of eternal peace. “Death,” I said, “any death
+      but that of the pit!” Fool! might I have not known that into the
+      pit it was the object of the burning iron to urge me? Could I
+      resist its glow? or, if even that, could I withstand its
+      pressure? And now, flatter and flatter grew the lozenge, with a
+      rapidity that left me no time for contemplation. Its centre, and
+      of course, its greatest width, came just over the yawning gulf. I
+      shrank back—but the closing walls pressed me resistlessly onward.
+      At length for my seared and writhing body there was no longer an
+      inch of foothold on the firm floor of the prison. I struggled no
+      more, but the agony of my soul found vent in one loud, long, and
+      final scream of despair. I felt that I tottered upon the brink—I
+      averted my eyes—
+
+      There was a discordant hum of human voices! There was a loud
+      blast as of many trumpets! There was a harsh grating as of a
+      thousand thunders! The fiery walls rushed back! An outstretched
+      arm caught my own as I fell, fainting, into the abyss. It was
+      that of General Lasalle. The French army had entered Toledo. The
+      Inquisition was in the hands of its enemies.
+
+
+
+
+THE PREMATURE BURIAL
+
+
+      There are certain themes of which the interest is all-absorbing,
+      but which are too entirely horrible for the purposes of
+      legitimate fiction. These the mere romanticist must eschew, if he
+      do not wish to offend or to disgust. They are with propriety
+      handled only when the severity and majesty of Truth sanctify and
+      sustain them. We thrill, for example, with the most intense of
+      “pleasurable pain” over the accounts of the Passage of the
+      Beresina, of the Earthquake at Lisbon, of the Plague at London,
+      of the Massacre of St. Bartholomew, or of the stifling of the
+      hundred and twenty-three prisoners in the Black Hole at Calcutta.
+      But in these accounts it is the fact——it is the reality——it is
+      the history which excites. As inventions, we should regard them
+      with simple abhorrence.
+
+      I have mentioned some few of the more prominent and august
+      calamities on record; but in these it is the extent, not less
+      than the character of the calamity, which so vividly impresses
+      the fancy. I need not remind the reader that, from the long and
+      weird catalogue of human miseries, I might have selected many
+      individual instances more replete with essential suffering than
+      any of these vast generalities of disaster. The true
+      wretchedness, indeed—the ultimate woe——is particular, not
+      diffuse. That the ghastly extremes of agony are endured by man
+      the unit, and never by man the mass——for this let us thank a
+      merciful God!
+
+      To be buried while alive is, beyond question, the most terrific
+      of these extremes which has ever fallen to the lot of mere
+      mortality. That it has frequently, very frequently, so fallen
+      will scarcely be denied by those who think. The boundaries which
+      divide Life from Death are at best shadowy and vague. Who shall
+      say where the one ends, and where the other begins? We know that
+      there are diseases in which occur total cessations of all the
+      apparent functions of vitality, and yet in which these cessations
+      are merely suspensions, properly so called. They are only
+      temporary pauses in the incomprehensible mechanism. A certain
+      period elapses, and some unseen mysterious principle again sets
+      in motion the magic pinions and the wizard wheels. The silver
+      cord was not for ever loosed, nor the golden bowl irreparably
+      broken. But where, meantime, was the soul?
+
+      Apart, however, from the inevitable conclusion, _a priori_ that
+      such causes must produce such effects——that the well-known
+      occurrence of such cases of suspended animation must naturally
+      give rise, now and then, to premature interments—apart from this
+      consideration, we have the direct testimony of medical and
+      ordinary experience to prove that a vast number of such
+      interments have actually taken place. I might refer at once, if
+      necessary, to a hundred well-authenticated instances. One of very
+      remarkable character, and of which the circumstances may be fresh
+      in the memory of some of my readers, occurred, not very long ago,
+      in the neighboring city of Baltimore, where it occasioned a
+      painful, intense, and widely-extended excitement. The wife of one
+      of the most respectable citizens—a lawyer of eminence and a
+      member of Congress—was seized with a sudden and unaccountable
+      illness, which completely baffled the skill of her physicians.
+      After much suffering she died, or was supposed to die. No one
+      suspected, indeed, or had reason to suspect, that she was not
+      actually dead. She presented all the ordinary appearances of
+      death. The face assumed the usual pinched and sunken outline. The
+      lips were of the usual marble pallor. The eyes were lustreless.
+      There was no warmth. Pulsation had ceased. For three days the
+      body was preserved unburied, during which it had acquired a stony
+      rigidity. The funeral, in short, was hastened, on account of the
+      rapid advance of what was supposed to be decomposition.
+
+      The lady was deposited in her family vault, which, for three
+      subsequent years, was undisturbed. At the expiration of this term
+      it was opened for the reception of a sarcophagus; but, alas! how
+      fearful a shock awaited the husband, who, personally, threw open
+      the door! As its portals swung outwardly back, some
+      white-apparelled object fell rattling within his arms. It was the
+      skeleton of his wife in her yet unmoulded shroud.
+
+      A careful investigation rendered it evident that she had revived
+      within two days after her entombment; that her struggles within
+      the coffin had caused it to fall from a ledge, or shelf to the
+      floor, where it was so broken as to permit her escape. A lamp
+      which had been accidentally left, full of oil, within the tomb,
+      was found empty; it might have been exhausted, however, by
+      evaporation. On the uttermost of the steps which led down into
+      the dread chamber was a large fragment of the coffin, with which,
+      it seemed, that she had endeavored to arrest attention by
+      striking the iron door. While thus occupied, she probably
+      swooned, or possibly died, through sheer terror; and, in failing,
+      her shroud became entangled in some iron-work which projected
+      interiorly. Thus she remained, and thus she rotted, erect.
+
+      In the year 1810, a case of living inhumation happened in France,
+      attended with circumstances which go far to warrant the assertion
+      that truth is, indeed, stranger than fiction. The heroine of the
+      story was a Mademoiselle Victorine Lafourcade, a young girl of
+      illustrious family, of wealth, and of great personal beauty.
+      Among her numerous suitors was Julien Bossuet, a poor
+      _litterateur_, or journalist of Paris. His talents and general
+      amiability had recommended him to the notice of the heiress, by
+      whom he seems to have been truly beloved; but her pride of birth
+      decided her, finally, to reject him, and to wed a Monsieur
+      Renelle, a banker and a diplomatist of some eminence. After
+      marriage, however, this gentleman neglected, and, perhaps, even
+      more positively ill-treated her. Having passed with him some
+      wretched years, she died—at least her condition so closely
+      resembled death as to deceive every one who saw her. She was
+      buried——not in a vault, but in an ordinary grave in the village
+      of her nativity. Filled with despair, and still inflamed by the
+      memory of a profound attachment, the lover journeys from the
+      capital to the remote province in which the village lies, with
+      the romantic purpose of disinterring the corpse, and possessing
+      himself of its luxuriant tresses. He reaches the grave. At
+      midnight he unearths the coffin, opens it, and is in the act of
+      detaching the hair, when he is arrested by the unclosing of the
+      beloved eyes. In fact, the lady had been buried alive. Vitality
+      had not altogether departed, and she was aroused by the caresses
+      of her lover from the lethargy which had been mistaken for death.
+      He bore her frantically to his lodgings in the village. He
+      employed certain powerful restoratives suggested by no little
+      medical learning. In fine, she revived. She recognized her
+      preserver. She remained with him until, by slow degrees, she
+      fully recovered her original health. Her woman’s heart was not
+      adamant, and this last lesson of love sufficed to soften it. She
+      bestowed it upon Bossuet. She returned no more to her husband,
+      but, concealing from him her resurrection, fled with her lover to
+      America. Twenty years afterward, the two returned to France, in
+      the persuasion that time had so greatly altered the lady’s
+      appearance that her friends would be unable to recognize her.
+      They were mistaken, however, for, at the first meeting, Monsieur
+      Renelle did actually recognize and make claim to his wife. This
+      claim she resisted, and a judicial tribunal sustained her in her
+      resistance, deciding that the peculiar circumstances, with the
+      long lapse of years, had extinguished, not only equitably, but
+      legally, the authority of the husband.
+
+      The “Chirurgical Journal” of Leipsic, a periodical of high
+      authority and merit, which some American bookseller would do well
+      to translate and republish, records in a late number a very
+      distressing event of the character in question.
+
+      An officer of artillery, a man of gigantic stature and of robust
+      health, being thrown from an unmanageable horse, received a very
+      severe contusion upon the head, which rendered him insensible at
+      once; the skull was slightly fractured, but no immediate danger
+      was apprehended. Trepanning was accomplished successfully. He was
+      bled, and many other of the ordinary means of relief were
+      adopted. Gradually, however, he fell into a more and more
+      hopeless state of stupor, and, finally, it was thought that he
+      died.
+
+      The weather was warm, and he was buried with indecent haste in
+      one of the public cemeteries. His funeral took place on Thursday.
+      On the Sunday following, the grounds of the cemetery were, as
+      usual, much thronged with visitors, and about noon an intense
+      excitement was created by the declaration of a peasant that,
+      while sitting upon the grave of the officer, he had distinctly
+      felt a commotion of the earth, as if occasioned by some one
+      struggling beneath. At first little attention was paid to the
+      man’s asseveration; but his evident terror, and the dogged
+      obstinacy with which he persisted in his story, had at length
+      their natural effect upon the crowd. Spades were hurriedly
+      procured, and the grave, which was shamefully shallow, was in a
+      few minutes so far thrown open that the head of its occupant
+      appeared. He was then seemingly dead; but he sat nearly erect
+      within his coffin, the lid of which, in his furious struggles, he
+      had partially uplifted.
+
+      He was forthwith conveyed to the nearest hospital, and there
+      pronounced to be still living, although in an asphytic condition.
+      After some hours he revived, recognized individuals of his
+      acquaintance, and, in broken sentences spoke of his agonies in
+      the grave.
+
+      From what he related, it was clear that he must have been
+      conscious of life for more than an hour, while inhumed, before
+      lapsing into insensibility. The grave was carelessly and loosely
+      filled with an exceedingly porous soil; and thus some air was
+      necessarily admitted. He heard the footsteps of the crowd
+      overhead, and endeavored to make himself heard in turn. It was
+      the tumult within the grounds of the cemetery, he said, which
+      appeared to awaken him from a deep sleep, but no sooner was he
+      awake than he became fully aware of the awful horrors of his
+      position.
+
+      This patient, it is recorded, was doing well and seemed to be in
+      a fair way of ultimate recovery, but fell a victim to the
+      quackeries of medical experiment. The galvanic battery was
+      applied, and he suddenly expired in one of those ecstatic
+      paroxysms which, occasionally, it superinduces.
+
+      The mention of the galvanic battery, nevertheless, recalls to my
+      memory a well known and very extraordinary case in point, where
+      its action proved the means of restoring to animation a young
+      attorney of London, who had been interred for two days. This
+      occurred in 1831, and created, at the time, a very profound
+      sensation wherever it was made the subject of converse.
+
+      The patient, Mr. Edward Stapleton, had died, apparently of typhus
+      fever, accompanied with some anomalous symptoms which had excited
+      the curiosity of his medical attendants. Upon his seeming
+      decease, his friends were requested to sanction a post-mortem
+      examination, but declined to permit it. As often happens, when
+      such refusals are made, the practitioners resolved to disinter
+      the body and dissect it at leisure, in private. Arrangements were
+      easily effected with some of the numerous corps of
+      body-snatchers, with which London abounds; and, upon the third
+      night after the funeral, the supposed corpse was unearthed from a
+      grave eight feet deep, and deposited in the opening chamber of
+      one of the private hospitals.
+
+      An incision of some extent had been actually made in the abdomen,
+      when the fresh and undecayed appearance of the subject suggested
+      an application of the battery. One experiment succeeded another,
+      and the customary effects supervened, with nothing to
+      characterize them in any respect, except, upon one or two
+      occasions, a more than ordinary degree of life-likeness in the
+      convulsive action.
+
+      It grew late. The day was about to dawn; and it was thought
+      expedient, at length, to proceed at once to the dissection. A
+      student, however, was especially desirous of testing a theory of
+      his own, and insisted upon applying the battery to one of the
+      pectoral muscles. A rough gash was made, and a wire hastily
+      brought in contact, when the patient, with a hurried but quite
+      unconvulsive movement, arose from the table, stepped into the
+      middle of the floor, gazed about him uneasily for a few seconds,
+      and then—spoke. What he said was unintelligible, but words were
+      uttered; the syllabification was distinct. Having spoken, he fell
+      heavily to the floor.
+
+      For some moments all were paralyzed with awe—but the urgency of
+      the case soon restored them their presence of mind. It was seen
+      that Mr. Stapleton was alive, although in a swoon. Upon
+      exhibition of ether he revived and was rapidly restored to
+      health, and to the society of his friends—from whom, however, all
+      knowledge of his resuscitation was withheld, until a relapse was
+      no longer to be apprehended. Their wonder—their rapturous
+      astonishment—may be conceived.
+
+      The most thrilling peculiarity of this incident, nevertheless, is
+      involved in what Mr. S. himself asserts. He declares that at no
+      period was he altogether insensible—that, dully and confusedly,
+      he was aware of everything which happened to him, from the moment
+      in which he was pronounced dead by his physicians, to that in
+      which he fell swooning to the floor of the hospital. “I am
+      alive,” were the uncomprehended words which, upon recognizing the
+      locality of the dissecting-room, he had endeavored, in his
+      extremity, to utter.
+
+      It were an easy matter to multiply such histories as these—but I
+      forbear—for, indeed, we have no need of such to establish the
+      fact that premature interments occur. When we reflect how very
+      rarely, from the nature of the case, we have it in our power to
+      detect them, we must admit that they may frequently occur without
+      our cognizance. Scarcely, in truth, is a graveyard ever
+      encroached upon, for any purpose, to any great extent, that
+      skeletons are not found in postures which suggest the most
+      fearful of suspicions.
+
+      Fearful indeed the suspicion—but more fearful the doom! It may be
+      asserted, without hesitation, that no event is so terribly well
+      adapted to inspire the supremeness of bodily and of mental
+      distress, as is burial before death. The unendurable oppression
+      of the lungs—the stifling fumes from the damp earth—the clinging
+      to the death garments—the rigid embrace of the narrow house—the
+      blackness of the absolute Night—the silence like a sea that
+      overwhelms—the unseen but palpable presence of the Conqueror
+      Worm—these things, with the thoughts of the air and grass above,
+      with memory of dear friends who would fly to save us if but
+      informed of our fate, and with consciousness that of this fate
+      they can never be informed—that our hopeless portion is that of
+      the really dead—these considerations, I say, carry into the
+      heart, which still palpitates, a degree of appalling and
+      intolerable horror from which the most daring imagination must
+      recoil. We know of nothing so agonizing upon Earth—we can dream
+      of nothing half so hideous in the realms of the nethermost Hell.
+      And thus all narratives upon this topic have an interest
+      profound; an interest, nevertheless, which, through the sacred
+      awe of the topic itself, very properly and very peculiarly
+      depends upon our conviction of the truth of the matter narrated.
+      What I have now to tell is of my own actual knowledge—of my own
+      positive and personal experience.
+
+      For several years I had been subject to attacks of the singular
+      disorder which physicians have agreed to term catalepsy, in
+      default of a more definitive title. Although both the immediate
+      and the predisposing causes, and even the actual diagnosis, of
+      this disease are still mysterious, its obvious and apparent
+      character is sufficiently well understood. Its variations seem to
+      be chiefly of degree. Sometimes the patient lies, for a day only,
+      or even for a shorter period, in a species of exaggerated
+      lethargy. He is senseless and externally motionless; but the
+      pulsation of the heart is still faintly perceptible; some traces
+      of warmth remain; a slight color lingers within the centre of the
+      cheek; and, upon application of a mirror to the lips, we can
+      detect a torpid, unequal, and vacillating action of the lungs.
+      Then again the duration of the trance is for weeks—even for
+      months; while the closest scrutiny, and the most rigorous medical
+      tests, fail to establish any material distinction between the
+      state of the sufferer and what we conceive of absolute death.
+      Very usually he is saved from premature interment solely by the
+      knowledge of his friends that he has been previously subject to
+      catalepsy, by the consequent suspicion excited, and, above all,
+      by the non-appearance of decay. The advances of the malady are,
+      luckily, gradual. The first manifestations, although marked, are
+      unequivocal. The fits grow successively more and more
+      distinctive, and endure each for a longer term than the
+      preceding. In this lies the principal security from inhumation.
+      The unfortunate whose first attack should be of the extreme
+      character which is occasionally seen, would almost inevitably be
+      consigned alive to the tomb.
+
+      My own case differed in no important particular from those
+      mentioned in medical books. Sometimes, without any apparent
+      cause, I sank, little by little, into a condition of
+      semi-syncope, or half swoon; and, in this condition, without
+      pain, without ability to stir, or, strictly speaking, to think,
+      but with a dull lethargic consciousness of life and of the
+      presence of those who surrounded my bed, I remained, until the
+      crisis of the disease restored me, suddenly, to perfect
+      sensation. At other times I was quickly and impetuously smitten.
+      I grew sick, and numb, and chilly, and dizzy, and so fell
+      prostrate at once. Then, for weeks, all was void, and black, and
+      silent, and Nothing became the universe. Total annihilation could
+      be no more. From these latter attacks I awoke, however, with a
+      gradation slow in proportion to the suddenness of the seizure.
+      Just as the day dawns to the friendless and houseless beggar who
+      roams the streets throughout the long desolate winter night—just
+      so tardily—just so wearily—just so cheerily came back the light
+      of the Soul to me.
+
+      Apart from the tendency to trance, however, my general health
+      appeared to be good; nor could I perceive that it was at all
+      affected by the one prevalent malady—unless, indeed, an
+      idiosyncrasy in my ordinary sleep may be looked upon as
+      superinduced. Upon awaking from slumber, I could never gain, at
+      once, thorough possession of my senses, and always remained, for
+      many minutes, in much bewilderment and perplexity—the mental
+      faculties in general, but the memory in especial, being in a
+      condition of absolute abeyance.
+
+      In all that I endured there was no physical suffering but of
+      moral distress an infinitude. My fancy grew charnel, I talked “of
+      worms, of tombs, and epitaphs.” I was lost in reveries of death,
+      and the idea of premature burial held continual possession of my
+      brain. The ghastly Danger to which I was subjected haunted me day
+      and night. In the former, the torture of meditation was
+      excessive—in the latter, supreme. When the grim Darkness
+      overspread the Earth, then, with every horror of thought, I
+      shook—shook as the quivering plumes upon the hearse. When Nature
+      could endure wakefulness no longer, it was with a struggle that I
+      consented to sleep—for I shuddered to reflect that, upon awaking,
+      I might find myself the tenant of a grave. And when, finally, I
+      sank into slumber, it was only to rush at once into a world of
+      phantasms, above which, with vast, sable, overshadowing wing,
+      hovered, predominant, the one sepulchral Idea.
+
+      From the innumerable images of gloom which thus oppressed me in
+      dreams, I select for record but a solitary vision. Methought I
+      was immersed in a cataleptic trance of more than usual duration
+      and profundity. Suddenly there came an icy hand upon my forehead,
+      and an impatient, gibbering voice whispered the word “Arise!”
+      within my ear.
+
+      I sat erect. The darkness was total. I could not see the figure
+      of him who had aroused me. I could call to mind neither the
+      period at which I had fallen into the trance, nor the locality in
+      which I then lay. While I remained motionless, and busied in
+      endeavors to collect my thought, the cold hand grasped me
+      fiercely by the wrist, shaking it petulantly, while the gibbering
+      voice said again:
+
+      “Arise! did I not bid thee arise?”
+
+      “And who,” I demanded, “art thou?”
+
+      “I have no name in the regions which I inhabit,” replied the
+      voice, mournfully; “I was mortal, but am fiend. I was merciless,
+      but am pitiful. Thou dost feel that I shudder. My teeth chatter
+      as I speak, yet it is not with the chilliness of the night—of the
+      night without end. But this hideousness is insufferable. How
+      canst thou tranquilly sleep? I cannot rest for the cry of these
+      great agonies. These sights are more than I can bear. Get thee
+      up! Come with me into the outer Night, and let me unfold to thee
+      the graves. Is not this a spectacle of woe?—Behold!”
+
+      I looked; and the unseen figure, which still grasped me by the
+      wrist, had caused to be thrown open the graves of all mankind;
+      and from each issued the faint phosphoric radiance of decay; so
+      that I could see into the innermost recesses, and there view the
+      shrouded bodies in their sad and solemn slumbers with the worm.
+      But alas! the real sleepers were fewer, by many millions, than
+      those who slumbered not at all; and there was a feeble
+      struggling; and there was a general sad unrest; and from out the
+      depths of the countless pits there came a melancholy rustling
+      from the garments of the buried. And of those who seemed
+      tranquilly to repose, I saw that a vast number had changed, in a
+      greater or less degree, the rigid and uneasy position in which
+      they had originally been entombed. And the voice again said to me
+      as I gazed:
+
+      “Is it not—oh! is it _not_ a pitiful sight?” But, before I could
+      find words to reply, the figure had ceased to grasp my wrist, the
+      phosphoric lights expired, and the graves were closed with a
+      sudden violence, while from out them arose a tumult of despairing
+      cries, saying again: “Is it not—O, God, is it _not_ a very
+      pitiful sight?”
+
+      Phantasies such as these, presenting themselves at night,
+      extended their terrific influence far into my waking hours. My
+      nerves became thoroughly unstrung, and I fell a prey to perpetual
+      horror. I hesitated to ride, or to walk, or to indulge in any
+      exercise that would carry me from home. In fact, I no longer
+      dared trust myself out of the immediate presence of those who
+      were aware of my proneness to catalepsy, lest, falling into one
+      of my usual fits, I should be buried before my real condition
+      could be ascertained. I doubted the care, the fidelity of my
+      dearest friends. I dreaded that, in some trance of more than
+      customary duration, they might be prevailed upon to regard me as
+      irrecoverable. I even went so far as to fear that, as I
+      occasioned much trouble, they might be glad to consider any very
+      protracted attack as sufficient excuse for getting rid of me
+      altogether. It was in vain they endeavored to reassure me by the
+      most solemn promises. I exacted the most sacred oaths, that under
+      no circumstances they would bury me until decomposition had so
+      materially advanced as to render farther preservation impossible.
+      And, even then, my mortal terrors would listen to no reason—would
+      accept no consolation. I entered into a series of elaborate
+      precautions. Among other things, I had the family vault so
+      remodelled as to admit of being readily opened from within. The
+      slightest pressure upon a long lever that extended far into the
+      tomb would cause the iron portal to fly back. There were
+      arrangements also for the free admission of air and light, and
+      convenient receptacles for food and water, within immediate reach
+      of the coffin intended for my reception. This coffin was warmly
+      and softly padded, and was provided with a lid, fashioned upon
+      the principle of the vault-door, with the addition of springs so
+      contrived that the feeblest movement of the body would be
+      sufficient to set it at liberty. Besides all this, there was
+      suspended from the roof of the tomb, a large bell, the rope of
+      which, it was designed, should extend through a hole in the
+      coffin, and so be fastened to one of the hands of the corpse.
+      But, alas? what avails the vigilance against the Destiny of man?
+      Not even these well-contrived securities sufficed to save from
+      the uttermost agonies of living inhumation, a wretch to these
+      agonies foredoomed!
+
+      There arrived an epoch—as often before there had arrived—in which
+      I found myself emerging from total unconsciousness into the first
+      feeble and indefinite sense of existence. Slowly—with a tortoise
+      gradation—approached the faint gray dawn of the psychal day. A
+      torpid uneasiness. An apathetic endurance of dull pain. No
+      care—no hope—no effort. Then, after a long interval, a ringing in
+      the ears; then, after a lapse still longer, a prickling or
+      tingling sensation in the extremities; then a seemingly eternal
+      period of pleasurable quiescence, during which the awakening
+      feelings are struggling into thought; then a brief re-sinking
+      into non-entity; then a sudden recovery. At length the slight
+      quivering of an eyelid, and immediately thereupon, an electric
+      shock of a terror, deadly and indefinite, which sends the blood
+      in torrents from the temples to the heart. And now the first
+      positive effort to think. And now the first endeavor to remember.
+      And now a partial and evanescent success. And now the memory has
+      so far regained its dominion, that, in some measure, I am
+      cognizant of my state. I feel that I am not awaking from ordinary
+      sleep. I recollect that I have been subject to catalepsy. And
+      now, at last, as if by the rush of an ocean, my shuddering spirit
+      is overwhelmed by the one grim Danger—by the one spectral and
+      ever-prevalent idea.
+
+      For some minutes after this fancy possessed me, I remained
+      without motion. And why? I could not summon courage to move. I
+      dared not make the effort which was to satisfy me of my fate—and
+      yet there was something at my heart which whispered me it was
+      sure. Despair—such as no other species of wretchedness ever calls
+      into being—despair alone urged me, after long irresolution, to
+      uplift the heavy lids of my eyes. I uplifted them. It was
+      dark—all dark. I knew that the fit was over. I knew that the
+      crisis of my disorder had long passed. I knew that I had now
+      fully recovered the use of my visual faculties—and yet it was
+      dark—all dark—the intense and utter raylessness of the Night that
+      endureth for evermore.
+
+      I endeavored to shriek; and my lips and my parched tongue moved
+      convulsively together in the attempt—but no voice issued from the
+      cavernous lungs, which oppressed as if by the weight of some
+      incumbent mountain, gasped and palpitated, with the heart, at
+      every elaborate and struggling inspiration.
+
+      The movement of the jaws, in this effort to cry aloud, showed me
+      that they were bound up, as is usual with the dead. I felt, too,
+      that I lay upon some hard substance; and by something similar my
+      sides were, also, closely compressed. So far, I had not ventured
+      to stir any of my limbs—but now I violently threw up my arms,
+      which had been lying at length, with the wrists crossed. They
+      struck a solid wooden substance, which extended above my person
+      at an elevation of not more than six inches from my face. I could
+      no longer doubt that I reposed within a coffin at last.
+
+      And now, amid all my infinite miseries, came sweetly the cherub
+      Hope—for I thought of my precautions. I writhed, and made
+      spasmodic exertions to force open the lid: it would not move. I
+      felt my wrists for the bell-rope: it was not to be found. And now
+      the Comforter fled for ever, and a still sterner Despair reigned
+      triumphant; for I could not help perceiving the absence of the
+      paddings which I had so carefully prepared—and then, too, there
+      came suddenly to my nostrils the strong peculiar odor of moist
+      earth. The conclusion was irresistible. I was not within the
+      vault. I had fallen into a trance while absent from home—while
+      among strangers—when, or how, I could not remember—and it was
+      they who had buried me as a dog—nailed up in some common
+      coffin—and thrust deep, deep, and for ever, into some ordinary
+      and nameless grave.
+
+      As this awful conviction forced itself, thus, into the innermost
+      chambers of my soul, I once again struggled to cry aloud. And in
+      this second endeavor I succeeded. A long, wild, and continuous
+      shriek, or yell of agony, resounded through the realms of the
+      subterranean Night.
+
+      “Hillo! hillo, there!” said a gruff voice, in reply.
+
+      “What the devil’s the matter now!” said a second.
+
+      “Get out o’ that!” said a third.
+
+      “What do you mean by yowling in that ere kind of style, like a
+      cattymount?” said a fourth; and hereupon I was seized and shaken
+      without ceremony, for several minutes, by a junto of very
+      rough-looking individuals. They did not arouse me from my
+      slumber—for I was wide awake when I screamed—but they restored me
+      to the full possession of my memory.
+
+      This adventure occurred near Richmond, in Virginia. Accompanied
+      by a friend, I had proceeded, upon a gunning expedition, some
+      miles down the banks of the James River. Night approached, and we
+      were overtaken by a storm. The cabin of a small sloop lying at
+      anchor in the stream, and laden with garden mould, afforded us
+      the only available shelter. We made the best of it, and passed
+      the night on board. I slept in one of the only two berths in the
+      vessel—and the berths of a sloop of sixty or twenty tons need
+      scarcely be described. That which I occupied had no bedding of
+      any kind. Its extreme width was eighteen inches. The distance of
+      its bottom from the deck overhead was precisely the same. I found
+      it a matter of exceeding difficulty to squeeze myself in.
+      Nevertheless, I slept soundly, and the whole of my vision—for it
+      was no dream, and no nightmare—arose naturally from the
+      circumstances of my position—from my ordinary bias of thought—and
+      from the difficulty, to which I have alluded, of collecting my
+      senses, and especially of regaining my memory, for a long time
+      after awaking from slumber. The men who shook me were the crew of
+      the sloop, and some laborers engaged to unload it. From the load
+      itself came the earthly smell. The bandage about the jaws was a
+      silk handkerchief in which I had bound up my head, in default of
+      my customary nightcap.
+
+      The tortures endured, however, were indubitably quite equal for
+      the time, to those of actual sepulture. They were fearfully—they
+      were inconceivably hideous; but out of Evil proceeded Good; for
+      their very excess wrought in my spirit an inevitable revulsion.
+      My soul acquired tone—acquired temper. I went abroad. I took
+      vigorous exercise. I breathed the free air of Heaven. I thought
+      upon other subjects than Death. I discarded my medical books.
+      “Buchan” I burned. I read no “Night Thoughts”—no fustian about
+      churchyards—no bugaboo tales—such as this. In short, I became a
+      new man, and lived a man’s life. From that memorable night, I
+      dismissed forever my charnel apprehensions, and with them
+      vanished the cataleptic disorder, of which, perhaps, they had
+      been less the consequence than the cause.
+
+      There are moments when, even to the sober eye of Reason, the
+      world of our sad Humanity may assume the semblance of a Hell—but
+      the imagination of man is no Carathis, to explore with impunity
+      its every cavern. Alas! the grim legion of sepulchral terrors
+      cannot be regarded as altogether fanciful—but, like the Demons in
+      whose company Afrasiab made his voyage down the Oxus, they must
+      sleep, or they will devour us—they must be suffered to slumber,
+      or we perish.
+
+
+
+
+THE DOMAIN OF ARNHEIM
+
+
+The garden like a lady fair was cut,
+    That lay as if she slumbered in delight,
+And to the open skies her eyes did shut.
+    The azure fields of Heaven were ’sembled right
+    In a large round, set with the flowers of light.
+The flowers de luce, and the round sparks of dew
+That hung upon their azure leaves did shew
+Like twinkling stars that sparkle in the evening blue.
+                    —_Giles Fletcher_.
+
+      From his cradle to his grave a gale of prosperity bore my friend
+      Ellison along. Nor do I use the word prosperity in its mere
+      worldly sense. I mean it as synonymous with happiness. The person
+      of whom I speak seemed born for the purpose of foreshadowing the
+      doctrines of Turgot, Price, Priestley, and Condorcet—of
+      exemplifying by individual instance what has been deemed the
+      chimera of the perfectionists. In the brief existence of Ellison
+      I fancy that I have seen refuted the dogma, that in man’s very
+      nature lies some hidden principle, the antagonist of bliss. An
+      anxious examination of his career has given me to understand that
+      in general, from the violation of a few simple laws of humanity
+      arises the wretchedness of mankind—that as a species we have in
+      our possession the as yet unwrought elements of content—and that,
+      even now, in the present darkness and madness of all thought on
+      the great question of the social condition, it is not impossible
+      that man, the individual, under certain unusual and highly
+      fortuitous conditions, may be happy.
+
+      With opinions such as these my young friend, too, was fully
+      imbued, and thus it is worthy of observation that the
+      uninterrupted enjoyment which distinguished his life was, in
+      great measure, the result of preconcert. It is indeed evident
+      that with less of the instinctive philosophy which, now and then,
+      stands so well in the stead of experience, Mr. Ellison would have
+      found himself precipitated, by the very extraordinary success of
+      his life, into the common vortex of unhappiness which yawns for
+      those of pre-eminent endowments. But it is by no means my object
+      to pen an essay on happiness. The ideas of my friend may be
+      summed up in a few words. He admitted but four elementary
+      principles, or more strictly, conditions of bliss. That which he
+      considered chief was (strange to say!) the simple and purely
+      physical one of free exercise in the open air. “The health,” he
+      said, “attainable by other means is scarcely worth the name.” He
+      instanced the ecstasies of the fox-hunter, and pointed to the
+      tillers of the earth, the only people who, as a class, can be
+      fairly considered happier than others. His second condition was
+      the love of woman. His third, and most difficult of realization,
+      was the contempt of ambition. His fourth was an object of
+      unceasing pursuit; and he held that, other things being equal,
+      the extent of attainable happiness was in proportion to the
+      spirituality of this object.
+
+      Ellison was remarkable in the continuous profusion of good gifts
+      lavished upon him by fortune. In personal grace and beauty he
+      exceeded all men. His intellect was of that order to which the
+      acquisition of knowledge is less a labor than an intuition and a
+      necessity. His family was one of the most illustrious of the
+      empire. His bride was the loveliest and most devoted of women.
+      His possessions had been always ample; but on the attainment of
+      his majority, it was discovered that one of those extraordinary
+      freaks of fate had been played in his behalf which startle the
+      whole social world amid which they occur, and seldom fail
+      radically to alter the moral constitution of those who are their
+      objects.
+
+      It appears that about a hundred years before Mr. Ellison’s coming
+      of age, there had died, in a remote province, one Mr. Seabright
+      Ellison. This gentleman had amassed a princely fortune, and,
+      having no immediate connections, conceived the whim of suffering
+      his wealth to accumulate for a century after his decease.
+      Minutely and sagaciously directing the various modes of
+      investment, he bequeathed the aggregate amount to the nearest of
+      blood, bearing the name of Ellison, who should be alive at the
+      end of the hundred years. Many attempts had been made to set
+      aside this singular bequest; their ex post facto character
+      rendered them abortive; but the attention of a jealous government
+      was aroused, and a legislative act finally obtained, forbidding
+      all similar accumulations. This act, however, did not prevent
+      young Ellison from entering into possession, on his twenty-first
+      birthday, as the heir of his ancestor Seabright, of a fortune of
+      four hundred and fifty millions of dollars. (*1)
+
+      When it had become known that such was the enormous wealth
+      inherited, there were, of course, many speculations as to the
+      mode of its disposal. The magnitude and the immediate
+      availability of the sum bewildered all who thought on the topic.
+      The possessor of any appreciable amount of money might have been
+      imagined to perform any one of a thousand things. With riches
+      merely surpassing those of any citizen, it would have been easy
+      to suppose him engaging to supreme excess in the fashionable
+      extravagances of his time—or busying himself with political
+      intrigue—or aiming at ministerial power—or purchasing increase of
+      nobility—or collecting large museums of virtu—or playing the
+      munificent patron of letters, of science, of art—or endowing, and
+      bestowing his name upon extensive institutions of charity. But
+      for the inconceivable wealth in the actual possession of the
+      heir, these objects and all ordinary objects were felt to afford
+      too limited a field. Recourse was had to figures, and these but
+      sufficed to confound. It was seen that, even at three per cent.,
+      the annual income of the inheritance amounted to no less than
+      thirteen millions and five hundred thousand dollars; which was
+      one million and one hundred and twenty-five thousand per month;
+      or thirty-six thousand nine hundred and eighty-six per day; or
+      one thousand five hundred and forty-one per hour; or six and
+      twenty dollars for every minute that flew. Thus the usual track
+      of supposition was thoroughly broken up. Men knew not what to
+      imagine. There were some who even conceived that Mr. Ellison
+      would divest himself of at least one-half of his fortune, as of
+      utterly superfluous opulence—enriching whole troops of his
+      relatives by division of his superabundance. To the nearest of
+      these he did, in fact, abandon the very unusual wealth which was
+      his own before the inheritance.
+
+      I was not surprised, however, to perceive that he had long made
+      up his mind on a point which had occasioned so much discussion to
+      his friends. Nor was I greatly astonished at the nature of his
+      decision. In regard to individual charities he had satisfied his
+      conscience. In the possibility of any improvement, properly so
+      called, being effected by man himself in the general condition of
+      man, he had (I am sorry to confess it) little faith. Upon the
+      whole, whether happily or unhappily, he was thrown back, in very
+      great measure, upon self.
+
+      In the widest and noblest sense he was a poet. He comprehended,
+      moreover, the true character, the august aims, the supreme
+      majesty and dignity of the poetic sentiment. The fullest, if not
+      the sole proper satisfaction of this sentiment he instinctively
+      felt to lie in the creation of novel forms of beauty. Some
+      peculiarities, either in his early education, or in the nature of
+      his intellect, had tinged with what is termed materialism all his
+      ethical speculations; and it was this bias, perhaps, which led
+      him to believe that the most advantageous at least, if not the
+      sole legitimate field for the poetic exercise, lies in the
+      creation of novel moods of purely physical loveliness. Thus it
+      happened he became neither musician nor poet—if we use this
+      latter term in its every-day acceptation. Or it might have been
+      that he neglected to become either, merely in pursuance of his
+      idea that in contempt of ambition is to be found one of the
+      essential principles of happiness on earth. Is it not indeed,
+      possible that, while a high order of genius is necessarily
+      ambitious, the highest is above that which is termed ambition?
+      And may it not thus happen that many far greater than Milton have
+      contentedly remained “mute and inglorious?” I believe that the
+      world has never seen—and that, unless through some series of
+      accidents goading the noblest order of mind into distasteful
+      exertion, the world will never see—that full extent of triumphant
+      execution, in the richer domains of art, of which the human
+      nature is absolutely capable.
+
+      Ellison became neither musician nor poet; although no man lived
+      more profoundly enamored of music and poetry. Under other
+      circumstances than those which invested him, it is not impossible
+      that he would have become a painter. Sculpture, although in its
+      nature rigorously poetical was too limited in its extent and
+      consequences, to have occupied, at any time, much of his
+      attention. And I have now mentioned all the provinces in which
+      the common understanding of the poetic sentiment has declared it
+      capable of expatiating. But Ellison maintained that the richest,
+      the truest, and most natural, if not altogether the most
+      extensive province, had been unaccountably neglected. No
+      definition had spoken of the landscape-gardener as of the poet;
+      yet it seemed to my friend that the creation of the
+      landscape-garden offered to the proper Muse the most magnificent
+      of opportunities. Here, indeed, was the fairest field for the
+      display of imagination in the endless combining of forms of novel
+      beauty; the elements to enter into combination being, by a vast
+      superiority, the most glorious which the earth could afford. In
+      the multiform and multicolor of the flowers and the trees, he
+      recognised the most direct and energetic efforts of Nature at
+      physical loveliness. And in the direction or concentration of
+      this effort—or, more properly, in its adaptation to the eyes
+      which were to behold it on earth—he perceived that he should be
+      employing the best means—laboring to the greatest advantage—in
+      the fulfilment, not only of his own destiny as poet, but of the
+      august purposes for which the Deity had implanted the poetic
+      sentiment in man.
+
+      “Its adaptation to the eyes which were to behold it on earth.” In
+      his explanation of this phraseology, Mr. Ellison did much toward
+      solving what has always seemed to me an enigma:—I mean the fact
+      (which none but the ignorant dispute) that no such combination of
+      scenery exists in nature as the painter of genius may produce. No
+      such paradises are to be found in reality as have glowed on the
+      canvas of Claude. In the most enchanting of natural landscapes,
+      there will always be found a defect or an excess—many excesses
+      and defects. While the component parts may defy, individually,
+      the highest skill of the artist, the arrangement of these parts
+      will always be susceptible of improvement. In short, no position
+      can be attained on the wide surface of the natural earth, from
+      which an artistical eye, looking steadily, will not find matter
+      of offence in what is termed the “composition” of the landscape.
+      And yet how unintelligible is this! In all other matters we are
+      justly instructed to regard nature as supreme. With her details
+      we shrink from competition. Who shall presume to imitate the
+      colors of the tulip, or to improve the proportions of the lily of
+      the valley? The criticism which says, of sculpture or
+      portraiture, that here nature is to be exalted or idealized
+      rather than imitated, is in error. No pictorial or sculptural
+      combinations of points of human liveliness do more than approach
+      the living and breathing beauty. In landscape alone is the
+      principle of the critic true; and, having felt its truth here, it
+      is but the headlong spirit of generalization which has led him to
+      pronounce it true throughout all the domains of art. Having, I
+      say, felt its truth here; for the feeling is no affectation or
+      chimera. The mathematics afford no more absolute demonstrations
+      than the sentiments of his art yields the artist. He not only
+      believes, but positively knows, that such and such apparently
+      arbitrary arrangements of matter constitute and alone constitute
+      the true beauty. His reasons, however, have not yet been matured
+      into expression. It remains for a more profound analysis than the
+      world has yet seen, fully to investigate and express them.
+      Nevertheless he is confirmed in his instinctive opinions by the
+      voice of all his brethren. Let a “composition” be defective; let
+      an emendation be wrought in its mere arrangement of form; let
+      this emendation be submitted to every artist in the world; by
+      each will its necessity be admitted. And even far more than this;
+      in remedy of the defective composition, each insulated member of
+      the fraternity would have suggested the identical emendation.
+
+      I repeat that in landscape arrangements alone is the physical
+      nature susceptible of exaltation, and that, therefore, her
+      susceptibility of improvement at this one point, was a mystery I
+      had been unable to solve. My own thoughts on the subject had
+      rested in the idea that the primitive intention of nature would
+      have so arranged the earth’s surface as to have fulfilled at all
+      points man’s sense of perfection in the beautiful, the sublime,
+      or the picturesque; but that this primitive intention had been
+      frustrated by the known geological disturbances—disturbances of
+      form and color—grouping, in the correction or allaying of which
+      lies the soul of art. The force of this idea was much weakened,
+      however, by the necessity which it involved of considering the
+      disturbances abnormal and unadapted to any purpose. It was
+      Ellison who suggested that they were prognostic of death. He thus
+      explained:—Admit the earthly immortality of man to have been the
+      first intention. We have then the primitive arrangement of the
+      earth’s surface adapted to his blissful estate, as not existent
+      but designed. The disturbances were the preparations for his
+      subsequently conceived deathful condition.
+
+      “Now,” said my friend, “what we regard as exaltation of the
+      landscape may be really such, as respects only the moral or human
+      point of view. Each alteration of the natural scenery may
+      possibly effect a blemish in the picture, if we can suppose this
+      picture viewed at large—in mass—from some point distant from the
+      earth’s surface, although not beyond the limits of its
+      atmosphere. It is easily understood that what might improve a
+      closely scrutinized detail, may at the same time injure a general
+      or more distantly observed effect. There may be a class of
+      beings, human once, but now invisible to humanity, to whom, from
+      afar, our disorder may seem order—our unpicturesqueness
+      picturesque; in a word, the earth-angels, for whose scrutiny more
+      especially than our own, and for whose death-refined appreciation
+      of the beautiful, may have been set in array by God the wide
+      landscape-gardens of the hemispheres.”
+
+      In the course of discussion, my friend quoted some passages from
+      a writer on landscape-gardening who has been supposed to have
+      well treated his theme:
+
+      “There are properly but two styles of landscape-gardening, the
+      natural and the artificial. One seeks to recall the original
+      beauty of the country, by adapting its means to the surrounding
+      scenery, cultivating trees in harmony with the hills or plain of
+      the neighboring land; detecting and bringing into practice those
+      nice relations of size, proportion, and color which, hid from the
+      common observer, are revealed everywhere to the experienced
+      student of nature. The result of the natural style of gardening,
+      is seen rather in the absence of all defects and incongruities—in
+      the prevalence of a healthy harmony and order—than in the
+      creation of any special wonders or miracles. The artificial style
+      has as many varieties as there are different tastes to gratify.
+      It has a certain general relation to the various styles of
+      building. There are the stately avenues and retirements of
+      Versailles; Italian terraces; and a various mixed old English
+      style, which bears some relation to the domestic Gothic or
+      English Elizabethan architecture. Whatever may be said against
+      the abuses of the artificial landscape-gardening, a mixture of
+      pure art in a garden scene adds to it a great beauty. This is
+      partly pleasing to the eye, by the show of order and design, and
+      partly moral. A terrace, with an old moss-covered balustrade,
+      calls up at once to the eye the fair forms that have passed there
+      in other days. The slightest exhibition of art is an evidence of
+      care and human interest.”
+
+      “From what I have already observed,” said Ellison, “you will
+      understand that I reject the idea, here expressed, of recalling
+      the original beauty of the country. The original beauty is never
+      so great as that which may be introduced. Of course, every thing
+      depends on the selection of a spot with capabilities. What is
+      said about detecting and bringing into practice nice relations of
+      size, proportion, and color, is one of those mere vaguenesses of
+      speech which serve to veil inaccuracy of thought. The phrase
+      quoted may mean any thing, or nothing, and guides in no degree.
+      That the true result of the natural style of gardening is seen
+      rather in the absence of all defects and incongruities than in
+      the creation of any special wonders or miracles, is a proposition
+      better suited to the grovelling apprehension of the herd than to
+      the fervid dreams of the man of genius. The negative merit
+      suggested appertains to that hobbling criticism which, in
+      letters, would elevate Addison into apotheosis. In truth, while
+      that virtue which consists in the mere avoidance of vice appeals
+      directly to the understanding, and can thus be circumscribed in
+      rule, the loftier virtue, which flames in creation, can be
+      apprehended in its results alone. Rule applies but to the merits
+      of denial—to the excellencies which refrain. Beyond these, the
+      critical art can but suggest. We may be instructed to build a
+      “Cato,” but we are in vain told how to conceive a Parthenon or an
+      “Inferno.” The thing done, however; the wonder accomplished; and
+      the capacity for apprehension becomes universal. The sophists of
+      the negative school who, through inability to create, have
+      scoffed at creation, are now found the loudest in applause. What,
+      in its chrysalis condition of principle, affronted their demure
+      reason, never fails, in its maturity of accomplishment, to extort
+      admiration from their instinct of beauty.
+
+      “The author’s observations on the artificial style,” continued
+      Ellison, “are less objectionable. A mixture of pure art in a
+      garden scene adds to it a great beauty. This is just; as also is
+      the reference to the sense of human interest. The principle
+      expressed is incontrovertible—but there may be something beyond
+      it. There may be an object in keeping with the principle—an
+      object unattainable by the means ordinarily possessed by
+      individuals, yet which, if attained, would lend a charm to the
+      landscape-garden far surpassing that which a sense of merely
+      human interest could bestow. A poet, having very unusual
+      pecuniary resources, might, while retaining the necessary idea of
+      art or culture, or, as our author expresses it, of interest, so
+      imbue his designs at once with extent and novelty of beauty, as
+      to convey the sentiment of spiritual interference. It will be
+      seen that, in bringing about such result, he secures all the
+      advantages of interest or design, while relieving his work of the
+      harshness or technicality of the worldly art. In the most rugged
+      of wildernesses—in the most savage of the scenes of pure
+      nature—there is apparent the art of a creator; yet this art is
+      apparent to reflection only; in no respect has it the obvious
+      force of a feeling. Now let us suppose this sense of the Almighty
+      design to be one step depressed—to be brought into something like
+      harmony or consistency with the sense of human art—to form an
+      intermedium between the two:—let us imagine, for example, a
+      landscape whose combined vastness and definitiveness—whose united
+      beauty, magnificence, and strangeness, shall convey the idea of
+      care, or culture, or superintendence, on the part of beings
+      superior, yet akin to humanity—then the sentiment of interest is
+      preserved, while the art intervolved is made to assume the air of
+      an intermediate or secondary nature—a nature which is not God,
+      nor an emanation from God, but which still is nature in the sense
+      of the handiwork of the angels that hover between man and God.”
+
+      It was in devoting his enormous wealth to the embodiment of a
+      vision such as this—in the free exercise in the open air ensured
+      by the personal superintendence of his plans—in the unceasing
+      object which these plans afforded—in the high spirituality of the
+      object—in the contempt of ambition which it enabled him truly to
+      feel—in the perennial springs with which it gratified, without
+      possibility of satiating, that one master passion of his soul,
+      the thirst for beauty, above all, it was in the sympathy of a
+      woman, not unwomanly, whose loveliness and love enveloped his
+      existence in the purple atmosphere of Paradise, that Ellison
+      thought to find, and found, exemption from the ordinary cares of
+      humanity, with a far greater amount of positive happiness than
+      ever glowed in the rapt day-dreams of De Staël.
+
+      I despair of conveying to the reader any distinct conception of
+      the marvels which my friend did actually accomplish. I wish to
+      describe, but am disheartened by the difficulty of description,
+      and hesitate between detail and generality. Perhaps the better
+      course will be to unite the two in their extremes.
+
+      Mr. Ellison’s first step regarded, of course, the choice of a
+      locality, and scarcely had he commenced thinking on this point,
+      when the luxuriant nature of the Pacific Islands arrested his
+      attention. In fact, he had made up his mind for a voyage to the
+      South Seas, when a night’s reflection induced him to abandon the
+      idea. “Were I misanthropic,” he said, “such a locale would suit
+      me. The thoroughness of its insulation and seclusion, and the
+      difficulty of ingress and egress, would in such case be the charm
+      of charms; but as yet I am not Timon. I wish the composure but
+      not the depression of solitude. There must remain with me a
+      certain control over the extent and duration of my repose. There
+      will be frequent hours in which I shall need, too, the sympathy
+      of the poetic in what I have done. Let me seek, then, a spot not
+      far from a populous city—whose vicinity, also, will best enable
+      me to execute my plans.”
+
+      In search of a suitable place so situated, Ellison travelled for
+      several years, and I was permitted to accompany him. A thousand
+      spots with which I was enraptured he rejected without hesitation,
+      for reasons which satisfied me, in the end, that he was right. We
+      came at length to an elevated table-land of wonderful fertility
+      and beauty, affording a panoramic prospect very little less in
+      extent than that of Aetna, and, in Ellison’s opinion as well as
+      my own, surpassing the far-famed view from that mountain in all
+      the true elements of the picturesque.
+
+      “I am aware,” said the traveller, as he drew a sigh of deep
+      delight after gazing on this scene, entranced, for nearly an
+      hour, “I know that here, in my circumstances, nine-tenths of the
+      most fastidious of men would rest content. This panorama is
+      indeed glorious, and I should rejoice in it but for the excess of
+      its glory. The taste of all the architects I have ever known
+      leads them, for the sake of ‘prospect,’ to put up buildings on
+      hill-tops. The error is obvious. Grandeur in any of its moods,
+      but especially in that of extent, startles, excites—and then
+      fatigues, depresses. For the occasional scene nothing can be
+      better—for the constant view nothing worse. And, in the constant
+      view, the most objectionable phase of grandeur is that of extent;
+      the worst phase of extent, that of distance. It is at war with
+      the sentiment and with the sense of seclusion—the sentiment and
+      sense which we seek to humor in ‘retiring to the country.’ In
+      looking from the summit of a mountain we cannot help feeling
+      abroad in the world. The heart-sick avoid distant prospects as a
+      pestilence.”
+
+      It was not until toward the close of the fourth year of our
+      search that we found a locality with which Ellison professed
+      himself satisfied. It is, of course, needless to say where was
+      the locality. The late death of my friend, in causing his domain
+      to be thrown open to certain classes of visitors, has given to
+      Arnheim a species of secret and subdued if not solemn celebrity,
+      similar in kind, although infinitely superior in degree, to that
+      which so long distinguished Fonthill.
+
+      The usual approach to Arnheim was by the river. The visitor left
+      the city in the early morning. During the forenoon he passed
+      between shores of a tranquil and domestic beauty, on which grazed
+      innumerable sheep, their white fleeces spotting the vivid green
+      of rolling meadows. By degrees the idea of cultivation subsided
+      into that of merely pastoral care. This slowly became merged in a
+      sense of retirement—this again in a consciousness of solitude. As
+      the evening approached, the channel grew more narrow; the banks
+      more and more precipitous; and these latter were clothed in rich,
+      more profuse, and more sombre foliage. The water increased in
+      transparency. The stream took a thousand turns, so that at no
+      moment could its gleaming surface be seen for a greater distance
+      than a furlong. At every instant the vessel seemed imprisoned
+      within an enchanted circle, having insuperable and impenetrable
+      walls of foliage, a roof of ultramarine satin, and no floor—the
+      keel balancing itself with admirable nicety on that of a phantom
+      bark which, by some accident having been turned upside down,
+      floated in constant company with the substantial one, for the
+      purpose of sustaining it. The channel now became a gorge—although
+      the term is somewhat inapplicable, and I employ it merely because
+      the language has no word which better represents the most
+      striking—not the most distinctive—feature of the scene. The
+      character of gorge was maintained only in the height and
+      parallelism of the shores; it was lost altogether in their other
+      traits. The walls of the ravine (through which the clear water
+      still tranquilly flowed) arose to an elevation of a hundred and
+      occasionally of a hundred and fifty feet, and inclined so much
+      toward each other as, in a great measure, to shut out the light
+      of day; while the long plume-like moss which depended densely
+      from the intertwining shrubberies overhead, gave the whole chasm
+      an air of funereal gloom. The windings became more frequent and
+      intricate, and seemed often as if returning in upon themselves,
+      so that the voyager had long lost all idea of direction. He was,
+      moreover, enwrapt in an exquisite sense of the strange. The
+      thought of nature still remained, but her character seemed to
+      have undergone modification, there was a weird symmetry, a
+      thrilling uniformity, a wizard propriety in these her works. Not
+      a dead branch—not a withered leaf—not a stray pebble—not a patch
+      of the brown earth was anywhere visible. The crystal water welled
+      up against the clean granite, or the unblemished moss, with a
+      sharpness of outline that delighted while it bewildered the eye.
+
+      Having threaded the mazes of this channel for some hours, the
+      gloom deepening every moment, a sharp and unexpected turn of the
+      vessel brought it suddenly, as if dropped from heaven, into a
+      circular basin of very considerable extent when compared with the
+      width of the gorge. It was about two hundred yards in diameter,
+      and girt in at all points but one—that immediately fronting the
+      vessel as it entered—by hills equal in general height to the
+      walls of the chasm, although of a thoroughly different character.
+      Their sides sloped from the water’s edge at an angle of some
+      forty-five degrees, and they were clothed from base to summit—not
+      a perceptible point escaping—in a drapery of the most gorgeous
+      flower-blossoms; scarcely a green leaf being visible among the
+      sea of odorous and fluctuating color. This basin was of great
+      depth, but so transparent was the water that the bottom, which
+      seemed to consist of a thick mass of small round alabaster
+      pebbles, was distinctly visible by glimpses—that is to say,
+      whenever the eye could permit itself not to see, far down in the
+      inverted heaven, the duplicate blooming of the hills. On these
+      latter there were no trees, nor even shrubs of any size. The
+      impressions wrought on the observer were those of richness,
+      warmth, color, quietude, uniformity, softness, delicacy,
+      daintiness, voluptuousness, and a miraculous extremeness of
+      culture that suggested dreams of a new race of fairies,
+      laborious, tasteful, magnificent, and fastidious; but as the eye
+      traced upward the myriad-tinted slope, from its sharp junction
+      with the water to its vague termination amid the folds of
+      overhanging cloud, it became, indeed, difficult not to fancy a
+      panoramic cataract of rubies, sapphires, opals, and golden
+      onyxes, rolling silently out of the sky.
+
+      The visitor, shooting suddenly into this bay from out the gloom
+      of the ravine, is delighted but astounded by the full orb of the
+      declining sun, which he had supposed to be already far below the
+      horizon, but which now confronts him, and forms the sole
+      termination of an otherwise limitless vista seen through another
+      chasm-like rift in the hills.
+
+      But here the voyager quits the vessel which has borne him so far,
+      and descends into a light canoe of ivory, stained with arabesque
+      devices in vivid scarlet, both within and without. The poop and
+      beak of this boat arise high above the water, with sharp points,
+      so that the general form is that of an irregular crescent. It
+      lies on the surface of the bay with the proud grace of a swan. On
+      its ermined floor reposes a single feathery paddle of satin-wood;
+      but no oarsmen or attendant is to be seen. The guest is bidden to
+      be of good cheer—that the fates will take care of him. The larger
+      vessel disappears, and he is left alone in the canoe, which lies
+      apparently motionless in the middle of the lake. While he
+      considers what course to pursue, however, he becomes aware of a
+      gentle movement in the fairy bark. It slowly swings itself around
+      until its prow points toward the sun. It advances with a gentle
+      but gradually accelerated velocity, while the slight ripples it
+      creates seem to break about the ivory side in divinest
+      melody—seem to offer the only possible explanation of the
+      soothing yet melancholy music for whose unseen origin the
+      bewildered voyager looks around him in vain.
+
+      The canoe steadily proceeds, and the rocky gate of the vista is
+      approached, so that its depths can be more distinctly seen. To
+      the right arise a chain of lofty hills rudely and luxuriantly
+      wooded. It is observed, however, that the trait of exquisite
+      cleanness where the bank dips into the water, still prevails.
+      There is not one token of the usual river _débris_. To the left
+      the character of the scene is softer and more obviously
+      artificial. Here the bank slopes upward from the stream in a very
+      gentle ascent, forming a broad sward of grass of a texture
+      resembling nothing so much as velvet, and of a brilliancy of
+      green which would bear comparison with the tint of the purest
+      emerald. This plateau varies in width from ten to three hundred
+      yards; reaching from the river-bank to a wall, fifty feet high,
+      which extends, in an infinity of curves, but following the
+      general direction of the river, until lost in the distance to the
+      westward. This wall is of one continuous rock, and has been
+      formed by cutting perpendicularly the once rugged precipice of
+      the stream’s southern bank, but no trace of the labor has been
+      suffered to remain. The chiselled stone has the hue of ages, and
+      is profusely overhung and overspread with the ivy, the coral
+      honeysuckle, the eglantine, and the clematis. The uniformity of
+      the top and bottom lines of the wall is fully relieved by
+      occasional trees of gigantic height, growing singly or in small
+      groups, both along the plateau and in the domain behind the wall,
+      but in close proximity to it; so that frequent limbs (of the
+      black walnut especially) reach over and dip their pendent
+      extremities into the water. Farther back within the domain, the
+      vision is impeded by an impenetrable screen of foliage.
+
+      These things are observed during the canoe’s gradual approach to
+      what I have called the gate of the vista. On drawing nearer to
+      this, however, its chasm-like appearance vanishes; a new outlet
+      from the bay is discovered to the left—in which direction the
+      wall is also seen to sweep, still following the general course of
+      the stream. Down this new opening the eye cannot penetrate very
+      far; for the stream, accompanied by the wall, still bends to the
+      left, until both are swallowed up by the leaves.
+
+      The boat, nevertheless, glides magically into the winding
+      channel; and here the shore opposite the wall is found to
+      resemble that opposite the wall in the straight vista. Lofty
+      hills, rising occasionally into mountains, and covered with
+      vegetation in wild luxuriance, still shut in the scene.
+
+      Floating gently onward, but with a velocity slightly augmented,
+      the voyager, after many short turns, finds his progress
+      apparently barred by a gigantic gate or rather door of burnished
+      gold, elaborately carved and fretted, and reflecting the direct
+      rays of the now fast-sinking sun with an effulgence that seems to
+      wreath the whole surrounding forest in flames. This gate is
+      inserted in the lofty wall; which here appears to cross the river
+      at right angles. In a few moments, however, it is seen that the
+      main body of the water still sweeps in a gentle and extensive
+      curve to the left, the wall following it as before, while a
+      stream of considerable volume, diverging from the principal one,
+      makes its way, with a slight ripple, under the door, and is thus
+      hidden from sight. The canoe falls into the lesser channel and
+      approaches the gate. Its ponderous wings are slowly and musically
+      expanded. The boat glides between them, and commences a rapid
+      descent into a vast amphitheatre entirely begirt with purple
+      mountains, whose bases are laved by a gleaming river throughout
+      the full extent of their circuit. Meantime the whole Paradise of
+      Arnheim bursts upon the view. There is a gush of entrancing
+      melody; there is an oppressive sense of strange sweet odor;—there
+      is a dream-like intermingling to the eye of tall slender Eastern
+      trees—bosky shrubberies—flocks of golden and crimson
+      birds—lily-fringed lakes—meadows of violets, tulips, poppies,
+      hyacinths, and tuberoses—long intertangled lines of silver
+      streamlets—and, upspringing confusedly from amid all, a mass of
+      semi-Gothic, semi-Saracenic architecture sustaining itself by
+      miracle in mid-air, glittering in the red sunlight with a hundred
+      oriels, minarets, and pinnacles; and seeming the phantom
+      handiwork, conjointly, of the Sylphs, of the Fairies, of the
+      Genii and of the Gnomes.
+
+
+
+
+LANDOR’S COTTAGE
+
+
+A Pendant to “The Domain of Arnheim”
+
+      During A pedestrian trip last summer, through one or two of the
+      river counties of New York, I found myself, as the day declined,
+      somewhat embarrassed about the road I was pursuing. The land
+      undulated very remarkably; and my path, for the last hour, had
+      wound about and about so confusedly, in its effort to keep in the
+      valleys, that I no longer knew in what direction lay the sweet
+      village of B——, where I had determined to stop for the night. The
+      sun had scarcely shone—strictly speaking—during the day, which
+      nevertheless, had been unpleasantly warm. A smoky mist,
+      resembling that of the Indian summer, enveloped all things, and
+      of course, added to my uncertainty. Not that I cared much about
+      the matter. If I did not hit upon the village before sunset, or
+      even before dark, it was more than possible that a little Dutch
+      farmhouse, or something of that kind, would soon make its
+      appearance—although, in fact, the neighborhood (perhaps on
+      account of being more picturesque than fertile) was very sparsely
+      inhabited. At all events, with my knapsack for a pillow, and my
+      hound as a sentry, a bivouac in the open air was just the thing
+      which would have amused me. I sauntered on, therefore, quite at
+      ease—Ponto taking charge of my gun—until at length, just as I had
+      begun to consider whether the numerous little glades that led
+      hither and thither, were intended to be paths at all, I was
+      conducted by one of them into an unquestionable carriage track.
+      There could be no mistaking it. The traces of light wheels were
+      evident; and although the tall shrubberies and overgrown
+      undergrowth met overhead, there was no obstruction whatever
+      below, even to the passage of a Virginian mountain wagon—the most
+      aspiring vehicle, I take it, of its kind. The road, however,
+      except in being open through the wood—if wood be not too weighty
+      a name for such an assemblage of light trees—and except in the
+      particulars of evident wheel-tracks—bore no resemblance to any
+      road I had before seen. The tracks of which I speak were but
+      faintly perceptible—having been impressed upon the firm, yet
+      pleasantly moist surface of—what looked more like green Genoese
+      velvet than any thing else. It was grass, clearly—but grass such
+      as we seldom see out of England—so short, so thick, so even, and
+      so vivid in color. Not a single impediment lay in the
+      wheel-route—not even a chip or dead twig. The stones that once
+      obstructed the way had been carefully _placed_—not thrown—along
+      the sides of the lane, so as to define its boundaries at bottom
+      with a kind of half-precise, half-negligent, and wholly
+      picturesque definition. Clumps of wild flowers grew everywhere,
+      luxuriantly, in the interspaces.
+
+      What to make of all this, of course I knew not. Here was art
+      undoubtedly—that did not surprise me—all roads, in the ordinary
+      sense, are works of art; nor can I say that there was much to
+      wonder at in the mere excess of art manifested; all that seemed
+      to have been done, might have been done here—with such natural
+      “capabilities” (as they have it in the books on Landscape
+      Gardening)—with very little labor and expense. No; it was not the
+      amount but the character of the art which caused me to take a
+      seat on one of the blossomy stones and gaze up and down this
+      fairy-like avenue for half an hour or more in bewildered
+      admiration. One thing became more and more evident the longer I
+      gazed: an artist, and one with a most scrupulous eye for form,
+      had superintended all these arrangements. The greatest care had
+      been taken to preserve a due medium between the neat and graceful
+      on the one hand, and the pittoresque, in the true sense of the
+      Italian term, on the other. There were few straight, and no long
+      uninterrupted lines. The same effect of curvature or of color
+      appeared twice, usually, but not oftener, at any one point of
+      view. Everywhere was variety in uniformity. It was a piece of
+      “composition,” in which the most fastidiously critical taste
+      could scarcely have suggested an emendation.
+
+      I had turned to the right as I entered this road, and now,
+      arising, I continued in the same direction. The path was so
+      serpentine, that at no moment could I trace its course for more
+      than two or three paces in advance. Its character did not undergo
+      any material change.
+
+      Presently the murmur of water fell gently upon my ear—and in a
+      few moments afterward, as I turned with the road somewhat more
+      abruptly than hitherto, I became aware that a building of some
+      kind lay at the foot of a gentle declivity just before me. I
+      could see nothing distinctly on account of the mist which
+      occupied all the little valley below. A gentle breeze, however,
+      now arose, as the sun was about descending; and while I remained
+      standing on the brow of the slope, the fog gradually became
+      dissipated into wreaths, and so floated over the scene.
+
+      As it came fully into view—thus gradually as I describe it—piece
+      by piece, here a tree, there a glimpse of water, and here again
+      the summit of a chimney, I could scarcely help fancying that the
+      whole was one of the ingenious illusions sometimes exhibited
+      under the name of “vanishing pictures.”
+
+      By the time, however, that the fog had thoroughly disappeared,
+      the sun had made its way down behind the gentle hills, and
+      thence, as if with a slight chassez to the south, had come again
+      fully into sight, glaring with a purplish lustre through a chasm
+      that entered the valley from the west. Suddenly, therefore—and as
+      if by the hand of magic—this whole valley and every thing in it
+      became brilliantly visible.
+
+      The first _coup d’œil_, as the sun slid into the position
+      described, impressed me very much as I have been impressed, when
+      a boy, by the concluding scene of some well-arranged theatrical
+      spectacle or melodrama. Not even the monstrosity of color was
+      wanting; for the sunlight came out through the chasm, tinted all
+      orange and purple; while the vivid green of the grass in the
+      valley was reflected more or less upon all objects from the
+      curtain of vapor that still hung overhead, as if loth to take its
+      total departure from a scene so enchantingly beautiful.
+
+      The little vale into which I thus peered down from under the fog
+      canopy could not have been more than four hundred yards long;
+      while in breadth it varied from fifty to one hundred and fifty or
+      perhaps two hundred. It was most narrow at its northern
+      extremity, opening out as it tended southwardly, but with no very
+      precise regularity. The widest portion was within eighty yards of
+      the southern extreme. The slopes which encompassed the vale could
+      not fairly be called hills, unless at their northern face. Here a
+      precipitous ledge of granite arose to a height of some ninety
+      feet; and, as I have mentioned, the valley at this point was not
+      more than fifty feet wide; but as the visitor proceeded
+      southwardly from the cliff, he found on his right hand and on his
+      left, declivities at once less high, less precipitous, and less
+      rocky. All, in a word, sloped and softened to the south; and yet
+      the whole vale was engirdled by eminences, more or less high,
+      except at two points. One of these I have already spoken of. It
+      lay considerably to the north of west, and was where the setting
+      sun made its way, as I have before described, into the
+      amphitheatre, through a cleanly cut natural cleft in the granite
+      embankment; this fissure might have been ten yards wide at its
+      widest point, so far as the eye could trace it. It seemed to lead
+      up, up like a natural causeway, into the recesses of unexplored
+      mountains and forests. The other opening was directly at the
+      southern end of the vale. Here, generally, the slopes were
+      nothing more than gentle inclinations, extending from east to
+      west about one hundred and fifty yards. In the middle of this
+      extent was a depression, level with the ordinary floor of the
+      valley. As regards vegetation, as well as in respect to every
+      thing else, the scene softened and sloped to the south. To the
+      north—on the craggy precipice—a few paces from the verge—up
+      sprang the magnificent trunks of numerous hickories, black
+      walnuts, and chestnuts, interspersed with occasional oak; and the
+      strong lateral branches thrown out by the walnuts especially,
+      spread far over the edge of the cliff. Proceeding southwardly,
+      the explorer saw, at first, the same class of trees, but less and
+      less lofty and Salvatorish in character; then he saw the gentler
+      elm, succeeded by the sassafras and locust—these again by the
+      softer linden, red-bud, catalpa, and maple—these yet again by
+      still more graceful and more modest varieties. The whole face of
+      the southern declivity was covered with wild shrubbery alone—an
+      occasional silver willow or white poplar excepted. In the bottom
+      of the valley itself—(for it must be borne in mind that the
+      vegetation hitherto mentioned grew only on the cliffs or
+      hillsides)—were to be seen three insulated trees. One was an elm
+      of fine size and exquisite form: it stood guard over the southern
+      gate of the vale. Another was a hickory, much larger than the
+      elm, and altogether a much finer tree, although both were
+      exceedingly beautiful: it seemed to have taken charge of the
+      northwestern entrance, springing from a group of rocks in the
+      very jaws of the ravine, and throwing its graceful body, at an
+      angle of nearly forty-five degrees, far out into the sunshine of
+      the amphitheatre. About thirty yards east of this tree stood,
+      however, the pride of the valley, and beyond all question the
+      most magnificent tree I have ever seen, unless, perhaps, among
+      the cypresses of the Itchiatuckanee. It was a triple-stemmed
+      tulip-tree—the Liriodendron Tulipiferum—one of the natural order
+      of magnolias. Its three trunks separated from the parent at about
+      three feet from the soil, and diverging very slightly and
+      gradually, were not more than four feet apart at the point where
+      the largest stem shot out into foliage: this was at an elevation
+      of about eighty feet. The whole height of the principal division
+      was one hundred and twenty feet. Nothing can surpass in beauty
+      the form, or the glossy, vivid green of the leaves of the
+      tulip-tree. In the present instance they were fully eight inches
+      wide; but their glory was altogether eclipsed by the gorgeous
+      splendor of the profuse blossoms. Conceive, closely congregated,
+      a million of the largest and most resplendent tulips! Only thus
+      can the reader get any idea of the picture I would convey. And
+      then the stately grace of the clean, delicately-granulated
+      columnar stems, the largest four feet in diameter, at twenty from
+      the ground. The innumerable blossoms, mingling with those of
+      other trees scarcely less beautiful, although infinitely less
+      majestic, filled the valley with more than Arabian perfumes.
+
+      The general floor of the amphitheatre was grass of the same
+      character as that I had found in the road; if anything, more
+      deliciously soft, thick, velvety, and miraculously green. It was
+      hard to conceive how all this beauty had been attained.
+
+      I have spoken of two openings into the vale. From the one to the
+      northwest issued a rivulet, which came, gently murmuring and
+      slightly foaming, down the ravine, until it dashed against the
+      group of rocks out of which sprang the insulated hickory. Here,
+      after encircling the tree, it passed on a little to the north of
+      east, leaving the tulip tree some twenty feet to the south, and
+      making no decided alteration in its course until it came near the
+      midway between the eastern and western boundaries of the valley.
+      At this point, after a series of sweeps, it turned off at right
+      angles and pursued a generally southern direction meandering as
+      it went—until it became lost in a small lake of irregular figure
+      (although roughly oval), that lay gleaming near the lower
+      extremity of the vale. This lakelet was, perhaps, a hundred yards
+      in diameter at its widest part. No crystal could be clearer than
+      its waters. Its bottom, which could be distinctly seen, consisted
+      altogether, of pebbles brilliantly white. Its banks, of the
+      emerald grass already described, rounded, rather than sloped, off
+      into the clear heaven below; and so clear was this heaven, so
+      perfectly, at times, did it reflect all objects above it, that
+      where the true bank ended and where the mimic one commenced, it
+      was a point of no little difficulty to determine. The trout, and
+      some other varieties of fish, with which this pond seemed to be
+      almost inconveniently crowded, had all the appearance of
+      veritable flying-fish. It was almost impossible to believe that
+      they were not absolutely suspended in the air. A light birch
+      canoe that lay placidly on the water, was reflected in its
+      minutest fibres with a fidelity unsurpassed by the most
+      exquisitely polished mirror. A small island, fairly laughing with
+      flowers in full bloom, and affording little more space than just
+      enough for a picturesque little building, seemingly a
+      fowl-house—arose from the lake not far from its northern shore—to
+      which it was connected by means of an inconceivably light-looking
+      and yet very primitive bridge. It was formed of a single, broad
+      and thick plank of the tulip wood. This was forty feet long, and
+      spanned the interval between shore and shore with a slight but
+      very perceptible arch, preventing all oscillation. From the
+      southern extreme of the lake issued a continuation of the
+      rivulet, which, after meandering for, perhaps, thirty yards,
+      finally passed through the “depression” (already described) in
+      the middle of the southern declivity, and tumbling down a sheer
+      precipice of a hundred feet, made its devious and unnoticed way
+      to the Hudson.
+
+      The lake was deep—at some points thirty feet—but the rivulet
+      seldom exceeded three, while its greatest width was about eight.
+      Its bottom and banks were as those of the pond—if a defect could
+      have been attributed, in point of picturesqueness, it was that of
+      excessive neatness.
+
+      The expanse of the green turf was relieved, here and there, by an
+      occasional showy shrub, such as the hydrangea, or the common
+      snowball, or the aromatic seringa; or, more frequently, by a
+      clump of geraniums blossoming gorgeously in great varieties.
+      These latter grew in pots which were carefully buried in the
+      soil, so as to give the plants the appearance of being
+      indigenous. Besides all this, the lawn’s velvet was exquisitely
+      spotted with sheep—a considerable flock of which roamed about the
+      vale, in company with three tamed deer, and a vast number of
+      brilliantly-plumed ducks. A very large mastiff seemed to be in
+      vigilant attendance upon these animals, each and all.
+
+      Along the eastern and western cliffs—where, toward the upper
+      portion of the amphitheatre, the boundaries were more or less
+      precipitous—grew ivy in great profusion—so that only here and
+      there could even a glimpse of the naked rock be obtained. The
+      northern precipice, in like manner, was almost entirely clothed
+      by grape-vines of rare luxuriance; some springing from the soil
+      at the base of the cliff, and others from ledges on its face.
+
+      The slight elevation which formed the lower boundary of this
+      little domain, was crowned by a neat stone wall, of sufficient
+      height to prevent the escape of the deer. Nothing of the fence
+      kind was observable elsewhere; for nowhere else was an artificial
+      enclosure needed:—any stray sheep, for example, which should
+      attempt to make its way out of the vale by means of the ravine,
+      would find its progress arrested, after a few yards’ advance, by
+      the precipitous ledge of rock over which tumbled the cascade that
+      had arrested my attention as I first drew near the domain. In
+      short, the only ingress or egress was through a gate occupying a
+      rocky pass in the road, a few paces below the point at which I
+      stopped to reconnoitre the scene.
+
+      I have described the brook as meandering very irregularly through
+      the whole of its course. Its two general directions, as I have
+      said, were first from west to east, and then from north to south.
+      At the turn, the stream, sweeping backward, made an almost
+      circular loop, so as to form a peninsula which was very nearly an
+      island, and which included about the sixteenth of an acre. On
+      this peninsula stood a dwelling-house—and when I say that this
+      house, like the infernal terrace seen by Vathek, “etait d’une
+      architecture inconnue dans les annales de la terre,” I mean,
+      merely, that its tout ensemble struck me with the keenest sense
+      of combined novelty and propriety—in a word, of poetry—(for, than
+      in the words just employed, I could scarcely give, of poetry in
+      the abstract, a more rigorous definition)—and I do not mean that
+      merely outre was perceptible in any respect.
+
+      In fact nothing could well be more simple—more utterly
+      unpretending than this cottage. Its marvellous effect lay
+      altogether in its artistic arrangement as a picture. I could have
+      fancied, while I looked at it, that some eminent
+      landscape-painter had built it with his brush.
+
+      The point of view from which I first saw the valley, was not
+      altogether, although it was nearly, the best point from which to
+      survey the house. I will therefore describe it as I afterwards
+      saw it—from a position on the stone wall at the southern extreme
+      of the amphitheatre.
+
+      The main building was about twenty-four feet long and sixteen
+      broad—certainly not more. Its total height, from the ground to
+      the apex of the roof, could not have exceeded eighteen feet. To
+      the west end of this structure was attached one about a third
+      smaller in all its proportions:—the line of its front standing
+      back about two yards from that of the larger house, and the line
+      of its roof, of course, being considerably depressed below that
+      of the roof adjoining. At right angles to these buildings, and
+      from the rear of the main one—not exactly in the middle—extended
+      a third compartment, very small—being, in general, one-third less
+      than the western wing. The roofs of the two larger were very
+      steep—sweeping down from the ridge-beam with a long concave
+      curve, and extending at least four feet beyond the walls in
+      front, so as to form the roofs of two piazzas. These latter
+      roofs, of course, needed no support; but as they had the air of
+      needing it, slight and perfectly plain pillars were inserted at
+      the corners alone. The roof of the northern wing was merely an
+      extension of a portion of the main roof. Between the chief
+      building and western wing arose a very tall and rather slender
+      square chimney of hard Dutch bricks, alternately black and red:—a
+      slight cornice of projecting bricks at the top. Over the gables
+      the roofs also projected very much:—in the main building about
+      four feet to the east and two to the west. The principal door was
+      not exactly in the main division, being a little to the
+      east—while the two windows were to the west. These latter did not
+      extend to the floor, but were much longer and narrower than
+      usual—they had single shutters like doors—the panes were of
+      lozenge form, but quite large. The door itself had its upper half
+      of glass, also in lozenge panes—a movable shutter secured it at
+      night. The door to the west wing was in its gable, and quite
+      simple—a single window looked out to the south. There was no
+      external door to the north wing, and it also had only one window
+      to the east.
+
+      The blank wall of the eastern gable was relieved by stairs (with
+      a balustrade) running diagonally across it—the ascent being from
+      the south. Under cover of the widely projecting eave these steps
+      gave access to a door leading to the garret, or rather loft—for
+      it was lighted only by a single window to the north, and seemed
+      to have been intended as a store-room.
+
+      The piazzas of the main building and western wing had no floors,
+      as is usual; but at the doors and at each window, large, flat
+      irregular slabs of granite lay imbedded in the delicious turf,
+      affording comfortable footing in all weather. Excellent paths of
+      the same material—not nicely adapted, but with the velvety sod
+      filling frequent intervals between the stones, led hither and
+      thither from the house, to a crystal spring about five paces off,
+      to the road, or to one or two out-houses that lay to the north,
+      beyond the brook, and were thoroughly concealed by a few locusts
+      and catalpas.
+
+      Not more than six steps from the main door of the cottage stood
+      the dead trunk of a fantastic pear-tree, so clothed from head to
+      foot in the gorgeous bignonia blossoms that one required no
+      little scrutiny to determine what manner of sweet thing it could
+      be. From various arms of this tree hung cages of different kinds.
+      In one, a large wicker cylinder with a ring at top, revelled a
+      mocking bird; in another an oriole; in a third the impudent
+      bobolink—while three or four more delicate prisons were loudly
+      vocal with canaries.
+
+      The pillars of the piazza were enwreathed in jasmine and sweet
+      honeysuckle; while from the angle formed by the main structure
+      and its west wing, in front, sprang a grape-vine of unexampled
+      luxuriance. Scorning all restraint, it had clambered first to the
+      lower roof—then to the higher; and along the ridge of this latter
+      it continued to writhe on, throwing out tendrils to the right and
+      left, until at length it fairly attained the east gable, and fell
+      trailing over the stairs.
+
+      The whole house, with its wings, was constructed of the
+      old-fashioned Dutch shingles—broad, and with unrounded corners.
+      It is a peculiarity of this material to give houses built of it
+      the appearance of being wider at bottom than at top—after the
+      manner of Egyptian architecture; and in the present instance,
+      this exceedingly picturesque effect was aided by numerous pots of
+      gorgeous flowers that almost encompassed the base of the
+      buildings.
+
+      The shingles were painted a dull gray; and the happiness with
+      which this neutral tint melted into the vivid green of the tulip
+      tree leaves that partially overshadowed the cottage, can readily
+      be conceived by an artist.
+
+      From the position near the stone wall, as described, the
+      buildings were seen at great advantage—for the southeastern angle
+      was thrown forward—so that the eye took in at once the whole of
+      the two fronts, with the picturesque eastern gable, and at the
+      same time obtained just a sufficient glimpse of the northern
+      wing, with parts of a pretty roof to the spring-house, and nearly
+      half of a light bridge that spanned the brook in the near
+      vicinity of the main buildings.
+
+      I did not remain very long on the brow of the hill, although long
+      enough to make a thorough survey of the scene at my feet. It was
+      clear that I had wandered from the road to the village, and I had
+      thus good traveller’s excuse to open the gate before me, and
+      inquire my way, at all events; so, without more ado, I proceeded.
+
+      The road, after passing the gate, seemed to lie upon a natural
+      ledge, sloping gradually down along the face of the north-eastern
+      cliffs. It led me on to the foot of the northern precipice, and
+      thence over the bridge, round by the eastern gable to the front
+      door. In this progress, I took notice that no sight of the
+      out-houses could be obtained.
+
+      As I turned the corner of the gable, the mastiff bounded towards
+      me in stern silence, but with the eye and the whole air of a
+      tiger. I held him out my hand, however, in token of amity—and I
+      never yet knew the dog who was proof against such an appeal to
+      his courtesy. He not only shut his mouth and wagged his tail, but
+      absolutely offered me his paw—afterward extending his civilities
+      to Ponto.
+
+      As no bell was discernible, I rapped with my stick against the
+      door, which stood half open. Instantly a figure advanced to the
+      threshold—that of a young woman about twenty-eight years of
+      age—slender, or rather slight, and somewhat above the medium
+      height. As she approached, with a certain modest decision of step
+      altogether indescribable. I said to myself, “Surely here I have
+      found the perfection of natural, in contradistinction from
+      artificial grace.” The second impression which she made on me,
+      but by far the more vivid of the two, was that of enthusiasm. So
+      intense an expression of romance, perhaps I should call it, or of
+      unworldliness, as that which gleamed from her deep-set eyes, had
+      never so sunk into my heart of hearts before. I know not how it
+      is, but this peculiar expression of the eye, wreathing itself
+      occasionally into the lips, is the most powerful, if not
+      absolutely the sole spell, which rivets my interest in woman.
+      “Romance,” provided my readers fully comprehended what I would
+      here imply by the word—“romance” and “womanliness” seem to me
+      convertible terms: and, after all, what man truly loves in woman,
+      is simply her womanhood. The eyes of Annie (I heard some one from
+      the interior call her “Annie, darling!”) were “spiritual grey;”
+      her hair, a light chestnut: this is all I had time to observe of
+      her.
+
+      At her most courteous of invitations, I entered—passing first
+      into a tolerably wide vestibule. Having come mainly to observe, I
+      took notice that to my right as I stepped in, was a window, such
+      as those in front of the house; to the left, a door leading into
+      the principal room; while, opposite me, an open door enabled me
+      to see a small apartment, just the size of the vestibule,
+      arranged as a study, and having a large bow window looking out to
+      the north.
+
+      Passing into the parlor, I found myself with Mr. Landor—for this,
+      I afterwards found, was his name. He was civil, even cordial in
+      his manner, but just then, I was more intent on observing the
+      arrangements of the dwelling which had so much interested me,
+      than the personal appearance of the tenant.
+
+      The north wing, I now saw, was a bed-chamber, its door opened
+      into the parlor. West of this door was a single window, looking
+      toward the brook. At the west end of the parlor, were a
+      fireplace, and a door leading into the west wing—probably a
+      kitchen.
+
+      Nothing could be more rigorously simple than the furniture of the
+      parlor. On the floor was an ingrain carpet, of excellent
+      texture—a white ground, spotted with small circular green
+      figures. At the windows were curtains of snowy white jaconet
+      muslin: they were tolerably full, and hung decisively, perhaps
+      rather formally in sharp, parallel plaits to the floor—just to
+      the floor. The walls were prepared with a French paper of great
+      delicacy, a silver ground, with a faint green cord running
+      zig-zag throughout. Its expanse was relieved merely by three of
+      Julien’s exquisite lithographs a trois crayons, fastened to the
+      wall without frames. One of these drawings was a scene of
+      Oriental luxury, or rather voluptuousness; another was a
+      “carnival piece,” spirited beyond compare; the third was a Greek
+      female head—a face so divinely beautiful, and yet of an
+      expression so provokingly indeterminate, never before arrested my
+      attention.
+
+      The more substantial furniture consisted of a round table, a few
+      chairs (including a large rocking-chair), and a sofa, or rather
+      “settee;” its material was plain maple painted a creamy white,
+      slightly interstriped with green; the seat of cane. The chairs
+      and table were “to match,” but the forms of all had evidently
+      been designed by the same brain which planned “the grounds;” it
+      is impossible to conceive anything more graceful.
+
+      On the table were a few books; a large, square, crystal bottle of
+      some novel perfume; a plain ground glass _astral_ (not solar)
+      lamp with an Italian shade; and a large vase of
+      resplendently-blooming flowers. Flowers, indeed, of gorgeous
+      colours and delicate odour formed the sole mere decoration of the
+      apartment. The fire-place was nearly filled with a vase of
+      brilliant geranium. On a triangular shelf in each angle of the
+      room stood also a similar vase, varied only as to its lovely
+      contents. One or two smaller bouquets adorned the mantel, and
+      late violets clustered about the open windows.
+
+      It is not the purpose of this work to do more than give in
+      detail, a picture of Mr. Landor’s residence—as I found it. How he
+      made it what it was—and why—with some particulars of Mr. Landor
+      himself—may, possibly form the subject of another article.
+
+
+
+
+WILLIAM WILSON
+
+
+    What say of it? what say of CONSCIENCE grim,
+    That spectre in my path?
+                    —_Chamberlayne’s Pharronida._
+
+      Let me call myself, for the present, William Wilson. The fair
+      page now lying before me need not be sullied with my real
+      appellation. This has been already too much an object for the
+      scorn—for the horror—for the detestation of my race. To the
+      uttermost regions of the globe have not the indignant winds
+      bruited its unparalleled infamy? Oh, outcast of all outcasts most
+      abandoned!—to the earth art thou not forever dead? to its honors,
+      to its flowers, to its golden aspirations?—and a cloud, dense,
+      dismal, and limitless, does it not hang eternally between thy
+      hopes and heaven?
+
+      I would not, if I could, here or to-day, embody a record of my
+      later years of unspeakable misery, and unpardonable crime. This
+      epoch—these later years—took unto themselves a sudden elevation
+      in turpitude, whose origin alone it is my present purpose to
+      assign. Men usually grow base by degrees. From me, in an instant,
+      all virtue dropped bodily as a mantle. From comparatively trivial
+      wickedness I passed, with the stride of a giant, into more than
+      the enormities of an Elah-Gabalus. What chance—what one event
+      brought this evil thing to pass, bear with me while I relate.
+      Death approaches; and the shadow which foreruns him has thrown a
+      softening influence over my spirit. I long, in passing through
+      the dim valley, for the sympathy—I had nearly said for the
+      pity—of my fellow men. I would fain have them believe that I have
+      been, in some measure, the slave of circumstances beyond human
+      control. I would wish them to seek out for me, in the details I
+      am about to give, some little oasis of fatality amid a wilderness
+      of error. I would have them allow—what they cannot refrain from
+      allowing—that, although temptation may have erewhile existed as
+      great, man was never thus, at least, tempted before—certainly,
+      never thus fell. And is it therefore that he has never thus
+      suffered? Have I not indeed been living in a dream? And am I not
+      now dying a victim to the horror and the mystery of the wildest
+      of all sublunary visions?
+
+      I am the descendant of a race whose imaginative and easily
+      excitable temperament has at all times rendered them remarkable;
+      and, in my earliest infancy, I gave evidence of having fully
+      inherited the family character. As I advanced in years it was
+      more strongly developed; becoming, for many reasons, a cause of
+      serious disquietude to my friends, and of positive injury to
+      myself. I grew self-willed, addicted to the wildest caprices, and
+      a prey to the most ungovernable passions. Weak-minded, and beset
+      with constitutional infirmities akin to my own, my parents could
+      do but little to check the evil propensities which distinguished
+      me. Some feeble and ill-directed efforts resulted in complete
+      failure on their part, and, of course, in total triumph on mine.
+      Thenceforward my voice was a household law; and at an age when
+      few children have abandoned their leading-strings, I was left to
+      the guidance of my own will, and became, in all but name, the
+      master of my own actions.
+
+      My earliest recollections of a school-life, are connected with a
+      large, rambling, Elizabethan house, in a misty-looking village of
+      England, where were a vast number of gigantic and gnarled trees,
+      and where all the houses were excessively ancient. In truth, it
+      was a dream-like and spirit-soothing place, that venerable old
+      town. At this moment, in fancy, I feel the refreshing chilliness
+      of its deeply-shadowed avenues, inhale the fragrance of its
+      thousand shrubberies, and thrill anew with undefinable delight,
+      at the deep hollow note of the church-bell, breaking, each hour,
+      with sullen and sudden roar, upon the stillness of the dusky
+      atmosphere in which the fretted Gothic steeple lay imbedded and
+      asleep.
+
+      It gives me, perhaps, as much of pleasure as I can now in any
+      manner experience, to dwell upon minute recollections of the
+      school and its concerns. Steeped in misery as I am—misery, alas!
+      only too real—I shall be pardoned for seeking relief, however
+      slight and temporary, in the weakness of a few rambling details.
+      These, moreover, utterly trivial, and even ridiculous in
+      themselves, assume, to my fancy, adventitious importance, as
+      connected with a period and a locality when and where I recognise
+      the first ambiguous monitions of the destiny which afterwards so
+      fully overshadowed me. Let me then remember.
+
+      The house, I have said, was old and irregular. The grounds were
+      extensive, and a high and solid brick wall, topped with a bed of
+      mortar and broken glass, encompassed the whole. This prison-like
+      rampart formed the limit of our domain; beyond it we saw but
+      thrice a week—once every Saturday afternoon, when, attended by
+      two ushers, we were permitted to take brief walks in a body
+      through some of the neighbouring fields—and twice during Sunday,
+      when we were paraded in the same formal manner to the morning and
+      evening service in the one church of the village. Of this church
+      the principal of our school was pastor. With how deep a spirit of
+      wonder and perplexity was I wont to regard him from our remote
+      pew in the gallery, as, with step solemn and slow, he ascended
+      the pulpit! This reverend man, with countenance so demurely
+      benign, with robes so glossy and so clerically flowing, with wig
+      so minutely powdered, so rigid and so vast,—-could this be he
+      who, of late, with sour visage, and in snuffy habiliments,
+      administered, ferule in hand, the Draconian laws of the academy?
+      Oh, gigantic paradox, too utterly monstrous for solution!
+
+      At an angle of the ponderous wall frowned a more ponderous gate.
+      It was riveted and studded with iron bolts, and surmounted with
+      jagged iron spikes. What impressions of deep awe did it inspire!
+      It was never opened save for the three periodical egressions and
+      ingressions already mentioned; then, in every creak of its mighty
+      hinges, we found a plenitude of mystery—a world of matter for
+      solemn remark, or for more solemn meditation.
+
+      The extensive enclosure was irregular in form, having many
+      capacious recesses. Of these, three or four of the largest
+      constituted the play-ground. It was level, and covered with fine
+      hard gravel. I well remember it had no trees, nor benches, nor
+      anything similar within it. Of course it was in the rear of the
+      house. In front lay a small parterre, planted with box and other
+      shrubs, but through this sacred division we passed only upon rare
+      occasions indeed—such as a first advent to school or final
+      departure thence, or perhaps, when a parent or friend having
+      called for us, we joyfully took our way home for the Christmas or
+      Midsummer holidays.
+
+      But the house!—how quaint an old building was this!—to me how
+      veritably a palace of enchantment! There was really no end to its
+      windings—to its incomprehensible subdivisions. It was difficult,
+      at any given time, to say with certainty upon which of its two
+      stories one happened to be. From each room to every other there
+      were sure to be found three or four steps either in ascent or
+      descent. Then the lateral branches were
+      innumerable—inconceivable—and so returning in upon themselves,
+      that our most exact ideas in regard to the whole mansion were not
+      very far different from those with which we pondered upon
+      infinity. During the five years of my residence here, I was never
+      able to ascertain with precision, in what remote locality lay the
+      little sleeping apartment assigned to myself and some eighteen or
+      twenty other scholars.
+
+      The school-room was the largest in the house—I could not help
+      thinking, in the world. It was very long, narrow, and dismally
+      low, with pointed Gothic windows and a ceiling of oak. In a
+      remote and terror-inspiring angle was a square enclosure of eight
+      or ten feet, comprising the sanctum, “during hours,” of our
+      principal, the Reverend Dr. Bransby. It was a solid structure,
+      with massy door, sooner than open which in the absence of the
+      “Dominie,” we would all have willingly perished by the _peine
+      forte et dure_. In other angles were two other similar boxes, far
+      less reverenced, indeed, but still greatly matters of awe. One of
+      these was the pulpit of the “classical” usher, one of the
+      “English and mathematical.” Interspersed about the room, crossing
+      and recrossing in endless irregularity, were innumerable benches
+      and desks, black, ancient, and time-worn, piled desperately with
+      much-bethumbed books, and so beseamed with initial letters, names
+      at full length, grotesque figures, and other multiplied efforts
+      of the knife, as to have entirely lost what little of original
+      form might have been their portion in days long departed. A huge
+      bucket with water stood at one extremity of the room, and a clock
+      of stupendous dimensions at the other.
+
+      Encompassed by the massy walls of this venerable academy, I
+      passed, yet not in tedium or disgust, the years of the third
+      lustrum of my life. The teeming brain of childhood requires no
+      external world of incident to occupy or amuse it; and the
+      apparently dismal monotony of a school was replete with more
+      intense excitement than my riper youth has derived from luxury,
+      or my full manhood from crime. Yet I must believe that my first
+      mental development had in it much of the uncommon—even much of
+      the _outré_. Upon mankind at large the events of very early
+      existence rarely leave in mature age any definite impression. All
+      is gray shadow—a weak and irregular remembrance—an indistinct
+      regathering of feeble pleasures and phantasmagoric pains. With me
+      this is not so. In childhood I must have felt with the energy of
+      a man what I now find stamped upon memory in lines as vivid, as
+      deep, and as durable as the _exergues_ of the Carthaginian
+      medals.
+
+      Yet in fact—in the fact of the world’s view—how little was there
+      to remember! The morning’s awakening, the nightly summons to bed;
+      the connings, the recitations; the periodical half-holidays, and
+      perambulations; the play-ground, with its broils, its pastimes,
+      its intrigues;—these, by a mental sorcery long forgotten, were
+      made to involve a wilderness of sensation, a world of rich
+      incident, an universe of varied emotion, of excitement the most
+      passionate and spirit-stirring. “_Oh, le bon temps, que ce siècle
+      de fer!_”
+
+      In truth, the ardor, the enthusiasm, and the imperiousness of my
+      disposition, soon rendered me a marked character among my
+      schoolmates, and by slow, but natural gradations, gave me an
+      ascendancy over all not greatly older than myself;—over all with
+      a single exception. This exception was found in the person of a
+      scholar, who, although no relation, bore the same Christian and
+      surname as myself;—a circumstance, in fact, little remarkable;
+      for, notwithstanding a noble descent, mine was one of those
+      everyday appellations which seem, by prescriptive right, to have
+      been, time out of mind, the common property of the mob. In this
+      narrative I have therefore designated myself as William Wilson,—a
+      fictitious title not very dissimilar to the real. My namesake
+      alone, of those who in school phraseology constituted “our set,”
+      presumed to compete with me in the studies of the class—in the
+      sports and broils of the play-ground—to refuse implicit belief in
+      my assertions, and submission to my will—indeed, to interfere
+      with my arbitrary dictation in any respect whatsoever. If there
+      is on earth a supreme and unqualified despotism, it is the
+      despotism of a master-mind in boyhood over the less energetic
+      spirits of its companions.
+
+      Wilson’s rebellion was to me a source of the greatest
+      embarrassment; the more so as, in spite of the bravado with which
+      in public I made a point of treating him and his pretensions, I
+      secretly felt that I feared him, and could not help thinking the
+      equality which he maintained so easily with myself, a proof of
+      his true superiority; since not to be overcome cost me a
+      perpetual struggle. Yet this superiority—even this equality—was
+      in truth acknowledged by no one but myself; our associates, by
+      some unaccountable blindness, seemed not even to suspect it.
+      Indeed, his competition, his resistance, and especially his
+      impertinent and dogged interference with my purposes, were not
+      more pointed than private. He appeared to be destitute alike of
+      the ambition which urged, and of the passionate energy of mind
+      which enabled me to excel. In his rivalry he might have been
+      supposed actuated solely by a whimsical desire to thwart,
+      astonish, or mortify myself; although there were times when I
+      could not help observing, with a feeling made up of wonder,
+      abasement, and pique, that he mingled with his injuries, his
+      insults, or his contradictions, a certain most inappropriate, and
+      assuredly most unwelcome affectionateness of manner. I could only
+      conceive this singular behavior to arise from a consummate
+      self-conceit assuming the vulgar airs of patronage and
+      protection.
+
+      Perhaps it was this latter trait in Wilson’s conduct, conjoined
+      with our identity of name, and the mere accident of our having
+      entered the school upon the same day, which set afloat the notion
+      that we were brothers, among the senior classes in the academy.
+      These do not usually inquire with much strictness into the
+      affairs of their juniors. I have before said, or should have
+      said, that Wilson was not, in the most remote degree, connected
+      with my family. But assuredly if we had been brothers we must
+      have been twins; for, after leaving Dr. Bransby’s, I casually
+      learned that my namesake was born on the nineteenth of January,
+      1813—and this is a somewhat remarkable coincidence; for the day
+      is precisely that of my own nativity.
+
+      It may seem strange that in spite of the continual anxiety
+      occasioned me by the rivalry of Wilson, and his intolerable
+      spirit of contradiction, I could not bring myself to hate him
+      altogether. We had, to be sure, nearly every day a quarrel in
+      which, yielding me publicly the palm of victory, he, in some
+      manner, contrived to make me feel that it was he who had deserved
+      it; yet a sense of pride on my part, and a veritable dignity on
+      his own, kept us always upon what are called “speaking terms,”
+      while there were many points of strong congeniality in our
+      tempers, operating to awake me in a sentiment which our position
+      alone, perhaps, prevented from ripening into friendship. It is
+      difficult, indeed, to define, or even to describe, my real
+      feelings towards him. They formed a motley and heterogeneous
+      admixture;—some petulant animosity, which was not yet hatred,
+      some esteem, more respect, much fear, with a world of uneasy
+      curiosity. To the moralist it will be unnecessary to say, in
+      addition, that Wilson and myself were the most inseparable of
+      companions.
+
+      It was no doubt the anomalous state of affairs existing between
+      us, which turned all my attacks upon him, (and they were many,
+      either open or covert) into the channel of banter or practical
+      joke (giving pain while assuming the aspect of mere fun) rather
+      than into a more serious and determined hostility. But my
+      endeavours on this head were by no means uniformly successful,
+      even when my plans were the most wittily concocted; for my
+      namesake had much about him, in character, of that unassuming and
+      quiet austerity which, while enjoying the poignancy of its own
+      jokes, has no heel of Achilles in itself, and absolutely refuses
+      to be laughed at. I could find, indeed, but one vulnerable point,
+      and that, lying in a personal peculiarity, arising, perhaps, from
+      constitutional disease, would have been spared by any antagonist
+      less at his wit’s end than myself;—my rival had a weakness in the
+      faucal or guttural organs, which precluded him from raising his
+      voice at any time above a very low whisper. Of this defect I did
+      not fail to take what poor advantage lay in my power.
+
+      Wilson’s retaliations in kind were many; and there was one form
+      of his practical wit that disturbed me beyond measure. How his
+      sagacity first discovered at all that so petty a thing would vex
+      me, is a question I never could solve; but, having discovered, he
+      habitually practised the annoyance. I had always felt aversion to
+      my uncourtly patronymic, and its very common, if not plebeian
+      praenomen. The words were venom in my ears; and when, upon the
+      day of my arrival, a second William Wilson came also to the
+      academy, I felt angry with him for bearing the name, and doubly
+      disgusted with the name because a stranger bore it, who would be
+      the cause of its twofold repetition, who would be constantly in
+      my presence, and whose concerns, in the ordinary routine of the
+      school business, must inevitably, on account of the detestable
+      coincidence, be often confounded with my own.
+
+      The feeling of vexation thus engendered grew stronger with every
+      circumstance tending to show resemblance, moral or physical,
+      between my rival and myself. I had not then discovered the
+      remarkable fact that we were of the same age; but I saw that we
+      were of the same height, and I perceived that we were even
+      singularly alike in general contour of person and outline of
+      feature. I was galled, too, by the rumor touching a relationship,
+      which had grown current in the upper forms. In a word, nothing
+      could more seriously disturb me, (although I scrupulously
+      concealed such disturbance,) than any allusion to a similarity of
+      mind, person, or condition existing between us. But, in truth, I
+      had no reason to believe that (with the exception of the matter
+      of relationship, and in the case of Wilson himself,) this
+      similarity had ever been made a subject of comment, or even
+      observed at all by our schoolfellows. That he observed it in all
+      its bearings, and as fixedly as I, was apparent; but that he
+      could discover in such circumstances so fruitful a field of
+      annoyance, can only be attributed, as I said before, to his more
+      than ordinary penetration.
+
+      His cue, which was to perfect an imitation of myself, lay both in
+      words and in actions; and most admirably did he play his part. My
+      dress it was an easy matter to copy; my gait and general manner
+      were, without difficulty, appropriated; in spite of his
+      constitutional defect, even my voice did not escape him. My
+      louder tones were, of course, unattempted, but then the key—it
+      was identical; _and his singular whisper, it grew the very echo
+      of my own_.
+
+      How greatly this most exquisite portraiture harassed me, (for it
+      could not justly be termed a caricature,) I will not now venture
+      to describe. I had but one consolation—in the fact that the
+      imitation, apparently, was noticed by myself alone, and that I
+      had to endure only the knowing and strangely sarcastic smiles of
+      my namesake himself. Satisfied with having produced in my bosom
+      the intended effect, he seemed to chuckle in secret over the
+      sting he had inflicted, and was characteristically disregardful
+      of the public applause which the success of his witty endeavours
+      might have so easily elicited. That the school, indeed, did not
+      feel his design, perceive its accomplishment, and participate in
+      his sneer, was, for many anxious months, a riddle I could not
+      resolve. Perhaps the gradation of his copy rendered it not so
+      readily perceptible; or, more possibly, I owed my security to the
+      master air of the copyist, who, disdaining the letter, (which in
+      a painting is all the obtuse can see,) gave but the full spirit
+      of his original for my individual contemplation and chagrin.
+
+      I have already more than once spoken of the disgusting air of
+      patronage which he assumed toward me, and of his frequent
+      officious interference with my will. This interference often took
+      the ungracious character of advice; advice not openly given, but
+      hinted or insinuated. I received it with a repugnance which
+      gained strength as I grew in years. Yet, at this distant day, let
+      me do him the simple justice to acknowledge that I can recall no
+      occasion when the suggestions of my rival were on the side of
+      those errors or follies so usual to his immature age and seeming
+      inexperience; that his moral sense, at least, if not his general
+      talents and worldly wisdom, was far keener than my own; and that
+      I might, to-day, have been a better, and thus a happier man, had
+      I less frequently rejected the counsels embodied in those meaning
+      whispers which I then but too cordially hated and too bitterly
+      despised.
+
+      As it was, I at length grew restive in the extreme under his
+      distasteful supervision, and daily resented more and more openly
+      what I considered his intolerable arrogance. I have said that, in
+      the first years of our connexion as schoolmates, my feelings in
+      regard to him might have been easily ripened into friendship;
+      but, in the latter months of my residence at the academy,
+      although the intrusion of his ordinary manner had, beyond doubt,
+      in some measure, abated, my sentiments, in nearly similar
+      proportion, partook very much of positive hatred. Upon one
+      occasion he saw this, I think, and afterwards avoided, or made a
+      show of avoiding me.
+
+      It was about the same period, if I remember aright, that, in an
+      altercation of violence with him, in which he was more than
+      usually thrown off his guard, and spoke and acted with an
+      openness of demeanor rather foreign to his nature, I discovered,
+      or fancied I discovered, in his accent, his air, and general
+      appearance, a something which first startled, and then deeply
+      interested me, by bringing to mind dim visions of my earliest
+      infancy—wild, confused and thronging memories of a time when
+      memory herself was yet unborn. I cannot better describe the
+      sensation which oppressed me than by saying that I could with
+      difficulty shake off the belief of my having been acquainted with
+      the being who stood before me, at some epoch very long ago—some
+      point of the past even infinitely remote. The delusion, however,
+      faded rapidly as it came; and I mention it at all but to define
+      the day of the last conversation I there held with my singular
+      namesake.
+
+      The huge old house, with its countless subdivisions, had several
+      large chambers communicating with each other, where slept the
+      greater number of the students. There were, however, (as must
+      necessarily happen in a building so awkwardly planned,) many
+      little nooks or recesses, the odds and ends of the structure; and
+      these the economic ingenuity of Dr. Bransby had also fitted up as
+      dormitories; although, being the merest closets, they were
+      capable of accommodating but a single individual. One of these
+      small apartments was occupied by Wilson.
+
+      One night, about the close of my fifth year at the school, and
+      immediately after the altercation just mentioned, finding every
+      one wrapped in sleep, I arose from bed, and, lamp in hand, stole
+      through a wilderness of narrow passages from my own bedroom to
+      that of my rival. I had long been plotting one of those
+      ill-natured pieces of practical wit at his expense in which I had
+      hitherto been so uniformly unsuccessful. It was my intention,
+      now, to put my scheme in operation, and I resolved to make him
+      feel the whole extent of the malice with which I was imbued.
+      Having reached his closet, I noiselessly entered, leaving the
+      lamp, with a shade over it, on the outside. I advanced a step,
+      and listened to the sound of his tranquil breathing. Assured of
+      his being asleep, I returned, took the light, and with it again
+      approached the bed. Close curtains were around it, which, in the
+      prosecution of my plan, I slowly and quietly withdrew, when the
+      bright rays fell vividly upon the sleeper, and my eyes, at the
+      same moment, upon his countenance. I looked;—and a numbness, an
+      iciness of feeling instantly pervaded my frame. My breast heaved,
+      my knees tottered, my whole spirit became possessed with an
+      objectless yet intolerable horror. Gasping for breath, I lowered
+      the lamp in still nearer proximity to the face. Were these—these
+      the lineaments of William Wilson? I saw, indeed, that they were
+      his, but I shook as if with a fit of the ague in fancying they
+      were not. What was there about them to confound me in this
+      manner? I gazed;—while my brain reeled with a multitude of
+      incoherent thoughts. Not thus he appeared—assuredly not thus—in
+      the vivacity of his waking hours. The same name! the same contour
+      of person! the same day of arrival at the academy! And then his
+      dogged and meaningless imitation of my gait, my voice, my habits,
+      and my manner! Was it, in truth, within the bounds of human
+      possibility, that what I now saw was the result, merely, of the
+      habitual practice of this sarcastic imitation? Awe-stricken, and
+      with a creeping shudder, I extinguished the lamp, passed silently
+      from the chamber, and left, at once, the halls of that old
+      academy, never to enter them again.
+
+      After a lapse of some months, spent at home in mere idleness, I
+      found myself a student at Eton. The brief interval had been
+      sufficient to enfeeble my remembrance of the events at Dr.
+      Bransby’s, or at least to effect a material change in the nature
+      of the feelings with which I remembered them. The truth—the
+      tragedy—of the drama was no more. I could now find room to doubt
+      the evidence of my senses; and seldom called up the subject at
+      all but with wonder at extent of human credulity, and a smile at
+      the vivid force of the imagination which I hereditarily
+      possessed. Neither was this species of scepticism likely to be
+      diminished by the character of the life I led at Eton. The vortex
+      of thoughtless folly into which I there so immediately and so
+      recklessly plunged, washed away all but the froth of my past
+      hours, engulfed at once every solid or serious impression, and
+      left to memory only the veriest levities of a former existence.
+
+      I do not wish, however, to trace the course of my miserable
+      profligacy here—a profligacy which set at defiance the laws,
+      while it eluded the vigilance of the institution. Three years of
+      folly, passed without profit, had but given me rooted habits of
+      vice, and added, in a somewhat unusual degree, to my bodily
+      stature, when, after a week of soulless dissipation, I invited a
+      small party of the most dissolute students to a secret carousal
+      in my chambers. We met at a late hour of the night; for our
+      debaucheries were to be faithfully protracted until morning. The
+      wine flowed freely, and there were not wanting other and perhaps
+      more dangerous seductions; so that the gray dawn had already
+      faintly appeared in the east, while our delirious extravagance
+      was at its height. Madly flushed with cards and intoxication, I
+      was in the act of insisting upon a toast of more than wonted
+      profanity, when my attention was suddenly diverted by the
+      violent, although partial unclosing of the door of the apartment,
+      and by the eager voice of a servant from without. He said that
+      some person, apparently in great haste, demanded to speak with me
+      in the hall.
+
+      Wildly excited with wine, the unexpected interruption rather
+      delighted than surprised me. I staggered forward at once, and a
+      few steps brought me to the vestibule of the building. In this
+      low and small room there hung no lamp; and now no light at all
+      was admitted, save that of the exceedingly feeble dawn which made
+      its way through the semi-circular window. As I put my foot over
+      the threshold, I became aware of the figure of a youth about my
+      own height, and habited in a white kerseymere morning frock, cut
+      in the novel fashion of the one I myself wore at the moment. This
+      the faint light enabled me to perceive; but the features of his
+      face I could not distinguish. Upon my entering he strode
+      hurriedly up to me, and, seizing me by the arm with a gesture of
+      petulant impatience, whispered the words “William Wilson!” in my
+      ear.
+
+      I grew perfectly sober in an instant.
+
+      There was that in the manner of the stranger, and in the
+      tremulous shake of his uplifted finger, as he held it between my
+      eyes and the light, which filled me with unqualified amazement;
+      but it was not this which had so violently moved me. It was the
+      pregnancy of solemn admonition in the singular, low, hissing
+      utterance; and, above all, it was the character, the tone, the
+      key, of those few, simple, and familiar, yet whispered syllables,
+      which came with a thousand thronging memories of bygone days, and
+      struck upon my soul with the shock of a galvanic battery. Ere I
+      could recover the use of my senses he was gone.
+
+      Although this event failed not of a vivid effect upon my
+      disordered imagination, yet was it evanescent as vivid. For some
+      weeks, indeed, I busied myself in earnest inquiry, or was wrapped
+      in a cloud of morbid speculation. I did not pretend to disguise
+      from my perception the identity of the singular individual who
+      thus perseveringly interfered with my affairs, and harassed me
+      with his insinuated counsel. But who and what was this
+      Wilson?—and whence came he?—and what were his purposes? Upon
+      neither of these points could I be satisfied; merely
+      ascertaining, in regard to him, that a sudden accident in his
+      family had caused his removal from Dr. Bransby’s academy on the
+      afternoon of the day in which I myself had eloped. But in a brief
+      period I ceased to think upon the subject; my attention being all
+      absorbed in a contemplated departure for Oxford. Thither I soon
+      went; the uncalculating vanity of my parents furnishing me with
+      an outfit and annual establishment, which would enable me to
+      indulge at will in the luxury already so dear to my heart,—to vie
+      in profuseness of expenditure with the haughtiest heirs of the
+      wealthiest earldoms in Great Britain.
+
+      Excited by such appliances to vice, my constitutional temperament
+      broke forth with redoubled ardor, and I spurned even the common
+      restraints of decency in the mad infatuation of my revels. But it
+      were absurd to pause in the detail of my extravagance. Let it
+      suffice, that among spendthrifts I out-Heroded Herod, and that,
+      giving name to a multitude of novel follies, I added no brief
+      appendix to the long catalogue of vices then usual in the most
+      dissolute university of Europe.
+
+      It could hardly be credited, however, that I had, even here, so
+      utterly fallen from the gentlemanly estate, as to seek
+      acquaintance with the vilest arts of the gambler by profession,
+      and, having become an adept in his despicable science, to
+      practise it habitually as a means of increasing my already
+      enormous income at the expense of the weak-minded among my
+      fellow-collegians. Such, nevertheless, was the fact. And the very
+      enormity of this offence against all manly and honourable
+      sentiment proved, beyond doubt, the main if not the sole reason
+      of the impunity with which it was committed. Who, indeed, among
+      my most abandoned associates, would not rather have disputed the
+      clearest evidence of his senses, than have suspected of such
+      courses, the gay, the frank, the generous William Wilson—the
+      noblest and most liberal commoner at Oxford—him whose follies
+      (said his parasites) were but the follies of youth and unbridled
+      fancy—whose errors but inimitable whim—whose darkest vice but a
+      careless and dashing extravagance?
+
+      I had been now two years successfully busied in this way, when
+      there came to the university a young parvenu nobleman,
+      Glendinning—rich, said report, as Herodes Atticus—his riches,
+      too, as easily acquired. I soon found him of weak intellect, and,
+      of course, marked him as a fitting subject for my skill. I
+      frequently engaged him in play, and contrived, with the gambler’s
+      usual art, to let him win considerable sums, the more effectually
+      to entangle him in my snares. At length, my schemes being ripe, I
+      met him (with the full intention that this meeting should be
+      final and decisive) at the chambers of a fellow-commoner, (Mr.
+      Preston,) equally intimate with both, but who, to do him justice,
+      entertained not even a remote suspicion of my design. To give to
+      this a better coloring, I had contrived to have assembled a party
+      of some eight or ten, and was solicitously careful that the
+      introduction of cards should appear accidental, and originate in
+      the proposal of my contemplated dupe himself. To be brief upon a
+      vile topic, none of the low finesse was omitted, so customary
+      upon similar occasions that it is a just matter for wonder how
+      any are still found so besotted as to fall its victim.
+
+      We had protracted our sitting far into the night, and I had at
+      length effected the manoeuvre of getting Glendinning as my sole
+      antagonist. The game, too, was my favorite _écarté!_ The rest of
+      the company, interested in the extent of our play, had abandoned
+      their own cards, and were standing around us as spectators. The
+      _parvenu_, who had been induced by my artifices in the early part
+      of the evening, to drink deeply, now shuffled, dealt, or played,
+      with a wild nervousness of manner for which his intoxication, I
+      thought, might partially, but could not altogether account. In a
+      very short period he had become my debtor to a large amount,
+      when, having taken a long draught of port, he did precisely what
+      I had been coolly anticipating—he proposed to double our already
+      extravagant stakes. With a well-feigned show of reluctance, and
+      not until after my repeated refusal had seduced him into some
+      angry words which gave a color of pique to my compliance, did I
+      finally comply. The result, of course, did but prove how entirely
+      the prey was in my toils: in less than an hour he had quadrupled
+      his debt. For some time his countenance had been losing the
+      florid tinge lent it by the wine; but now, to my astonishment, I
+      perceived that it had grown to a pallor truly fearful. I say to
+      my astonishment. Glendinning had been represented to my eager
+      inquiries as immeasurably wealthy; and the sums which he had as
+      yet lost, although in themselves vast, could not, I supposed,
+      very seriously annoy, much less so violently affect him. That he
+      was overcome by the wine just swallowed, was the idea which most
+      readily presented itself; and, rather with a view to the
+      preservation of my own character in the eyes of my associates,
+      than from any less interested motive, I was about to insist,
+      peremptorily, upon a discontinuance of the play, when some
+      expressions at my elbow from among the company, and an
+      ejaculation evincing utter despair on the part of Glendinning,
+      gave me to understand that I had effected his total ruin under
+      circumstances which, rendering him an object for the pity of all,
+      should have protected him from the ill offices even of a fiend.
+
+      What now might have been my conduct it is difficult to say. The
+      pitiable condition of my dupe had thrown an air of embarrassed
+      gloom over all; and, for some moments, a profound silence was
+      maintained, during which I could not help feeling my cheeks
+      tingle with the many burning glances of scorn or reproach cast
+      upon me by the less abandoned of the party. I will even own that
+      an intolerable weight of anxiety was for a brief instant lifted
+      from my bosom by the sudden and extraordinary interruption which
+      ensued. The wide, heavy folding doors of the apartment were all
+      at once thrown open, to their full extent, with a vigorous and
+      rushing impetuosity that extinguished, as if by magic, every
+      candle in the room. Their light, in dying, enabled us just to
+      perceive that a stranger had entered, about my own height, and
+      closely muffled in a cloak. The darkness, however, was now total;
+      and we could only feel that he was standing in our midst. Before
+      any one of us could recover from the extreme astonishment into
+      which this rudeness had thrown all, we heard the voice of the
+      intruder.
+
+      “Gentlemen,” he said, in a low, distinct, and
+      never-to-be-forgotten whisper which thrilled to the very marrow
+      of my bones, “Gentlemen, I make no apology for this behaviour,
+      because in thus behaving, I am but fulfilling a duty. You are,
+      beyond doubt, uninformed of the true character of the person who
+      has to-night won at _écarté_ a large sum of money from Lord
+      Glendinning. I will therefore put you upon an expeditious and
+      decisive plan of obtaining this very necessary information.
+      Please to examine, at your leisure, the inner linings of the cuff
+      of his left sleeve, and the several little packages which may be
+      found in the somewhat capacious pockets of his embroidered
+      morning wrapper.”
+
+      While he spoke, so profound was the stillness that one might have
+      heard a pin drop upon the floor. In ceasing, he departed at once,
+      and as abruptly as he had entered. Can I—shall I describe my
+      sensations? Must I say that I felt all the horrors of the damned?
+      Most assuredly I had little time given for reflection. Many hands
+      roughly seized me upon the spot, and lights were immediately
+      reprocured. A search ensued. In the lining of my sleeve were
+      found all the court cards essential in _écarté_, and, in the
+      pockets of my wrapper, a number of packs, facsimiles of those
+      used at our sittings, with the single exception that mine were of
+      the species called, technically, arrondees; the honours being
+      slightly convex at the ends, the lower cards slightly convex at
+      the sides. In this disposition, the dupe who cuts, as customary,
+      at the length of the pack, will invariably find that he cuts his
+      antagonist an honor; while the gambler, cutting at the breadth,
+      will, as certainly, cut nothing for his victim which may count in
+      the records of the game.
+
+      Any burst of indignation upon this discovery would have affected
+      me less than the silent contempt, or the sarcastic composure,
+      with which it was received.
+
+      “Mr. Wilson,” said our host, stooping to remove from beneath his
+      feet an exceedingly luxurious cloak of rare furs, “Mr. Wilson,
+      this is your property.” (The weather was cold; and, upon quitting
+      my own room, I had thrown a cloak over my dressing wrapper,
+      putting it off upon reaching the scene of play.) “I presume it is
+      supererogatory to seek here (eyeing the folds of the garment with
+      a bitter smile) for any farther evidence of your skill. Indeed,
+      we have had enough. You will see the necessity, I hope, of
+      quitting Oxford—at all events, of quitting instantly my
+      chambers.”
+
+      Abased, humbled to the dust as I then was, it is probable that I
+      should have resented this galling language by immediate personal
+      violence, had not my whole attention been at the moment arrested
+      by a fact of the most startling character. The cloak which I had
+      worn was of a rare description of fur; how rare, how
+      extravagantly costly, I shall not venture to say. Its fashion,
+      too, was of my own fantastic invention; for I was fastidious to
+      an absurd degree of coxcombry, in matters of this frivolous
+      nature. When, therefore, Mr. Preston reached me that which he had
+      picked up upon the floor, and near the folding doors of the
+      apartment, it was with an astonishment nearly bordering upon
+      terror, that I perceived my own already hanging on my arm, (where
+      I had no doubt unwittingly placed it,) and that the one presented
+      me was but its exact counterpart in every, in even the minutest
+      possible particular. The singular being who had so disastrously
+      exposed me, had been muffled, I remembered, in a cloak; and none
+      had been worn at all by any of the members of our party with the
+      exception of myself. Retaining some presence of mind, I took the
+      one offered me by Preston; placed it, unnoticed, over my own;
+      left the apartment with a resolute scowl of defiance; and, next
+      morning ere dawn of day, commenced a hurried journey from Oxford
+      to the continent, in a perfect agony of horror and of shame.
+
+      I fled in vain. My evil destiny pursued me as if in exultation,
+      and proved, indeed, that the exercise of its mysterious dominion
+      had as yet only begun. Scarcely had I set foot in Paris ere I had
+      fresh evidence of the detestable interest taken by this Wilson in
+      my concerns. Years flew, while I experienced no relief.
+      Villain!—at Rome, with how untimely, yet with how spectral an
+      officiousness, stepped he in between me and my ambition! At
+      Vienna, too—at Berlin—and at Moscow! Where, in truth, had I not
+      bitter cause to curse him within my heart? From his inscrutable
+      tyranny did I at length flee, panic-stricken, as from a
+      pestilence; and to the very ends of the earth I fled in vain.
+
+      And again, and again, in secret communion with my own spirit,
+      would I demand the questions “Who is he?—whence came he?—and what
+      are his objects?” But no answer was there found. And then I
+      scrutinized, with a minute scrutiny, the forms, and the methods,
+      and the leading traits of his impertinent supervision. But even
+      here there was very little upon which to base a conjecture. It
+      was noticeable, indeed, that, in no one of the multiplied
+      instances in which he had of late crossed my path, had he so
+      crossed it except to frustrate those schemes, or to disturb those
+      actions, which, if fully carried out, might have resulted in
+      bitter mischief. Poor justification this, in truth, for an
+      authority so imperiously assumed! Poor indemnity for natural
+      rights of self-agency so pertinaciously, so insultingly denied!
+
+      I had also been forced to notice that my tormentor, for a very
+      long period of time, (while scrupulously and with miraculous
+      dexterity maintaining his whim of an identity of apparel with
+      myself,) had so contrived it, in the execution of his varied
+      interference with my will, that I saw not, at any moment, the
+      features of his face. Be Wilson what he might, this, at least,
+      was but the veriest of affectation, or of folly. Could he, for an
+      instant, have supposed that, in my admonisher at Eton—in the
+      destroyer of my honor at Oxford,—in him who thwarted my ambition
+      at Rome, my revenge at Paris, my passionate love at Naples, or
+      what he falsely termed my avarice in Egypt,—that in this, my
+      arch-enemy and evil genius, could fail to recognise the William
+      Wilson of my school boy days,—the namesake, the companion, the
+      rival,—the hated and dreaded rival at Dr. Bransby’s?
+      Impossible!—But let me hasten to the last eventful scene of the
+      drama.
+
+      Thus far I had succumbed supinely to this imperious domination.
+      The sentiment of deep awe with which I habitually regarded the
+      elevated character, the majestic wisdom, the apparent
+      omnipresence and omnipotence of Wilson, added to a feeling of
+      even terror, with which certain other traits in his nature and
+      assumptions inspired me, had operated, hitherto, to impress me
+      with an idea of my own utter weakness and helplessness, and to
+      suggest an implicit, although bitterly reluctant submission to
+      his arbitrary will. But, of late days, I had given myself up
+      entirely to wine; and its maddening influence upon my hereditary
+      temper rendered me more and more impatient of control. I began to
+      murmur,—to hesitate,—to resist. And was it only fancy which
+      induced me to believe that, with the increase of my own firmness,
+      that of my tormentor underwent a proportional diminution? Be this
+      as it may, I now began to feel the inspiration of a burning hope,
+      and at length nurtured in my secret thoughts a stern and
+      desperate resolution that I would submit no longer to be
+      enslaved.
+
+      It was at Rome, during the Carnival of 18—, that I attended a
+      masquerade in the palazzo of the Neapolitan Duke Di Broglio. I
+      had indulged more freely than usual in the excesses of the
+      wine-table; and now the suffocating atmosphere of the crowded
+      rooms irritated me beyond endurance. The difficulty, too, of
+      forcing my way through the mazes of the company contributed not a
+      little to the ruffling of my temper; for I was anxiously seeking,
+      (let me not say with what unworthy motive) the young, the gay,
+      the beautiful wife of the aged and doting Di Broglio. With a too
+      unscrupulous confidence she had previously communicated to me the
+      secret of the costume in which she would be habited, and now,
+      having caught a glimpse of her person, I was hurrying to make my
+      way into her presence. At this moment I felt a light hand placed
+      upon my shoulder, and that ever-remembered, low, damnable
+      _whisper_ within my ear.
+
+      In an absolute phrenzy of wrath, I turned at once upon him who
+      had thus interrupted me, and seized him violently by the collar.
+      He was attired, as I had expected, in a costume altogether
+      similar to my own; wearing a Spanish cloak of blue velvet, begirt
+      about the waist with a crimson belt sustaining a rapier. A mask
+      of black silk entirely covered his face.
+
+      “Scoundrel!” I said, in a voice husky with rage, while every
+      syllable I uttered seemed as new fuel to my fury, “scoundrel!
+      impostor! accursed villain! you shall not—you shall not dog me
+      unto death! Follow me, or I stab you where you stand!”—and I
+      broke my way from the ball-room into a small ante-chamber
+      adjoining, dragging him unresistingly with me as I went.
+
+      Upon entering, I thrust him furiously from me. He staggered
+      against the wall, while I closed the door with an oath, and
+      commanded him to draw. He hesitated but for an instant; then,
+      with a slight sigh, drew in silence, and put himself upon his
+      defence.
+
+      The contest was brief indeed. I was frantic with every species of
+      wild excitement, and felt within my single arm the energy and
+      power of a multitude. In a few seconds I forced him by sheer
+      strength against the wainscoting, and thus, getting him at mercy,
+      plunged my sword, with brute ferocity, repeatedly through and
+      through his bosom.
+
+      At that instant some person tried the latch of the door. I
+      hastened to prevent an intrusion, and then immediately returned
+      to my dying antagonist. But what human language can adequately
+      portray that astonishment, that horror which possessed me at the
+      spectacle then presented to view? The brief moment in which I
+      averted my eyes had been sufficient to produce, apparently, a
+      material change in the arrangements at the upper or farther end
+      of the room. A large mirror,—so at first it seemed to me in my
+      confusion—now stood where none had been perceptible before; and,
+      as I stepped up to it in extremity of terror, mine own image, but
+      with features all pale and dabbled in blood, advanced to meet me
+      with a feeble and tottering gait.
+
+      Thus it appeared, I say, but was not. It was my antagonist—it was
+      Wilson, who then stood before me in the agonies of his
+      dissolution. His mask and cloak lay, where he had thrown them,
+      upon the floor. Not a thread in all his raiment—not a line in all
+      the marked and singular lineaments of his face which was not,
+      even in the most absolute identity, mine own!
+
+      It was Wilson; but he spoke no longer in a whisper, and I could
+      have fancied that I myself was speaking while he said:
+
+      _“You have conquered, and I yield. Yet, henceforward art thou
+      also dead—dead to the World, to Heaven and to Hope! In me didst
+      thou exist—and, in my death, see by this image, which is thine
+      own, how utterly thou hast murdered thyself.”_
+
+
+
+
+THE TELL-TALE HEART.
+
+
+      True!—nervous—very, very dreadfully nervous I had been and am;
+      but why will you say that I am mad? The disease had sharpened my
+      senses—not destroyed—not dulled them. Above all was the sense of
+      hearing acute. I heard all things in the heaven and in the earth.
+      I heard many things in hell. How, then, am I mad? Hearken! and
+      observe how healthily—how calmly I can tell you the whole story.
+
+      It is impossible to say how first the idea entered my brain; but
+      once conceived, it haunted me day and night. Object there was
+      none. Passion there was none. I loved the old man. He had never
+      wronged me. He had never given me insult. For his gold I had no
+      desire. I think it was his eye! yes, it was this! He had the eye
+      of a vulture—a pale blue eye, with a film over it. Whenever it
+      fell upon me, my blood ran cold; and so by degrees—very
+      gradually—I made up my mind to take the life of the old man, and
+      thus rid myself of the eye forever.
+
+      Now this is the point. You fancy me mad. Madmen know nothing. But
+      you should have seen me. You should have seen how wisely I
+      proceeded—with what caution—with what foresight—with what
+      dissimulation I went to work! I was never kinder to the old man
+      than during the whole week before I killed him. And every night,
+      about midnight, I turned the latch of his door and opened it—oh,
+      so gently! And then, when I had made an opening sufficient for my
+      head, I put in a dark lantern, all closed, closed, that no light
+      shone out, and then I thrust in my head. Oh, you would have
+      laughed to see how cunningly I thrust it in! I moved it
+      slowly—very, very slowly, so that I might not disturb the old
+      man’s sleep. It took me an hour to place my whole head within the
+      opening so far that I could see him as he lay upon his bed.
+      Ha!—would a madman have been so wise as this? And then, when my
+      head was well in the room, I undid the lantern cautiously—oh, so
+      cautiously—cautiously (for the hinges creaked)—I undid it just so
+      much that a single thin ray fell upon the vulture eye. And this I
+      did for seven long nights—every night just at midnight—but I
+      found the eye always closed; and so it was impossible to do the
+      work; for it was not the old man who vexed me, but his Evil Eye.
+      And every morning, when the day broke, I went boldly into the
+      chamber, and spoke courageously to him, calling him by name in a
+      hearty tone, and inquiring how he has passed the night. So you
+      see he would have been a very profound old man, indeed, to
+      suspect that every night, just at twelve, I looked in upon him
+      while he slept.
+
+      Upon the eighth night I was more than usually cautious in opening
+      the door. A watch’s minute hand moves more quickly than did mine.
+      Never before that night had I felt the extent of my own powers—of
+      my sagacity. I could scarcely contain my feelings of triumph. To
+      think that there I was, opening the door, little by little, and
+      he not even to dream of my secret deeds or thoughts. I fairly
+      chuckled at the idea; and perhaps he heard me; for he moved on
+      the bed suddenly, as if startled. Now you may think that I drew
+      back—but no. His room was as black as pitch with the thick
+      darkness, (for the shutters were close fastened, through fear of
+      robbers,) and so I knew that he could not see the opening of the
+      door, and I kept pushing it on steadily, steadily.
+
+      I had my head in, and was about to open the lantern, when my
+      thumb slipped upon the tin fastening, and the old man sprang up
+      in bed, crying out—“Who’s there?”
+
+      I kept quite still and said nothing. For a whole hour I did not
+      move a muscle, and in the meantime I did not hear him lie down.
+      He was still sitting up in the bed listening;—just as I have
+      done, night after night, hearkening to the death watches in the
+      wall.
+
+      Presently I heard a slight groan, and I knew it was the groan of
+      mortal terror. It was not a groan of pain or of grief—oh, no!—it
+      was the low stifled sound that arises from the bottom of the soul
+      when overcharged with awe. I knew the sound well. Many a night,
+      just at midnight, when all the world slept, it has welled up from
+      my own bosom, deepening, with its dreadful echo, the terrors that
+      distracted me. I say I knew it well. I knew what the old man
+      felt, and pitied him, although I chuckled at heart. I knew that
+      he had been lying awake ever since the first slight noise, when
+      he had turned in the bed. His fears had been ever since growing
+      upon him. He had been trying to fancy them causeless, but could
+      not. He had been saying to himself—“It is nothing but the wind in
+      the chimney—it is only a mouse crossing the floor,” or “It is
+      merely a cricket which has made a single chirp.” Yes, he had been
+      trying to comfort himself with these suppositions: but he had
+      found all in vain. All in vain; because Death, in approaching him
+      had stalked with his black shadow before him, and enveloped the
+      victim. And it was the mournful influence of the unperceived
+      shadow that caused him to feel—although he neither saw nor
+      heard—to feel the presence of my head within the room.
+
+      When I had waited a long time, very patiently, without hearing
+      him lie down, I resolved to open a little—a very, very little
+      crevice in the lantern. So I opened it—you cannot imagine how
+      stealthily, stealthily—until, at length a simple dim ray, like
+      the thread of the spider, shot from out the crevice and fell full
+      upon the vulture eye.
+
+      It was open—wide, wide open—and I grew furious as I gazed upon
+      it. I saw it with perfect distinctness—all a dull blue, with a
+      hideous veil over it that chilled the very marrow in my bones;
+      but I could see nothing else of the old man’s face or person: for
+      I had directed the ray as if by instinct, precisely upon the
+      damned spot.
+
+      And have I not told you that what you mistake for madness is but
+      over-acuteness of the sense?—now, I say, there came to my ears a
+      low, dull, quick sound, such as a watch makes when enveloped in
+      cotton. I knew that sound well, too. It was the beating of the
+      old man’s heart. It increased my fury, as the beating of a drum
+      stimulates the soldier into courage.
+
+      But even yet I refrained and kept still. I scarcely breathed. I
+      held the lantern motionless. I tried how steadily I could
+      maintain the ray upon the eye. Meantime the hellish tattoo of the
+      heart increased. It grew quicker and quicker, and louder and
+      louder every instant. The old man’s terror must have been
+      extreme! It grew louder, I say, louder every moment!—do you mark
+      me well? I have told you that I am nervous: so I am. And now at
+      the dead hour of the night, amid the dreadful silence of that old
+      house, so strange a noise as this excited me to uncontrollable
+      terror. Yet, for some minutes longer I refrained and stood still.
+      But the beating grew louder, louder! I thought the heart must
+      burst. And now a new anxiety seized me—the sound would be heard
+      by a neighbour! The old man’s hour had come! With a loud yell, I
+      threw open the lantern and leaped into the room. He shrieked
+      once—once only. In an instant I dragged him to the floor, and
+      pulled the heavy bed over him. I then smiled gaily, to find the
+      deed so far done. But, for many minutes, the heart beat on with a
+      muffled sound. This, however, did not vex me; it would not be
+      heard through the wall. At length it ceased. The old man was
+      dead. I removed the bed and examined the corpse. Yes, he was
+      stone, stone dead. I placed my hand upon the heart and held it
+      there many minutes. There was no pulsation. He was stone dead.
+      His eye would trouble me no more.
+
+      If still you think me mad, you will think so no longer when I
+      describe the wise precautions I took for the concealment of the
+      body. The night waned, and I worked hastily, but in silence.
+      First of all I dismembered the corpse. I cut off the head and the
+      arms and the legs.
+
+      I then took up three planks from the flooring of the chamber, and
+      deposited all between the scantlings. I then replaced the boards
+      so cleverly, so cunningly, that no human eye—not even his—could
+      have detected any thing wrong. There was nothing to wash out—no
+      stain of any kind—no blood-spot whatever. I had been too wary for
+      that. A tub had caught all—ha! ha!
+
+      When I had made an end of these labors, it was four o’clock—still
+      dark as midnight. As the bell sounded the hour, there came a
+      knocking at the street door. I went down to open it with a light
+      heart,—for what had I now to fear? There entered three men, who
+      introduced themselves, with perfect suavity, as officers of the
+      police. A shriek had been heard by a neighbour during the night;
+      suspicion of foul play had been aroused; information had been
+      lodged at the police office, and they (the officers) had been
+      deputed to search the premises.
+
+      I smiled,—for what had I to fear? I bade the gentlemen welcome.
+      The shriek, I said, was my own in a dream. The old man, I
+      mentioned, was absent in the country. I took my visitors all over
+      the house. I bade them search—search well. I led them, at length,
+      to his chamber. I showed them his treasures, secure, undisturbed.
+      In the enthusiasm of my confidence, I brought chairs into the
+      room, and desired them here to rest from their fatigues, while I
+      myself, in the wild audacity of my perfect triumph, placed my own
+      seat upon the very spot beneath which reposed the corpse of the
+      victim.
+
+      The officers were satisfied. My manner had convinced them. I was
+      singularly at ease. They sat, and while I answered cheerily, they
+      chatted of familiar things. But, ere long, I felt myself getting
+      pale and wished them gone. My head ached, and I fancied a ringing
+      in my ears: but still they sat and still chatted. The ringing
+      became more distinct:—it continued and became more distinct: I
+      talked more freely to get rid of the feeling: but it continued
+      and gained definiteness—until, at length, I found that the noise
+      was not within my ears.
+
+      No doubt I now grew _very_ pale;—but I talked more fluently, and
+      with a heightened voice. Yet the sound increased—and what could I
+      do? It was a low, dull, quick sound—much such a sound as a watch
+      makes when enveloped in cotton. I gasped for breath—and yet the
+      officers heard it not. I talked more quickly—more vehemently; but
+      the noise steadily increased. I arose and argued about trifles,
+      in a high key and with violent gesticulations; but the noise
+      steadily increased. Why would they not be gone? I paced the floor
+      to and fro with heavy strides, as if excited to fury by the
+      observations of the men—but the noise steadily increased. Oh God!
+      what could I do? I foamed—I raved—I swore! I swung the chair upon
+      which I had been sitting, and grated it upon the boards, but the
+      noise arose over all and continually increased. It grew
+      louder—louder—louder! And still the men chatted pleasantly, and
+      smiled. Was it possible they heard not? Almighty God!—no, no!
+      They heard!—they suspected!—they knew!—they were making a mockery
+      of my horror!—this I thought, and this I think. But anything was
+      better than this agony! Anything was more tolerable than this
+      derision! I could bear those hypocritical smiles no longer! I
+      felt that I must scream or die! and now—again!—hark! louder!
+      louder! louder! _louder!_
+
+      “Villains!” I shrieked, “dissemble no more! I admit the
+      deed!—tear up the planks!—here, here!—It is the beating of his
+      hideous heart!”
+
+
+
+
+BERENICE
+
+
+     Dicebant mihi sodales, si sepulchrum amicae visitarem, curas meas
+     aliquar tulum fore levatas.—_Ebn Zaiat_.
+
+      Misery is manifold. The wretchedness of earth is multiform.
+      Overreaching the wide horizon as the rainbow, its hues are as
+      various as the hues of that arch—as distinct too, yet as
+      intimately blended. Overreaching the wide horizon as the rainbow!
+      How is it that from beauty I have derived a type of
+      unloveliness?—from the covenant of peace, a simile of sorrow? But
+      as, in ethics, evil is a consequence of good, so, in fact, out of
+      joy is sorrow born. Either the memory of past bliss is the
+      anguish of to-day, or the agonies which _are_, have their origin
+      in the ecstasies which _might have been_.
+
+      My baptismal name is Egaeus; that of my family I will not
+      mention. Yet there are no towers in the land more time-honored
+      than my gloomy, gray, hereditary halls. Our line has been called
+      a race of visionaries; and in many striking particulars—in the
+      character of the family mansion—in the frescos of the chief
+      saloon—in the tapestries of the dormitories—in the chiselling of
+      some buttresses in the armory—but more especially in the gallery
+      of antique paintings—in the fashion of the library chamber—and,
+      lastly, in the very peculiar nature of the library’s
+      contents—there is more than sufficient evidence to warrant the
+      belief.
+
+      The recollections of my earliest years are connected with that
+      chamber, and with its volumes—of which latter I will say no more.
+      Here died my mother. Herein was I born. But it is mere idleness
+      to say that I had not lived before—that the soul has no previous
+      existence. You deny it?—let us not argue the matter. Convinced
+      myself, I seek not to convince. There is, however, a remembrance
+      of aerial forms—of spiritual and meaning eyes—of sounds, musical
+      yet sad—a remembrance which will not be excluded; a memory like a
+      shadow—vague, variable, indefinite, unsteady; and like a shadow,
+      too, in the impossibility of my getting rid of it while the
+      sunlight of my reason shall exist.
+
+      In that chamber was I born. Thus awaking from the long night of
+      what seemed, but was not, nonentity, at once into the very
+      regions of fairy land—into a palace of imagination—into the wild
+      dominions of monastic thought and erudition—it is not singular
+      that I gazed around me with a startled and ardent eye—that I
+      loitered away my boyhood in books, and dissipated my youth in
+      reverie; but it _is_ singular that as years rolled away, and the
+      noon of manhood found me still in the mansion of my fathers—it
+      _is_ wonderful what stagnation there fell upon the springs of my
+      life—wonderful how total an inversion took place in the character
+      of my commonest thought. The realities of the world affected me
+      as visions, and as visions only, while the wild ideas of the land
+      of dreams became, in turn, not the material of my every-day
+      existence, but in very deed that existence utterly and solely in
+      itself.
+
+      Berenice and I were cousins, and we grew up together in my
+      paternal halls. Yet differently we grew—I, ill of health, and
+      buried in gloom—she, agile, graceful, and overflowing with
+      energy; hers, the ramble on the hill-side—mine the studies of the
+      cloister; I, living within my own heart, and addicted, body and
+      soul, to the most intense and painful meditation—she, roaming
+      carelessly through life, with no thought of the shadows in her
+      path, or the silent flight of the raven-winged hours. Berenice!—I
+      call upon her name—Berenice!—and from the gray ruins of memory a
+      thousand tumultuous recollections are startled at the sound! Ah,
+      vividly is her image before me now, as in the early days of her
+      light-heartedness and joy! Oh, gorgeous yet fantastic beauty! Oh,
+      sylph amid the shrubberies of Arnheim! Oh, Naiad among its
+      fountains! And then—then all is mystery and terror, and a tale
+      which should not be told. Disease—a fatal disease, fell like the
+      simoon upon her frame; and, even while I gazed upon her, the
+      spirit of change swept over her, pervading her mind, her habits,
+      and her character, and, in a manner the most subtle and terrible,
+      disturbing even the identity of her person! Alas! the destroyer
+      came and went!—and the victim—where is she? I knew her not—or
+      knew her no longer as Berenice.
+
+      Among the numerous train of maladies superinduced by that fatal
+      and primary one which effected a revolution of so horrible a kind
+      in the moral and physical being of my cousin, may be mentioned as
+      the most distressing and obstinate in its nature, a species of
+      epilepsy not unfrequently terminating in _trance_ itself—trance
+      very nearly resembling positive dissolution, and from which her
+      manner of recovery was in most instances, startlingly abrupt. In
+      the mean time my own disease—for I have been told that I should
+      call it by no other appellation—my own disease, then, grew
+      rapidly upon me, and assumed finally a monomaniac character of a
+      novel and extraordinary form—hourly and momently gaining
+      vigor—and at length obtaining over me the most incomprehensible
+      ascendancy. This monomania, if I must so term it, consisted in a
+      morbid irritability of those properties of the mind in
+      metaphysical science termed the _attentive_. It is more than
+      probable that I am not understood; but I fear, indeed, that it is
+      in no manner possible to convey to the mind of the merely general
+      reader, an adequate idea of that nervous _intensity of interest_
+      with which, in my case, the powers of meditation (not to speak
+      technically) busied and buried themselves, in the contemplation
+      of even the most ordinary objects of the universe.
+
+      To muse for long unwearied hours, with my attention riveted to
+      some frivolous device on the margin, or in the typography of a
+      book; to become absorbed, for the better part of a summer’s day,
+      in a quaint shadow falling aslant upon the tapestry or upon the
+      floor; to lose myself, for an entire night, in watching the
+      steady flame of a lamp, or the embers of a fire; to dream away
+      whole days over the perfume of a flower; to repeat, monotonously,
+      some common word, until the sound, by dint of frequent
+      repetition, ceased to convey any idea whatever to the mind; to
+      lose all sense of motion or physical existence, by means of
+      absolute bodily quiescence long and obstinately persevered in:
+      such were a few of the most common and least pernicious vagaries
+      induced by a condition of the mental faculties, not, indeed,
+      altogether unparalleled, but certainly bidding defiance to
+      anything like analysis or explanation.
+
+      Yet let me not be misapprehended. The undue, earnest, and morbid
+      attention thus excited by objects in their own nature frivolous,
+      must not be confounded in character with that ruminating
+      propensity common to all mankind, and more especially indulged in
+      by persons of ardent imagination. It was not even, as might be at
+      first supposed, an extreme condition, or exaggeration of such
+      propensity, but primarily and essentially distinct and different.
+      In the one instance, the dreamer, or enthusiast, being interested
+      by an object usually _not_ frivolous, imperceptibly loses sight
+      of this object in a wilderness of deductions and suggestions
+      issuing therefrom, until, at the conclusion of a day-dream _often
+      replete with luxury_, he finds the _incitamentum_, or first cause
+      of his musings, entirely vanished and forgotten. In my case, the
+      primary object was _invariably frivolous_, although assuming,
+      through the medium of my distempered vision, a refracted and
+      unreal importance. Few deductions, if any, were made; and those
+      few pertinaciously returning in upon the original object as a
+      centre. The meditations were _never_ pleasurable; and, at the
+      termination of the reverie, the first cause, so far from being
+      out of sight, had attained that supernaturally exaggerated
+      interest which was the prevailing feature of the disease. In a
+      word, the powers of mind more particularly exercised were, with
+      me, as I have said before, the _attentive_, and are, with the
+      day-dreamer, the _speculative_.
+
+      My books, at this epoch, if they did not actually serve to
+      irritate the disorder, partook, it will be perceived, largely, in
+      their imaginative and inconsequential nature, of the
+      characteristic qualities of the disorder itself. I well remember,
+      among others, the treatise of the noble Italian, Coelius Secundus
+      Curio, “_De Amplitudine Beati Regni Dei;_” St. Austin’s great
+      work, the “City of God;” and Tertullian’s “_De Carne Christi_,”
+      in which the paradoxical sentence “_Mortuus est Dei filius;
+      credible est quia ineptum est: et sepultus resurrexit; certum est
+      quia impossibile est,_” occupied my undivided time, for many
+      weeks of laborious and fruitless investigation.
+
+      Thus it will appear that, shaken from its balance only by trivial
+      things, my reason bore resemblance to that ocean-crag spoken of
+      by Ptolemy Hephestion, which steadily resisting the attacks of
+      human violence, and the fiercer fury of the waters and the winds,
+      trembled only to the touch of the flower called Asphodel. And
+      although, to a careless thinker, it might appear a matter beyond
+      doubt, that the alteration produced by her unhappy malady, in the
+      _moral_ condition of Berenice, would afford me many objects for
+      the exercise of that intense and abnormal meditation whose nature
+      I have been at some trouble in explaining, yet such was not in
+      any degree the case. In the lucid intervals of my infirmity, her
+      calamity, indeed, gave me pain, and, taking deeply to heart that
+      total wreck of her fair and gentle life, I did not fail to
+      ponder, frequently and bitterly, upon the wonder-working means by
+      which so strange a revolution had been so suddenly brought to
+      pass. But these reflections partook not of the idiosyncrasy of my
+      disease, and were such as would have occurred, under similar
+      circumstances, to the ordinary mass of mankind. True to its own
+      character, my disorder revelled in the less important but more
+      startling changes wrought in the _physical_ frame of Berenice—in
+      the singular and most appalling distortion of her personal
+      identity.
+
+      During the brightest days of her unparalleled beauty, most surely
+      I had never loved her. In the strange anomaly of my existence,
+      feelings with me, _had never been_ of the heart, and my passions
+      _always were_ of the mind. Through the gray of the early
+      morning—among the trellised shadows of the forest at noonday—and
+      in the silence of my library at night—she had flitted by my eyes,
+      and I had seen her—not as the living and breathing Berenice, but
+      as the Berenice of a dream; not as a being of the earth, earthy,
+      but as the abstraction of such a being; not as a thing to admire,
+      but to analyze; not as an object of love, but as the theme of the
+      most abstruse although desultory speculation. And _now_—now I
+      shuddered in her presence, and grew pale at her approach; yet,
+      bitterly lamenting her fallen and desolate condition, I called to
+      mind that she had loved me long, and, in an evil moment, I spoke
+      to her of marriage.
+
+      And at length the period of our nuptials was approaching, when,
+      upon an afternoon in the winter of the year—one of those
+      unseasonably warm, calm, and misty days which are the nurse of
+      the beautiful Halcyon (*1),—I sat, (and sat, as I thought,
+      alone,) in the inner apartment of the library. But, uplifting my
+      eyes, I saw that Berenice stood before me.
+
+      Was it my own excited imagination—or the misty influence of the
+      atmosphere—or the uncertain twilight of the chamber—or the gray
+      draperies which fell around her figure—that caused in it so
+      vacillating and indistinct an outline? I could not tell. She
+      spoke no word; and I—not for worlds could I have uttered a
+      syllable. An icy chill ran through my frame; a sense of
+      insufferable anxiety oppressed me; a consuming curiosity pervaded
+      my soul; and sinking back upon the chair, I remained for some
+      time breathless and motionless, with my eyes riveted upon her
+      person. Alas! its emaciation was excessive, and not one vestige
+      of the former being lurked in any single line of the contour. My
+      burning glances at length fell upon the face.
+
+      The forehead was high, and very pale, and singularly placid; and
+      the once jetty hair fell partially over it, and overshadowed the
+      hollow temples with innumerable ringlets, now of a vivid yellow,
+      and jarring discordantly, in their fantastic character, with the
+      reigning melancholy of the countenance. The eyes were lifeless,
+      and lustreless, and seemingly pupilless, and I shrank
+      involuntarily from their glassy stare to the contemplation of the
+      thin and shrunken lips. They parted; and in a smile of peculiar
+      meaning, _the teeth_ of the changed Berenice disclosed themselves
+      slowly to my view. Would to God that I had never beheld them, or
+      that, having done so, I had died!
+
+      The shutting of a door disturbed me, and, looking up, I found
+      that my cousin had departed from the chamber. But from the
+      disordered chamber of my brain, had not, alas! departed, and
+      would not be driven away, the white and ghastly _spectrum_ of the
+      teeth. Not a speck on their surface—not a shade on their
+      enamel—not an indenture in their edges—but what that period of
+      her smile had sufficed to brand in upon my memory. I saw them
+      _now_ even more unequivocally than I beheld them _then_. The
+      teeth!—the teeth!—they were here, and there, and everywhere, and
+      visibly and palpably before me; long, narrow, and excessively
+      white, with the pale lips writhing about them, as in the very
+      moment of their first terrible development. Then came the full
+      fury of my _monomania_, and I struggled in vain against its
+      strange and irresistible influence. In the multiplied objects of
+      the external world I had no thoughts but for the teeth. For these
+      I longed with a phrenzied desire. All other matters and all
+      different interests became absorbed in their single
+      contemplation. They—they alone were present to the mental eye,
+      and they, in their sole individuality, became the essence of my
+      mental life. I held them in every light. I turned them in every
+      attitude. I surveyed their characteristics. I dwelt upon their
+      peculiarities. I pondered upon their conformation. I mused upon
+      the alteration in their nature. I shuddered as I assigned to them
+      in imagination a sensitive and sentient power, and even when
+      unassisted by the lips, a capability of moral expression. Of
+      Mademoiselle Salle it has been well said, “_Que tous ses pas
+      etaient des sentiments_,” and of Berenice I more seriously
+      believed _que toutes ses dents etaient des idées_. _Des
+      idées!_—ah here was the idiotic thought that destroyed me! _Des
+      idées!_—ah, _therefore_ it was that I coveted them so madly! I
+      felt that their possession could alone ever restore me to peace,
+      in giving me back to reason.
+
+      And the evening closed in upon me thus—and then the darkness
+      came, and tarried, and went—and the day again dawned—and the
+      mists of a second night were now gathering around—and still I sat
+      motionless in that solitary room—and still I sat buried in
+      meditation—and still the _phantasma_ of the teeth maintained its
+      terrible ascendancy, as, with the most vivid hideous
+      distinctness, it floated about amid the changing lights and
+      shadows of the chamber. At length there broke in upon my dreams a
+      cry as of horror and dismay; and thereunto, after a pause,
+      succeeded the sound of troubled voices, intermingled with many
+      low moanings of sorrow or of pain. I arose from my seat, and
+      throwing open one of the doors of the library, saw standing out
+      in the ante-chamber a servant maiden, all in tears, who told me
+      that Berenice was—no more! She had been seized with epilepsy in
+      the early morning, and now, at the closing in of the night, the
+      grave was ready for its tenant, and all the preparations for the
+      burial were completed.
+
+      I found myself sitting in the library, and again sitting there
+      alone. It seemed that I had newly awakened from a confused and
+      exciting dream. I knew that it was now midnight, and I was well
+      aware, that since the setting of the sun, Berenice had been
+      interred. But of that dreary period which intervened I had no
+      positive, at least no definite comprehension. Yet its memory was
+      replete with horror—horror more horrible from being vague, and
+      terror more terrible from ambiguity. It was a fearful page in the
+      record my existence, written all over with dim, and hideous, and
+      unintelligible recollections. I strived to decypher them, but in
+      vain; while ever and anon, like the spirit of a departed sound,
+      the shrill and piercing shriek of a female voice seemed to be
+      ringing in my ears. I had done a deed—what was it? I asked myself
+      the question aloud, and the whispering echoes of the chamber
+      answered me,—“_What was it?_”
+
+      On the table beside me burned a lamp, and near it lay a little
+      box. It was of no remarkable character, and I had seen it
+      frequently before, for it was the property of the family
+      physician; but how came it _there_, upon my table, and why did I
+      shudder in regarding it? These things were in no manner to be
+      accounted for, and my eyes at length dropped to the open pages of
+      a book, and to a sentence underscored therein. The words were the
+      singular but simple ones of the poet Ebn Zaiat:—“_Dicebant mihi
+      sodales si sepulchrum amicae visitarem, curas meas aliquantulum
+      fore levatas_.” Why then, as I perused them, did the hairs of my
+      head erect themselves on end, and the blood of my body become
+      congealed within my veins?
+
+      There came a light tap at the library door—and, pale as the
+      tenant of a tomb, a menial entered upon tiptoe. His looks were
+      wild with terror, and he spoke to me in a voice tremulous, husky,
+      and very low. What said he?—some broken sentences I heard. He
+      told of a wild cry disturbing the silence of the night—of the
+      gathering together of the household—of a search in the direction
+      of the sound; and then his tones grew thrillingly distinct as he
+      whispered me of a violated grave—of a disfigured body enshrouded,
+      yet still breathing—still palpitating—_still alive_!
+
+      He pointed to garments;—they were muddy and clotted with gore. I
+      spoke not, and he took me gently by the hand: it was indented
+      with the impress of human nails. He directed my attention to some
+      object against the wall. I looked at it for some minutes: it was
+      a spade. With a shriek I bounded to the table, and grasped the
+      box that lay upon it. But I could not force it open; and in my
+      tremor, it slipped from my hands, and fell heavily, and burst
+      into pieces; and from it, with a rattling sound, there rolled out
+      some instruments of dental surgery, intermingled with thirty-two
+      small, white and ivory-looking substances that were scattered to
+      and fro about the floor.
+
+
+
+
+ELEONORA
+
+
+     Sub conservatione formæ specificæ salva anima.
+                    —_Raymond Lully_.
+
+      I am come of a race noted for vigor of fancy and ardor of
+      passion. Men have called me mad; but the question is not yet
+      settled, whether madness is or is not the loftiest
+      intelligence—whether much that is glorious—whether all that is
+      profound—does not spring from disease of thought—from moods of
+      mind exalted at the expense of the general intellect. They who
+      dream by day are cognizant of many things which escape those who
+      dream only by night. In their gray visions they obtain glimpses
+      of eternity, and thrill, in awakening, to find that they have
+      been upon the verge of the great secret. In snatches, they learn
+      something of the wisdom which is of good, and more of the mere
+      knowledge which is of evil. They penetrate, however, rudderless
+      or compassless into the vast ocean of the “light ineffable,” and
+      again, like the adventures of the Nubian geographer, “agressi
+      sunt mare tenebrarum, quid in eo esset exploraturi.”
+
+      We will say, then, that I am mad. I grant, at least, that there
+      are two distinct conditions of my mental existence—the condition
+      of a lucid reason, not to be disputed, and belonging to the
+      memory of events forming the first epoch of my life—and a
+      condition of shadow and doubt, appertaining to the present, and
+      to the recollection of what constitutes the second great era of
+      my being. Therefore, what I shall tell of the earlier period,
+      believe; and to what I may relate of the later time, give only
+      such credit as may seem due, or doubt it altogether, or, if doubt
+      it ye cannot, then play unto its riddle the Oedipus.
+
+      She whom I loved in youth, and of whom I now pen calmly and
+      distinctly these remembrances, was the sole daughter of the only
+      sister of my mother long departed. Eleonora was the name of my
+      cousin. We had always dwelled together, beneath a tropical sun,
+      in the Valley of the Many-Colored Grass. No unguided footstep
+      ever came upon that vale; for it lay away up among a range of
+      giant hills that hung beetling around about it, shutting out the
+      sunlight from its sweetest recesses. No path was trodden in its
+      vicinity; and, to reach our happy home, there was need of putting
+      back, with force, the foliage of many thousands of forest trees,
+      and of crushing to death the glories of many millions of fragrant
+      flowers. Thus it was that we lived all alone, knowing nothing of
+      the world without the valley—I, and my cousin, and her mother.
+
+      From the dim regions beyond the mountains at the upper end of our
+      encircled domain, there crept out a narrow and deep river,
+      brighter than all save the eyes of Eleonora; and, winding
+      stealthily about in mazy courses, it passed away, at length,
+      through a shadowy gorge, among hills still dimmer than those
+      whence it had issued. We called it the “River of Silence”; for
+      there seemed to be a hushing influence in its flow. No murmur
+      arose from its bed, and so gently it wandered along, that the
+      pearly pebbles upon which we loved to gaze, far down within its
+      bosom, stirred not at all, but lay in a motionless content, each
+      in its own old station, shining on gloriously forever.
+
+      The margin of the river, and of the many dazzling rivulets that
+      glided through devious ways into its channel, as well as the
+      spaces that extended from the margins away down into the depths
+      of the streams until they reached the bed of pebbles at the
+      bottom,—these spots, not less than the whole surface of the
+      valley, from the river to the mountains that girdled it in, were
+      carpeted all by a soft green grass, thick, short, perfectly even,
+      and vanilla-perfumed, but so besprinkled throughout with the
+      yellow buttercup, the white daisy, the purple violet, and the
+      ruby-red asphodel, that its exceeding beauty spoke to our hearts
+      in loud tones, of the love and of the glory of God.
+
+      And, here and there, in groves about this grass, like
+      wildernesses of dreams, sprang up fantastic trees, whose tall
+      slender stems stood not upright, but slanted gracefully toward
+      the light that peered at noon-day into the centre of the valley.
+      Their mark was speckled with the vivid alternate splendor of
+      ebony and silver, and was smoother than all save the cheeks of
+      Eleonora; so that, but for the brilliant green of the huge leaves
+      that spread from their summits in long, tremulous lines, dallying
+      with the Zephyrs, one might have fancied them giant serpents of
+      Syria doing homage to their sovereign the Sun.
+
+      Hand in hand about this valley, for fifteen years, roamed I with
+      Eleonora before Love entered within our hearts. It was one
+      evening at the close of the third lustrum of her life, and of the
+      fourth of my own, that we sat, locked in each other’s embrace,
+      beneath the serpent-like trees, and looked down within the water
+      of the River of Silence at our images therein. We spoke no words
+      during the rest of that sweet day, and our words even upon the
+      morrow were tremulous and few. We had drawn the God Eros from
+      that wave, and now we felt that he had enkindled within us the
+      fiery souls of our forefathers. The passions which had for
+      centuries distinguished our race, came thronging with the fancies
+      for which they had been equally noted, and together breathed a
+      delirious bliss over the Valley of the Many-Colored Grass. A
+      change fell upon all things. Strange, brilliant flowers,
+      star-shaped, burn out upon the trees where no flowers had been
+      known before. The tints of the green carpet deepened; and when,
+      one by one, the white daisies shrank away, there sprang up in
+      place of them, ten by ten of the ruby-red asphodel. And life
+      arose in our paths; for the tall flamingo, hitherto unseen, with
+      all gay glowing birds, flaunted his scarlet plumage before us.
+      The golden and silver fish haunted the river, out of the bosom of
+      which issued, little by little, a murmur that swelled, at length,
+      into a lulling melody more divine than that of the harp of
+      Æolus—sweeter than all save the voice of Eleonora. And now, too,
+      a voluminous cloud, which we had long watched in the regions of
+      Hesper, floated out thence, all gorgeous in crimson and gold, and
+      settling in peace above us, sank, day by day, lower and lower,
+      until its edges rested upon the tops of the mountains, turning
+      all their dimness into magnificence, and shutting us up, as if
+      forever, within a magic prison-house of grandeur and of glory.
+
+      The loveliness of Eleonora was that of the Seraphim; but she was
+      a maiden artless and innocent as the brief life she had led among
+      the flowers. No guile disguised the fervor of love which animated
+      her heart, and she examined with me its inmost recesses as we
+      walked together in the Valley of the Many-Colored Grass, and
+      discoursed of the mighty changes which had lately taken place
+      therein.
+
+      At length, having spoken one day, in tears, of the last sad
+      change which must befall Humanity, she thenceforward dwelt only
+      upon this one sorrowful theme, interweaving it into all our
+      converse, as, in the songs of the bard of Schiraz, the same
+      images are found occurring, again and again, in every impressive
+      variation of phrase.
+
+      She had seen that the finger of Death was upon her bosom—that,
+      like the ephemeron, she had been made perfect in loveliness only
+      to die; but the terrors of the grave to her lay solely in a
+      consideration which she revealed to me, one evening at twilight,
+      by the banks of the River of Silence. She grieved to think that,
+      having entombed her in the Valley of the Many-Colored Grass, I
+      would quit forever its happy recesses, transferring the love
+      which now was so passionately her own to some maiden of the outer
+      and everyday world. And, then and there, I threw myself hurriedly
+      at the feet of Eleonora, and offered up a vow, to herself and to
+      Heaven, that I would never bind myself in marriage to any
+      daughter of Earth—that I would in no manner prove recreant to her
+      dear memory, or to the memory of the devout affection with which
+      she had blessed me. And I called the Mighty Ruler of the Universe
+      to witness the pious solemnity of my vow. And the curse which I
+      invoked of Him and of her, a saint in Helusion should I prove
+      traitorous to that promise, involved a penalty the exceeding
+      great horror of which will not permit me to make record of it
+      here. And the bright eyes of Eleonora grew brighter at my words;
+      and she sighed as if a deadly burthen had been taken from her
+      breast; and she trembled and very bitterly wept; but she made
+      acceptance of the vow, (for what was she but a child?) and it
+      made easy to her the bed of her death. And she said to me, not
+      many days afterward, tranquilly dying, that, because of what I
+      had done for the comfort of her spirit she would watch over me in
+      that spirit when departed, and, if so it were permitted her
+      return to me visibly in the watches of the night; but, if this
+      thing were, indeed, beyond the power of the souls in Paradise,
+      that she would, at least, give me frequent indications of her
+      presence, sighing upon me in the evening winds, or filling the
+      air which I breathed with perfume from the censers of the angels.
+      And, with these words upon her lips, she yielded up her innocent
+      life, putting an end to the first epoch of my own.
+
+      Thus far I have faithfully said. But as I pass the barrier in
+      Time’s path, formed by the death of my beloved, and proceed with
+      the second era of my existence, I feel that a shadow gathers over
+      my brain, and I mistrust the perfect sanity of the record. But
+      let me on.—Years dragged themselves along heavily, and still I
+      dwelled within the Valley of the Many-Colored Grass; but a second
+      change had come upon all things. The star-shaped flowers shrank
+      into the stems of the trees, and appeared no more. The tints of
+      the green carpet faded; and, one by one, the ruby-red asphodels
+      withered away; and there sprang up, in place of them, ten by ten,
+      dark, eye-like violets, that writhed uneasily and were ever
+      encumbered with dew. And Life departed from our paths; for the
+      tall flamingo flaunted no longer his scarlet plumage before us,
+      but flew sadly from the vale into the hills, with all the gay
+      glowing birds that had arrived in his company. And the golden and
+      silver fish swam down through the gorge at the lower end of our
+      domain and bedecked the sweet river never again. And the lulling
+      melody that had been softer than the wind-harp of Æolus, and more
+      divine than all save the voice of Eleonora, it died little by
+      little away, in murmurs growing lower and lower, until the stream
+      returned, at length, utterly, into the solemnity of its original
+      silence. And then, lastly, the voluminous cloud uprose, and,
+      abandoning the tops of the mountains to the dimness of old, fell
+      back into the regions of Hesper, and took away all its manifold
+      golden and gorgeous glories from the Valley of the Many-Colored
+      Grass.
+
+      Yet the promises of Eleonora were not forgotten; for I heard the
+      sounds of the swinging of the censers of the angels; and streams
+      of a holy perfume floated ever and ever about the valley; and at
+      lone hours, when my heart beat heavily, the winds that bathed my
+      brow came unto me laden with soft sighs; and indistinct murmurs
+      filled often the night air, and once—oh, but once only! I was
+      awakened from a slumber, like the slumber of death, by the
+      pressing of spiritual lips upon my own.
+
+      But the void within my heart refused, even thus, to be filled. I
+      longed for the love which had before filled it to overflowing. At
+      length the valley pained me through its memories of Eleonora, and
+      I left it for ever for the vanities and the turbulent triumphs of
+      the world.
+
+      I found myself within a strange city, where all things might have
+      served to blot from recollection the sweet dreams I had dreamed
+      so long in the Valley of the Many-Colored Grass. The pomps and
+      pageantries of a stately court, and the mad clangor of arms, and
+      the radiant loveliness of women, bewildered and intoxicated my
+      brain. But as yet my soul had proved true to its vows, and the
+      indications of the presence of Eleonora were still given me in
+      the silent hours of the night. Suddenly these manifestations they
+      ceased, and the world grew dark before mine eyes, and I stood
+      aghast at the burning thoughts which possessed, at the terrible
+      temptations which beset me; for there came from some far, far
+      distant and unknown land, into the gay court of the king I
+      served, a maiden to whose beauty my whole recreant heart yielded
+      at once—at whose footstool I bowed down without a struggle, in
+      the most ardent, in the most abject worship of love. What,
+      indeed, was my passion for the young girl of the valley in
+      comparison with the fervor, and the delirium, and the
+      spirit-lifting ecstasy of adoration with which I poured out my
+      whole soul in tears at the feet of the ethereal Ermengarde?—Oh,
+      bright was the seraph Ermengarde! and in that knowledge I had
+      room for none other. Oh, divine was the angel Ermengarde! and as
+      I looked down into the depths of her memorial eyes, I thought
+      only of them—and of her.
+
+      I wedded—nor dreaded the curse I had invoked; and its bitterness
+      was not visited upon me. And once—but once again in the silence
+      of the night; there came through my lattice the soft sighs which
+      had forsaken me; and they modelled themselves into familiar and
+      sweet voice, saying:
+
+      “Sleep in peace! for the Spirit of Love reigneth and ruleth, and,
+      in taking to thy passionate heart her who is Ermengarde, thou art
+      absolved, for reasons which shall be made known to thee in
+      Heaven, of thy vows unto Eleonora.”
+
+
+
+
+NOTES TO THE SECOND VOLUME
+
+
+Notes — Scheherazade
+
+      (*1) The coralites.
+
+      (*2) “One of the most remarkable natural curiosities in Texas is
+      a petrified forest, near the head of Pasigno river. It consists
+      of several hundred trees, in an erect position, all turned to
+      stone. Some trees, now growing, are partly petrified. This is a
+      startling fact for natural philosophers, and must cause them to
+      modify the existing theory of petrification.—_Kennedy_.
+
+      This account, at first discredited, has since been corroborated
+      by the discovery of a completely petrified forest, near the head
+      waters of the Cheyenne, or Chienne river, which has its source in
+      the Black Hills of the rocky chain.
+
+      There is scarcely, perhaps, a spectacle on the surface of the
+      globe more remarkable, either in a geological or picturesque
+      point of view than that presented by the petrified forest, near
+      Cairo. The traveller, having passed the tombs of the caliphs,
+      just beyond the gates of the city, proceeds to the southward,
+      nearly at right angles to the road across the desert to Suez, and
+      after having travelled some ten miles up a low barren valley,
+      covered with sand, gravel, and sea shells, fresh as if the tide
+      had retired but yesterday, crosses a low range of sandhills,
+      which has for some distance run parallel to his path. The scene
+      now presented to him is beyond conception singular and desolate.
+      A mass of fragments of trees, all converted into stone, and when
+      struck by his horse’s hoof ringing like cast iron, is seen to
+      extend itself for miles and miles around him, in the form of a
+      decayed and prostrate forest. The wood is of a dark brown hue,
+      but retains its form in perfection, the pieces being from one to
+      fifteen feet in length, and from half a foot to three feet in
+      thickness, strewed so closely together, as far as the eye can
+      reach, that an Egyptian donkey can scarcely thread its way
+      through amongst them, and so natural that, were it in Scotland or
+      Ireland, it might pass without remark for some enormous drained
+      bog, on which the exhumed trees lay rotting in the sun. The roots
+      and rudiments of the branches are, in many cases, nearly perfect,
+      and in some the worm-holes eaten under the bark are readily
+      recognizable. The most delicate of the sap vessels, and all the
+      finer portions of the centre of the wood, are perfectly entire,
+      and bear to be examined with the strongest magnifiers. The whole
+      are so thoroughly silicified as to scratch glass and are capable
+      of receiving the highest polish.— _Asiatic Magazine_.
+
+      (*3) The Mammoth Cave of Kentucky.
+
+      (*4) In Iceland, 1783.
+
+      (*5) “During the eruption of Hecla, in 1766, clouds of this kind
+      produced such a degree of darkness that, at Glaumba, which is
+      more than fifty leagues from the mountain, people could only find
+      their way by groping. During the eruption of Vesuvius, in 1794,
+      at Caserta, four leagues distant, people could only walk by the
+      light of torches. On the first of May, 1812, a cloud of volcanic
+      ashes and sand, coming from a volcano in the island of St.
+      Vincent, covered the whole of Barbadoes, spreading over it so
+      intense a darkness that, at mid-day, in the open air, one could
+      not perceive the trees or other objects near him, or even a white
+      handkerchief placed at the distance of six inches from the
+      eye._“—Murray, p. 215, Phil. edit._
+
+      (*6) In the year 1790, in the Caraccas during an earthquake a
+      portion of the granite soil sank and left a lake eight hundred
+      yards in diameter, and from eighty to a hundred feet deep. It was
+      a part of the forest of Aripao which sank, and the trees remained
+      green for several months under the water.”—_Murray_, p. 221
+
+      (*7) The hardest steel ever manufactured may, under the action of
+      a blowpipe, be reduced to an impalpable powder, which will float
+      readily in the atmospheric air.
+
+      (*8) The region of the Niger. See Simmona’s _Colonial Magazine_.
+
+      (*9) The _Myrmeleon_—lion-ant. The term “monster” is equally
+      applicable to small abnormal things and to great, while such
+      epithets as “vast” are merely comparative. The cavern of the
+      myrmeleon is vast in comparison with the hole of the common red
+      ant. A grain of silex is also a “rock.”
+
+      (*10) The _Epidendron, Flos Aeris,_ of the family of the
+      _Orchideae_, grows with merely the surface of its roots attached
+      to a tree or other object, from which it derives no
+      nutriment—subsisting altogether upon air.
+
+      (*11) The _Parasites,_ such as the wonderful _Rafflesia
+      Arnaldii_.
+
+      (*12) _Schouw_ advocates a class of plants that grow upon living
+      animals—the _Plantae_ _Epizoae_. Of this class are the _Fuci_ and
+      _Algae_.
+
+      _Mr. J. B. Williams, of Salem, Mass._, presented the “National
+      Institute” with an insect from New Zealand, with the following
+      description: “‘_The Hotte_, a decided caterpillar, or worm, is
+      found gnawing at the root of the _Rota_ tree, with a plant
+      growing out of its head. This most peculiar and extraordinary
+      insect travels up both the _Rota_ and _Ferriri_ trees, and
+      entering into the top, eats its way, perforating the trunk of the
+      trees until it reaches the root, and dies, or remains dormant,
+      and the plant propagates out of its head; the body remains
+      perfect and entire, of a harder substance than when alive. From
+      this insect the natives make a coloring for tattooing.
+
+      (*13) In mines and natural caves we find a species of
+      cryptogamous _fungus_ that emits an intense phosphorescence.
+
+      (*14) The orchis, scabius and valisneria.
+
+      (*15) The corolla of this flower (_Aristolochia Clematitis_),
+      which is tubular, but terminating upwards in a ligulate limb, is
+      inflated into a globular figure at the base. The tubular part is
+      internally beset with stiff hairs, pointing downwards. The
+      globular part contains the pistil, which consists merely of a
+      germen and stigma, together with the surrounding stamens. But the
+      stamens, being shorter than the germen, cannot discharge the
+      pollen so as to throw it upon the stigma, as the flower stands
+      always upright till after impregnation. And hence, without some
+      additional and peculiar aid, the pollen must necessarily fan down
+      to the bottom of the flower. Now, the aid that nature has
+      furnished in this case, is that of the _Tiputa Pennicornis_, a
+      small insect, which entering the tube of the corrolla in quest of
+      honey, descends to the bottom, and rummages about till it becomes
+      quite covered with pollen; but not being able to force its way
+      out again, owing to the downward position of the hairs, which
+      converge to a point like the wires of a mouse-trap, and being
+      somewhat impatient of its confinement it brushes backwards and
+      forwards, trying every corner, till, after repeatedly traversing
+      the stigma, it covers it with pollen sufficient for its
+      impregnation, in consequence of which the flower soon begins to
+      droop, and the hairs to shrink to the sides of the tube,
+      effecting an easy passage for the escape of the insect.”—_Rev. P.
+      Keith-System of Physiological Botany_.
+
+      (*16) The bees—ever since bees were—have been constructing their
+      cells with just such sides, in just such number, and at just such
+      inclinations, as it has been demonstrated (in a problem involving
+      the profoundest mathematical principles) are the very sides, in
+      the very number, and at the very angles, which will afford the
+      creatures the most room that is compatible with the greatest
+      stability of structure.
+
+      During the latter part of the last century, the question arose
+      among mathematicians—“to determine the best form that can be
+      given to the sails of a windmill, according to their varying
+      distances from the revolving vanes, and likewise from the centres
+      of the revolution.” This is an excessively complex problem, for
+      it is, in other words, to find the best possible position at an
+      infinity of varied distances and at an infinity of points on the
+      arm. There were a thousand futile attempts to answer the query on
+      the part of the most illustrious mathematicians, and when at
+      length, an undeniable solution was discovered, men found that the
+      wings of a bird had given it with absolute precision ever since
+      the first bird had traversed the air.
+
+      (*17) He observed a flock of pigeons passing betwixt Frankfort
+      and the Indian territory, one mile at least in breadth; it took
+      up four hours in passing, which, at the rate of one mile per
+      minute, gives a length of 240 miles; and, supposing three pigeons
+      to each square yard, gives 2,230,272,000 Pigeons.—“_Travels in
+      Canada and the United States,” by Lieut. F. Hall._
+
+      (*18) The earth is upheld by a cow of a blue color, having horns
+      four hundred in number.”—_Sale’s Koran_.
+
+      (*19) “The _Entozoa_, or intestinal worms, have repeatedly been
+      observed in the muscles, and in the cerebral substance of
+      men.”—See Wyatt’s Physiology, p. 143.
+
+      (*20) On the Great Western Railway, between London and Exeter, a
+      speed of 71 miles per hour has been attained. A train weighing 90
+      tons was whirled from Paddington to Didcot (53 miles) in 51
+      minutes.
+
+      (*21) The _Eccalobeion_
+
+      (*22) Mäelzel’s Automaton Chess-player.
+
+      (*23) Babbage’s Calculating Machine.
+
+      (*24) _Chabert_, and since him, a hundred others.
+
+      (*25) The Electrotype.
+
+      (*26) _Wollaston_ made of platinum for the field of views in a
+      telescope a wire one eighteen-thousandth part of an inch in
+      thickness. It could be seen only by means of the microscope.
+
+      (*27) Newton demonstrated that the retina beneath the influence
+      of the violet ray of the spectrum, vibrated 900,000,000 of times
+      in a second.
+
+      (*28) Voltaic pile.
+
+      (*29) The Electro Telegraph Printing Apparatus.
+
+      (*30) The Electro telegraph transmits intelligence
+      instantaneously—at least at so far as regards any distance upon
+      the earth.
+
+      (*31) Common experiments in Natural Philosophy. If two red rays
+      from two luminous points be admitted into a dark chamber so as to
+      fall on a white surface, and differ in their length by 0.0000258
+      of an inch, their intensity is doubled. So also if the difference
+      in length be any whole-number multiple of that fraction. A
+      multiple by 2 1/4, 3 1/4, &c., gives an intensity equal to one
+      ray only; but a multiple by 2 1/2, 3 1/2, &c., gives the result
+      of total darkness. In violet rays similar effects arise when the
+      difference in length is 0.000157 of an inch; and with all other
+      rays the results are the same—the difference varying with a
+      uniform increase from the violet to the red.
+
+      “Analogous experiments in respect to sound produce analogous
+      results.”
+
+      (*32) Place a platina crucible over a spirit lamp, and keep it a
+      red heat; pour in some sulphuric acid, which, though the most
+      volatile of bodies at a common temperature, will be found to
+      become completely fixed in a hot crucible, and not a drop
+      evaporates—being surrounded by an atmosphere of its own, it does
+      not, in fact, touch the sides. A few drops of water are now
+      introduced, when the acid, immediately coming in contact with the
+      heated sides of the crucible, flies off in sulphurous acid vapor,
+      and so rapid is its progress, that the caloric of the water
+      passes off with it, which falls a lump of ice to the bottom; by
+      taking advantage of the moment before it is allowed to remelt, it
+      may be turned out a lump of ice from a red-hot vessel.
+
+      (*33) The Daguerreotype.
+
+      (*34) Although light travels 167,000 miles in a second, the
+      distance of 61 Cygni (the only star whose distance is
+      ascertained) is so inconceivably great, that its rays would
+      require more than ten years to reach the earth. For stars beyond
+      this, 20—or even 1000 years—would be a moderate estimate. Thus,
+      if they had been annihilated 20, or 1000 years ago, we might
+      still see them to-day by the light which started from their
+      surfaces 20 or 1000 years in the past time. That many which we
+      see daily are really extinct, is not impossible—not even
+      improbable.
+
+Notes—Maelstrom
+
+      (*1) See Archimedes, “_De Incidentibus in Fluido_.”—lib. 2.
+
+Notes—Island of the Fay
+
+      (*1) Moraux is here derived from moeurs, and its meaning is
+      “fashionable” or more strictly “of manners.”
+
+      (*2) Speaking of the tides, Pomponius Mela, in his treatise “De
+      Situ Orbis,” says “either the world is a great animal, or” etc
+
+      (*3) Balzac—in substance—I do not remember the words
+
+      (*4) Florem putares nare per liquidum aethera.—P. Commire.
+
+Notes — Domain of Arnheim
+
+      (*1) An incident, similar in outline to the one here imagined,
+      occurred, not very long ago, in England. The name of the
+      fortunate heir was Thelluson. I first saw an account of this
+      matter in the “Tour” of Prince Puckler Muskau, who makes the sum
+      inherited _ninety millions of pounds_, and justly observes that
+      “in the contemplation of so vast a sum, and of the services to
+      which it might be applied, there is something even of the
+      sublime.” To suit the views of this article I have followed the
+      Prince’s statement, although a grossly exaggerated one. The germ,
+      and in fact, the commencement of the present paper was published
+      many years ago—previous to the issue of the first number of Sue’s
+      admirable _Juif Errant_, which may possibly have been suggested
+      to him by Muskau’s account.
+
+Notes—Berenice
+
+      (*1) For as Jove, during the winter season, gives twice seven
+      days of warmth, men have called this element and temperate time
+      the nurse of the beautiful Halcyon—_Simonides_
+
+
+
+
+*** END OF THE PROJECT GUTENBERG EBOOK THE WORKS OF EDGAR ALLAN POE — VOLUME 2 ***
+
+
+    
+
+Updated editions will replace the previous one—the old editions will
+be renamed.
+
+Creating the works from print editions not protected by U.S. copyright
+law means that no one owns a United States copyright in these works,
+so the Foundation (and you!) can copy and distribute it in the United
+States without permission and without paying copyright
+royalties. Special rules, set forth in the General Terms of Use part
+of this license, apply to copying and distributing Project
+Gutenberg™ electronic works to protect the PROJECT GUTENBERG™
+concept and trademark. Project Gutenberg is a registered trademark,
+and may not be used if you charge for an eBook, except by following
+the terms of the trademark license, including paying royalties for use
+of the Project Gutenberg trademark. If you do not charge anything for
+copies of this eBook, complying with the trademark license is very
+easy. You may use this eBook for nearly any purpose such as creation
+of derivative works, reports, performances and research. Project
+Gutenberg eBooks may be modified and printed and given away—you may
+do practically ANYTHING in the United States with eBooks not protected
+by U.S. copyright law. Redistribution is subject to the trademark
+license, especially commercial redistribution.
+
+
+START: FULL LICENSE
+
+THE FULL PROJECT GUTENBERG LICENSE
+
+PLEASE READ THIS BEFORE YOU DISTRIBUTE OR USE THIS WORK
+
+To protect the Project Gutenberg™ mission of promoting the free
+distribution of electronic works, by using or distributing this work
+(or any other work associated in any way with the phrase “Project
+Gutenberg”), you agree to comply with all the terms of the Full
+Project Gutenberg™ License available with this file or online at
+www.gutenberg.org/license.
+
+Section 1. General Terms of Use and Redistributing Project Gutenberg™
+electronic works
+
+1.A. By reading or using any part of this Project Gutenberg™
+electronic work, you indicate that you have read, understand, agree to
+and accept all the terms of this license and intellectual property
+(trademark/copyright) agreement. If you do not agree to abide by all
+the terms of this agreement, you must cease using and return or
+destroy all copies of Project Gutenberg™ electronic works in your
+possession. If you paid a fee for obtaining a copy of or access to a
+Project Gutenberg™ electronic work and you do not agree to be bound
+by the terms of this agreement, you may obtain a refund from the person
+or entity to whom you paid the fee as set forth in paragraph 1.E.8.
+
+1.B. “Project Gutenberg” is a registered trademark. It may only be
+used on or associated in any way with an electronic work by people who
+agree to be bound by the terms of this agreement. There are a few
+things that you can do with most Project Gutenberg™ electronic works
+even without complying with the full terms of this agreement. See
+paragraph 1.C below. There are a lot of things you can do with Project
+Gutenberg™ electronic works if you follow the terms of this
+agreement and help preserve free future access to Project Gutenberg™
+electronic works. See paragraph 1.E below.
+
+1.C. The Project Gutenberg Literary Archive Foundation (“the
+Foundation” or PGLAF), owns a compilation copyright in the collection
+of Project Gutenberg™ electronic works. Nearly all the individual
+works in the collection are in the public domain in the United
+States. If an individual work is unprotected by copyright law in the
+United States and you are located in the United States, we do not
+claim a right to prevent you from copying, distributing, performing,
+displaying or creating derivative works based on the work as long as
+all references to Project Gutenberg are removed. Of course, we hope
+that you will support the Project Gutenberg™ mission of promoting
+free access to electronic works by freely sharing Project Gutenberg™
+works in compliance with the terms of this agreement for keeping the
+Project Gutenberg™ name associated with the work. You can easily
+comply with the terms of this agreement by keeping this work in the
+same format with its attached full Project Gutenberg™ License when
+you share it without charge with others.
+
+1.D. The copyright laws of the place where you are located also govern
+what you can do with this work. Copyright laws in most countries are
+in a constant state of change. If you are outside the United States,
+check the laws of your country in addition to the terms of this
+agreement before downloading, copying, displaying, performing,
+distributing or creating derivative works based on this work or any
+other Project Gutenberg™ work. The Foundation makes no
+representations concerning the copyright status of any work in any
+country other than the United States.
+
+1.E. Unless you have removed all references to Project Gutenberg:
+
+1.E.1. The following sentence, with active links to, or other
+immediate access to, the full Project Gutenberg™ License must appear
+prominently whenever any copy of a Project Gutenberg™ work (any work
+on which the phrase “Project Gutenberg” appears, or with which the
+phrase “Project Gutenberg” is associated) is accessed, displayed,
+performed, viewed, copied or distributed:
+
+    This eBook is for the use of anyone anywhere in the United States and most
+    other parts of the world at no cost and with almost no restrictions
+    whatsoever. You may copy it, give it away or re-use it under the terms
+    of the Project Gutenberg License included with this eBook or online
+    at www.gutenberg.org. If you
+    are not located in the United States, you will have to check the laws
+    of the country where you are located before using this eBook.
+  
+1.E.2. If an individual Project Gutenberg™ electronic work is
+derived from texts not protected by U.S. copyright law (does not
+contain a notice indicating that it is posted with permission of the
+copyright holder), the work can be copied and distributed to anyone in
+the United States without paying any fees or charges. If you are
+redistributing or providing access to a work with the phrase “Project
+Gutenberg” associated with or appearing on the work, you must comply
+either with the requirements of paragraphs 1.E.1 through 1.E.7 or
+obtain permission for the use of the work and the Project Gutenberg™
+trademark as set forth in paragraphs 1.E.8 or 1.E.9.
+
+1.E.3. If an individual Project Gutenberg™ electronic work is posted
+with the permission of the copyright holder, your use and distribution
+must comply with both paragraphs 1.E.1 through 1.E.7 and any
+additional terms imposed by the copyright holder. Additional terms
+will be linked to the Project Gutenberg™ License for all works
+posted with the permission of the copyright holder found at the
+beginning of this work.
+
+1.E.4. Do not unlink or detach or remove the full Project Gutenberg™
+License terms from this work, or any files containing a part of this
+work or any other work associated with Project Gutenberg™.
+
+1.E.5. Do not copy, display, perform, distribute or redistribute this
+electronic work, or any part of this electronic work, without
+prominently displaying the sentence set forth in paragraph 1.E.1 with
+active links or immediate access to the full terms of the Project
+Gutenberg™ License.
+
+1.E.6. You may convert to and distribute this work in any binary,
+compressed, marked up, nonproprietary or proprietary form, including
+any word processing or hypertext form. However, if you provide access
+to or distribute copies of a Project Gutenberg™ work in a format
+other than “Plain Vanilla ASCII” or other format used in the official
+version posted on the official Project Gutenberg™ website
+(www.gutenberg.org), you must, at no additional cost, fee or expense
+to the user, provide a copy, a means of exporting a copy, or a means
+of obtaining a copy upon request, of the work in its original “Plain
+Vanilla ASCII” or other form. Any alternate format must include the
+full Project Gutenberg™ License as specified in paragraph 1.E.1.
+
+1.E.7. Do not charge a fee for access to, viewing, displaying,
+performing, copying or distributing any Project Gutenberg™ works
+unless you comply with paragraph 1.E.8 or 1.E.9.
+
+1.E.8. You may charge a reasonable fee for copies of or providing
+access to or distributing Project Gutenberg™ electronic works
+provided that:
+
+    • You pay a royalty fee of 20% of the gross profits you derive from
+        the use of Project Gutenberg™ works calculated using the method
+        you already use to calculate your applicable taxes. The fee is owed
+        to the owner of the Project Gutenberg™ trademark, but he has
+        agreed to donate royalties under this paragraph to the Project
+        Gutenberg Literary Archive Foundation. Royalty payments must be paid
+        within 60 days following each date on which you prepare (or are
+        legally required to prepare) your periodic tax returns. Royalty
+        payments should be clearly marked as such and sent to the Project
+        Gutenberg Literary Archive Foundation at the address specified in
+        Section 4, “Information about donations to the Project Gutenberg
+        Literary Archive Foundation.”
+    
+    • You provide a full refund of any money paid by a user who notifies
+        you in writing (or by e-mail) within 30 days of receipt that s/he
+        does not agree to the terms of the full Project Gutenberg™
+        License. You must require such a user to return or destroy all
+        copies of the works possessed in a physical medium and discontinue
+        all use of and all access to other copies of Project Gutenberg™
+        works.
+    
+    • You provide, in accordance with paragraph 1.F.3, a full refund of
+        any money paid for a work or a replacement copy, if a defect in the
+        electronic work is discovered and reported to you within 90 days of
+        receipt of the work.
+    
+    • You comply with all other terms of this agreement for free
+        distribution of Project Gutenberg™ works.
+    
+
+1.E.9. If you wish to charge a fee or distribute a Project
+Gutenberg™ electronic work or group of works on different terms than
+are set forth in this agreement, you must obtain permission in writing
+from the Project Gutenberg Literary Archive Foundation, the manager of
+the Project Gutenberg™ trademark. Contact the Foundation as set
+forth in Section 3 below.
+
+1.F.
+
+1.F.1. Project Gutenberg volunteers and employees expend considerable
+effort to identify, do copyright research on, transcribe and proofread
+works not protected by U.S. copyright law in creating the Project
+Gutenberg™ collection. Despite these efforts, Project Gutenberg™
+electronic works, and the medium on which they may be stored, may
+contain “Defects,” such as, but not limited to, incomplete, inaccurate
+or corrupt data, transcription errors, a copyright or other
+intellectual property infringement, a defective or damaged disk or
+other medium, a computer virus, or computer codes that damage or
+cannot be read by your equipment.
+
+1.F.2. LIMITED WARRANTY, DISCLAIMER OF DAMAGES - Except for the “Right
+of Replacement or Refund” described in paragraph 1.F.3, the Project
+Gutenberg Literary Archive Foundation, the owner of the Project
+Gutenberg™ trademark, and any other party distributing a Project
+Gutenberg™ electronic work under this agreement, disclaim all
+liability to you for damages, costs and expenses, including legal
+fees. YOU AGREE THAT YOU HAVE NO REMEDIES FOR NEGLIGENCE, STRICT
+LIABILITY, BREACH OF WARRANTY OR BREACH OF CONTRACT EXCEPT THOSE
+PROVIDED IN PARAGRAPH 1.F.3. YOU AGREE THAT THE FOUNDATION, THE
+TRADEMARK OWNER, AND ANY DISTRIBUTOR UNDER THIS AGREEMENT WILL NOT BE
+LIABLE TO YOU FOR ACTUAL, DIRECT, INDIRECT, CONSEQUENTIAL, PUNITIVE OR
+INCIDENTAL DAMAGES EVEN IF YOU GIVE NOTICE OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+1.F.3. LIMITED RIGHT OF REPLACEMENT OR REFUND - If you discover a
+defect in this electronic work within 90 days of receiving it, you can
+receive a refund of the money (if any) you paid for it by sending a
+written explanation to the person you received the work from. If you
+received the work on a physical medium, you must return the medium
+with your written explanation. The person or entity that provided you
+with the defective work may elect to provide a replacement copy in
+lieu of a refund. If you received the work electronically, the person
+or entity providing it to you may choose to give you a second
+opportunity to receive the work electronically in lieu of a refund. If
+the second copy is also defective, you may demand a refund in writing
+without further opportunities to fix the problem.
+
+1.F.4. Except for the limited right of replacement or refund set forth
+in paragraph 1.F.3, this work is provided to you ‘AS-IS’, WITH NO
+OTHER WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY PURPOSE.
+
+1.F.5. Some states do not allow disclaimers of certain implied
+warranties or the exclusion or limitation of certain types of
+damages. If any disclaimer or limitation set forth in this agreement
+violates the law of the state applicable to this agreement, the
+agreement shall be interpreted to make the maximum disclaimer or
+limitation permitted by the applicable state law. The invalidity or
+unenforceability of any provision of this agreement shall not void the
+remaining provisions.
+
+1.F.6. INDEMNITY - You agree to indemnify and hold the Foundation, the
+trademark owner, any agent or employee of the Foundation, anyone
+providing copies of Project Gutenberg™ electronic works in
+accordance with this agreement, and any volunteers associated with the
+production, promotion and distribution of Project Gutenberg™
+electronic works, harmless from all liability, costs and expenses,
+including legal fees, that arise directly or indirectly from any of
+the following which you do or cause to occur: (a) distribution of this
+or any Project Gutenberg™ work, (b) alteration, modification, or
+additions or deletions to any Project Gutenberg™ work, and (c) any
+Defect you cause.
+
+Section 2. Information about the Mission of Project Gutenberg™
+
+Project Gutenberg™ is synonymous with the free distribution of
+electronic works in formats readable by the widest variety of
+computers including obsolete, old, middle-aged and new computers. It
+exists because of the efforts of hundreds of volunteers and donations
+from people in all walks of life.
+
+Volunteers and financial support to provide volunteers with the
+assistance they need are critical to reaching Project Gutenberg™’s
+goals and ensuring that the Project Gutenberg™ collection will
+remain freely available for generations to come. In 2001, the Project
+Gutenberg Literary Archive Foundation was created to provide a secure
+and permanent future for Project Gutenberg™ and future
+generations. To learn more about the Project Gutenberg Literary
+Archive Foundation and how your efforts and donations can help, see
+Sections 3 and 4 and the Foundation information page at www.gutenberg.org.
+
+Section 3. Information about the Project Gutenberg Literary Archive Foundation
+
+The Project Gutenberg Literary Archive Foundation is a non-profit
+501(c)(3) educational corporation organized under the laws of the
+state of Mississippi and granted tax exempt status by the Internal
+Revenue Service. The Foundation’s EIN or federal tax identification
+number is 64-6221541. Contributions to the Project Gutenberg Literary
+Archive Foundation are tax deductible to the full extent permitted by
+U.S. federal laws and your state’s laws.
+
+The Foundation’s business office is located at 809 North 1500 West,
+Salt Lake City, UT 84116, (801) 596-1887. Email contact links and up
+to date contact information can be found at the Foundation’s website
+and official page at www.gutenberg.org/contact
+
+Section 4. Information about Donations to the Project Gutenberg
+Literary Archive Foundation
+
+Project Gutenberg™ depends upon and cannot survive without widespread
+public support and donations to carry out its mission of
+increasing the number of public domain and licensed works that can be
+freely distributed in machine-readable form accessible by the widest
+array of equipment including outdated equipment. Many small donations
+($1 to $5,000) are particularly important to maintaining tax exempt
+status with the IRS.
+
+The Foundation is committed to complying with the laws regulating
+charities and charitable donations in all 50 states of the United
+States. Compliance requirements are not uniform and it takes a
+considerable effort, much paperwork and many fees to meet and keep up
+with these requirements. We do not solicit donations in locations
+where we have not received written confirmation of compliance. To SEND
+DONATIONS or determine the status of compliance for any particular state
+visit www.gutenberg.org/donate.
+
+While we cannot and do not solicit contributions from states where we
+have not met the solicitation requirements, we know of no prohibition
+against accepting unsolicited donations from donors in such states who
+approach us with offers to donate.
+
+International donations are gratefully accepted, but we cannot make
+any statements concerning tax treatment of donations received from
+outside the United States. U.S. laws alone swamp our small staff.
+
+Please check the Project Gutenberg web pages for current donation
+methods and addresses. Donations are accepted in a number of other
+ways including checks, online payments and credit card donations. To
+donate, please visit: www.gutenberg.org/donate.
+
+Section 5. General Information About Project Gutenberg™ electronic works
+
+Professor Michael S. Hart was the originator of the Project
+Gutenberg™ concept of a library of electronic works that could be
+freely shared with anyone. For forty years, he produced and
+distributed Project Gutenberg™ eBooks with only a loose network of
+volunteer support.
+
+Project Gutenberg™ eBooks are often created from several printed
+editions, all of which are confirmed as not protected by copyright in
+the U.S. unless a copyright notice is included. Thus, we do not
+necessarily keep eBooks in compliance with any particular paper
+edition.
+
+Most people start at our website which has the main PG search
+facility: www.gutenberg.org.
+
+This website includes information about Project Gutenberg™,
+including how to make donations to the Project Gutenberg Literary
+Archive Foundation, how to help produce our new eBooks, and how to
+subscribe to our email newsletter to hear about new eBooks.
+
+

--- a/corpora/poeWorks.txt
+++ b/corpora/poeWorks.txt
@@ -1,0 +1,10011 @@
+﻿Contents
+
+ THE PURLOINED LETTER
+ THE THOUSAND-AND-SECOND TALE OF SCHEHERAZADE
+ A DESCENT INTO THE MAELSTROM.
+ VON KEMPELEN AND HIS DISCOVERY
+ MESMERIC REVELATION
+ THE FACTS IN THE CASE OF M. VALDEMAR
+ THE BLACK CAT.
+ THE FALL OF THE HOUSE OF USHER
+ SILENCE—A FABLE
+ THE MASQUE OF THE RED DEATH.
+ THE CASK OF AMONTILLADO.
+ THE IMP OF THE PERVERSE
+ THE ISLAND OF THE FAY
+ THE ASSIGNATION
+ THE PIT AND THE PENDULUM
+ THE PREMATURE BURIAL
+ THE DOMAIN OF ARNHEIM
+ LANDOR’S COTTAGE
+ WILLIAM WILSO
+ THE TELL-TALE HEART.
+ BERENICE
+ ELEONORA
+
+
+
+
+THE PURLOINED LETTER
+
+
+Nil sapientiæ odiosius acumine nimio.—_Seneca_.
+
+      At Paris, just after dark one gusty evening in the autumn of 18-,
+      I was enjoying the twofold luxury of meditation and a meerschaum,
+      in company with my friend C. Auguste Dupin, in his little back
+      library, or book-closet, _au troisième_, No. 33, _Rue Dunôt,
+      Faubourg St. Germain_. For one hour at least we had maintained a
+      profound silence; while each, to any casual observer, might have
+      seemed intently and exclusively occupied with the curling eddies
+      of smoke that oppressed the atmosphere of the chamber. For
+      myself, however, I was mentally discussing certain topics which
+      had formed matter for conversation between us at an earlier
+      period of the evening; I mean the affair of the Rue Morgue, and
+      the mystery attending the murder of Marie Rogêt. I looked upon
+      it, therefore, as something of a coincidence, when the door of
+      our apartment was thrown open and admitted our old acquaintance,
+      Monsieur G——, the Prefect of the Parisian police.
+
+      We gave him a hearty welcome; for there was nearly half as much
+      of the entertaining as of the contemptible about the man, and we
+      had not seen him for several years. We had been sitting in the
+      dark, and Dupin now arose for the purpose of lighting a lamp, but
+      sat down again, without doing so, upon G.‘s saying that he had
+      called to consult us, or rather to ask the opinion of my friend,
+      about some official business which had occasioned a great deal of
+      trouble.
+
+      “If it is any point requiring reflection,” observed Dupin, as he
+      forebore to enkindle the wick, “we shall examine it to better
+      purpose in the dark.”
+
+      “That is another of your odd notions,” said the Prefect, who had
+      a fashion of calling every thing “odd” that was beyond his
+      comprehension, and thus lived amid an absolute legion of
+      “oddities.”
+
+      “Very true,” said Dupin, as he supplied his visitor with a pipe,
+      and rolled towards him a comfortable chair.
+
+      “And what is the difficulty now?” I asked. “Nothing more in the
+      assassination way, I hope?”
+
+      “Oh no; nothing of that nature. The fact is, the business is very
+      simple indeed, and I make no doubt that we can manage it
+      sufficiently well ourselves; but then I thought Dupin would like
+      to hear the details of it, because it is so excessively odd.”
+
+      “Simple and odd,” said Dupin.
+
+      “Why, yes; and not exactly that, either. The fact is, we have all
+      been a good deal puzzled because the affair is so simple, and yet
+      baffles us altogether.”
+
+      “Perhaps it is the very simplicity of the thing which puts you at
+      fault,” said my friend.
+
+      “What nonsense you do talk!” replied the Prefect, laughing
+      heartily.
+
+      “Perhaps the mystery is a little too plain,” said Dupin.
+
+      “Oh, good heavens! who ever heard of such an idea?”
+
+      “A little too self-evident.”
+
+      “Ha! ha! ha—ha! ha! ha!—ho! ho! ho!” roared our visitor,
+      profoundly amused, “oh, Dupin, you will be the death of me yet!”
+
+      “And what, after all, is the matter on hand?” I asked.
+
+      “Why, I will tell you,” replied the Prefect, as he gave a long,
+      steady and contemplative puff, and settled himself in his chair.
+      “I will tell you in a few words; but, before I begin, let me
+      caution you that this is an affair demanding the greatest
+      secrecy, and that I should most probably lose the position I now
+      hold, were it known that I confided it to any one.”
+
+      “Proceed,” said I.
+
+      “Or not,” said Dupin.
+
+      “Well, then; I have received personal information, from a very
+      high quarter, that a certain document of the last importance has
+      been purloined from the royal apartments. The individual who
+      purloined it is known; this beyond a doubt; he was seen to take
+      it. It is known, also, that it still remains in his possession.”
+
+      “How is this known?” asked Dupin.
+
+      “It is clearly inferred,” replied the Prefect, “from the nature
+      of the document, and from the non-appearance of certain results
+      which would at once arise from its passing out of the robber’s
+      possession; that is to say, from his employing it as he must
+      design in the end to employ it.”
+
+      “Be a little more explicit,” I said.
+
+      “Well, I may venture so far as to say that the paper gives its
+      holder a certain power in a certain quarter where such power is
+      immensely valuable.” The Prefect was fond of the cant of
+      diplomacy.
+
+      “Still I do not quite understand,” said Dupin.
+
+      “No? Well; the disclosure of the document to a third person, who
+      shall be nameless, would bring in question the honor of a
+      personage of most exalted station; and this fact gives the holder
+      of the document an ascendancy over the illustrious personage
+      whose honor and peace are so jeopardized.”
+
+      “But this ascendancy,” I interposed, “would depend upon the
+      robber’s knowledge of the loser’s knowledge of the robber. Who
+      would dare—”
+
+      “The thief,” said G., “is the Minister D——, who dares all things,
+      those unbecoming as well as those becoming a man. The method of
+      the theft was not less ingenious than bold. The document in
+      question—a letter, to be frank—had been received by the personage
+      robbed while alone in the royal boudoir. During its perusal she
+      was suddenly interrupted by the entrance of the other exalted
+      personage from whom especially it was her wish to conceal it.
+      After a hurried and vain endeavor to thrust it in a drawer, she
+      was forced to place it, open as it was, upon a table. The
+      address, however, was uppermost, and, the contents thus
+      unexposed, the letter escaped notice. At this juncture enters the
+      Minister D——. His lynx eye immediately perceives the paper,
+      recognises the handwriting of the address, observes the confusion
+      of the personage addressed, and fathoms her secret. After some
+      business transactions, hurried through in his ordinary manner, he
+      produces a letter somewhat similar to the one in question, opens
+      it, pretends to read it, and then places it in close
+      juxtaposition to the other. Again he converses, for some fifteen
+      minutes, upon the public affairs. At length, in taking leave, he
+      takes also from the table the letter to which he had no claim.
+      Its rightful owner saw, but, of course, dared not call attention
+      to the act, in the presence of the third personage who stood at
+      her elbow. The minister decamped; leaving his own letter—one of
+      no importance—upon the table.”
+
+      “Here, then,” said Dupin to me, “you have precisely what you
+      demand to make the ascendancy complete—the robber’s knowledge of
+      the loser’s knowledge of the robber.”
+
+      “Yes,” replied the Prefect; “and the power thus attained has, for
+      some months past, been wielded, for political purposes, to a very
+      dangerous extent. The personage robbed is more thoroughly
+      convinced, every day, of the necessity of reclaiming her letter.
+      But this, of course, cannot be done openly. In fine, driven to
+      despair, she has committed the matter to me.”
+
+      “Than whom,” said Dupin, amid a perfect whirlwind of smoke, “no
+      more sagacious agent could, I suppose, be desired, or even
+      imagined.”
+
+      “You flatter me,” replied the Prefect; “but it is possible that
+      some such opinion may have been entertained.”
+
+      “It is clear,” said I, “as you observe, that the letter is still
+      in possession of the minister; since it is this possession, and
+      not any employment of the letter, which bestows the power. With
+      the employment the power departs.”
+
+      “True,” said G.; “and upon this conviction I proceeded. My first
+      care was to make thorough search of the minister’s hotel; and
+      here my chief embarrassment lay in the necessity of searching
+      without his knowledge. Beyond all things, I have been warned of
+      the danger which would result from giving him reason to suspect
+      our design.”
+
+      “But,” said I, “you are quite au fait in these investigations.
+      The Parisian police have done this thing often before.”
+
+      “Oh, yes; and for this reason I did not despair. The habits of
+      the minister gave me, too, a great advantage. He is frequently
+      absent from home all night. His servants are by no means
+      numerous. They sleep at a distance from their master’s apartment,
+      and, being chiefly Neapolitans, are readily made drunk. I have
+      keys, as you know, with which I can open any chamber or cabinet
+      in Paris. For three months a night has not passed, during the
+      greater part of which I have not been engaged, personally, in
+      ransacking the D—— Hotel. My honor is interested, and, to mention
+      a great secret, the reward is enormous. So I did not abandon the
+      search until I had become fully satisfied that the thief is a
+      more astute man than myself. I fancy that I have investigated
+      every nook and corner of the premises in which it is possible
+      that the paper can be concealed.”
+
+      “But is it not possible,” I suggested, “that although the letter
+      may be in possession of the minister, as it unquestionably is, he
+      may have concealed it elsewhere than upon his own premises?”
+
+      “This is barely possible,” said Dupin. “The present peculiar
+      condition of affairs at court, and especially of those intrigues
+      in which D—— is known to be involved, would render the instant
+      availability of the document—its susceptibility of being produced
+      at a moment’s notice—a point of nearly equal importance with its
+      possession.”
+
+      “Its susceptibility of being produced?” said I.
+
+      “That is to say, of being destroyed,” said Dupin.
+
+      “True,” I observed; “the paper is clearly then upon the premises.
+      As for its being upon the person of the minister, we may consider
+      that as out of the question.”
+
+      “Entirely,” said the Prefect. “He has been twice waylaid, as if
+      by footpads, and his person rigorously searched under my own
+      inspection.”
+
+      “You might have spared yourself this trouble,” said Dupin. “D——,
+      I presume, is not altogether a fool, and, if not, must have
+      anticipated these waylayings, as a matter of course.”
+
+      “Not altogether a fool,” said G., “but then he’s a poet, which I
+      take to be only one remove from a fool.”
+
+      “True,” said Dupin, after a long and thoughtful whiff from his
+      meerschaum, “although I have been guilty of certain doggrel
+      myself.”
+
+      “Suppose you detail,” said I, “the particulars of your search.”
+
+      “Why the fact is, we took our time, and we searched _everywhere_.
+      I have had long experience in these affairs. I took the entire
+      building, room by room; devoting the nights of a whole week to
+      each. We examined, first, the furniture of each apartment. We
+      opened every possible drawer; and I presume you know that, to a
+      properly trained police agent, such a thing as a secret drawer is
+      impossible. Any man is a dolt who permits a ‘secret’ drawer to
+      escape him in a search of this kind. The thing is so plain. There
+      is a certain amount of bulk—of space—to be accounted for in every
+      cabinet. Then we have accurate rules. The fiftieth part of a line
+      could not escape us. After the cabinets we took the chairs. The
+      cushions we probed with the fine long needles you have seen me
+      employ. From the tables we removed the tops.”
+
+      “Why so?”
+
+      “Sometimes the top of a table, or other similarly arranged piece
+      of furniture, is removed by the person wishing to conceal an
+      article; then the leg is excavated, the article deposited within
+      the cavity, and the top replaced. The bottoms and tops of
+      bedposts are employed in the same way.”
+
+      “But could not the cavity be detected by sounding?” I asked.
+
+      “By no means, if, when the article is deposited, a sufficient
+      wadding of cotton be placed around it. Besides, in our case, we
+      were obliged to proceed without noise.”
+
+      “But you could not have removed—you could not have taken to
+      pieces all articles of furniture in which it would have been
+      possible to make a deposit in the manner you mention. A letter
+      may be compressed into a thin spiral roll, not differing much in
+      shape or bulk from a large knitting-needle, and in this form it
+      might be inserted into the rung of a chair, for example. You did
+      not take to pieces all the chairs?”
+
+      “Certainly not; but we did better—we examined the rungs of every
+      chair in the hotel, and, indeed the jointings of every
+      description of furniture, by the aid of a most powerful
+      microscope. Had there been any traces of recent disturbance we
+      should not have failed to detect it instantly. A single grain of
+      gimlet-dust, for example, would have been as obvious as an apple.
+      Any disorder in the glueing—any unusual gaping in the
+      joints—would have sufficed to insure detection.”
+
+      “I presume you looked to the mirrors, between the boards and the
+      plates, and you probed the beds and the bed-clothes, as well as
+      the curtains and carpets.”
+
+      “That of course; and when we had absolutely completed every
+      particle of the furniture in this way, then we examined the house
+      itself. We divided its entire surface into compartments, which we
+      numbered, so that none might be missed; then we scrutinized each
+      individual square inch throughout the premises, including the two
+      houses immediately adjoining, with the microscope, as before.”
+
+      “The two houses adjoining!” I exclaimed; “you must have had a
+      great deal of trouble.”
+
+      “We had; but the reward offered is prodigious!”
+
+      “You include the grounds about the houses?”
+
+      “All the grounds are paved with brick. They gave us comparatively
+      little trouble. We examined the moss between the bricks, and
+      found it undisturbed.”
+
+      “You looked among D——‘s papers, of course, and into the books of
+      the library?”
+
+      “Certainly; we opened every package and parcel; we not only
+      opened every book, but we turned over every leaf in each volume,
+      not contenting ourselves with a mere shake, according to the
+      fashion of some of our police officers. We also measured the
+      thickness of every book-cover, with the most accurate
+      admeasurement, and applied to each the most jealous scrutiny of
+      the microscope. Had any of the bindings been recently meddled
+      with, it would have been utterly impossible that the fact should
+      have escaped observation. Some five or six volumes, just from the
+      hands of the binder, we carefully probed, longitudinally, with
+      the needles.”
+
+      “You explored the floors beneath the carpets?”
+
+      “Beyond doubt. We removed every carpet, and examined the boards
+      with the microscope.”
+
+      “And the paper on the walls?”
+
+      “Yes.”
+
+      “You looked into the cellars?”
+
+      “We did.”
+
+      “Then,” I said, “you have been making a miscalculation, and the
+      letter is not upon the premises, as you suppose.”
+
+      “I fear you are right there,” said the Prefect. “And now, Dupin,
+      what would you advise me to do?”
+
+      “To make a thorough re-search of the premises.”
+
+      “That is absolutely needless,” replied G——. “I am not more sure
+      that I breathe than I am that the letter is not at the Hotel.”
+
+      “I have no better advice to give you,” said Dupin. “You have, of
+      course, an accurate description of the letter?”
+
+      “Oh yes!”—And here the Prefect, producing a memorandum-book,
+      proceeded to read aloud a minute account of the internal, and
+      especially of the external appearance of the missing document.
+      Soon after finishing the perusal of this description, he took his
+      departure, more entirely depressed in spirits than I had ever
+      known the good gentleman before.
+
+      In about a month afterwards he paid us another visit, and found
+      us occupied very nearly as before. He took a pipe and a chair and
+      entered into some ordinary conversation. At length I said,—
+
+      “Well, but G——, what of the purloined letter? I presume you have
+      at last made up your mind that there is no such thing as
+      overreaching the Minister?”
+
+      “Confound him, say I—yes; I made the re-examination, however, as
+      Dupin suggested—but it was all labor lost, as I knew it would
+      be.”
+
+      “How much was the reward offered, did you say?” asked Dupin.
+
+      “Why, a very great deal—a very liberal reward—I don’t like to say
+      how much, precisely; but one thing I will say, that I wouldn’t
+      mind giving my individual check for fifty thousand francs to any
+      one who could obtain me that letter. The fact is, it is becoming
+      of more and more importance every day; and the reward has been
+      lately doubled. If it were trebled, however, I could do no more
+      than I have done.”
+
+      “Why, yes,” said Dupin, drawlingly, between the whiffs of his
+      meerschaum, “I really—think, G——, you have not exerted
+      yourself—to the utmost in this matter. You might—do a little
+      more, I think, eh?”
+
+      “How?—in what way?”
+
+      “Why—puff, puff—you might—puff, puff—employ counsel in the
+      matter, eh?—puff, puff, puff. Do you remember the story they tell
+      of Abernethy?”
+
+      “No; hang Abernethy!”
+
+      “To be sure! hang him and welcome. But, once upon a time, a
+      certain rich miser conceived the design of spunging upon this
+      Abernethy for a medical opinion. Getting up, for this purpose, an
+      ordinary conversation in a private company, he insinuated his
+      case to the physician, as that of an imaginary individual.
+
+      “‘We will suppose,’ said the miser, ‘that his symptoms are such
+      and such; now, doctor, what would you have directed him to take?’
+
+      “‘Take!’ said Abernethy, ‘why, take advice, to be sure.’”
+
+      “But,” said the Prefect, a little discomposed, “I am perfectly
+      willing to take advice, and to pay for it. I would really give
+      fifty thousand francs to any one who would aid me in the matter.”
+
+      “In that case,” replied Dupin, opening a drawer, and producing a
+      check-book, “you may as well fill me up a check for the amount
+      mentioned. When you have signed it, I will hand you the letter.”
+
+      I was astounded. The Prefect appeared absolutely
+      thunder-stricken. For some minutes he remained speechless and
+      motionless, looking incredulously at my friend with open mouth,
+      and eyes that seemed starting from their sockets; then,
+      apparently recovering himself in some measure, he seized a pen,
+      and after several pauses and vacant stares, finally filled up and
+      signed a check for fifty thousand francs, and handed it across
+      the table to Dupin. The latter examined it carefully and
+      deposited it in his pocket-book; then, unlocking an escritoire,
+      took thence a letter and gave it to the Prefect. This functionary
+      grasped it in a perfect agony of joy, opened it with a trembling
+      hand, cast a rapid glance at its contents, and then, scrambling
+      and struggling to the door, rushed at length unceremoniously from
+      the room and from the house, without having uttered a syllable
+      since Dupin had requested him to fill up the check.
+
+      When he had gone, my friend entered into some explanations.
+
+      “The Parisian police,” he said, “are exceedingly able in their
+      way. They are persevering, ingenious, cunning, and thoroughly
+      versed in the knowledge which their duties seem chiefly to
+      demand. Thus, when G—— detailed to us his mode of searching the
+      premises at the Hotel D——, I felt entire confidence in his having
+      made a satisfactory investigation—so far as his labors extended.”
+
+      “So far as his labors extended?” said I.
+
+      “Yes,” said Dupin. “The measures adopted were not only the best
+      of their kind, but carried out to absolute perfection. Had the
+      letter been deposited within the range of their search, these
+      fellows would, beyond a question, have found it.”
+
+      I merely laughed—but he seemed quite serious in all that he said.
+
+      “The measures, then,” he continued, “were good in their kind, and
+      well executed; their defect lay in their being inapplicable to
+      the case, and to the man. A certain set of highly ingenious
+      resources are, with the Prefect, a sort of Procrustean bed, to
+      which he forcibly adapts his designs. But he perpetually errs by
+      being too deep or too shallow for the matter in hand; and many a
+      schoolboy is a better reasoner than he. I knew one about eight
+      years of age, whose success at guessing in the game of ‘even and
+      odd’ attracted universal admiration. This game is simple, and is
+      played with marbles. One player holds in his hand a number of
+      these toys, and demands of another whether that number is even or
+      odd. If the guess is right, the guesser wins one; if wrong, he
+      loses one. The boy to whom I allude won all the marbles of the
+      school. Of course he had some principle of guessing; and this lay
+      in mere observation and admeasurement of the astuteness of his
+      opponents. For example, an arrant simpleton is his opponent, and,
+      holding up his closed hand, asks, ‘are they even or odd?’ Our
+      schoolboy replies, ‘odd,’ and loses; but upon the second trial he
+      wins, for he then says to himself, ‘the simpleton had them even
+      upon the first trial, and his amount of cunning is just
+      sufficient to make him have them odd upon the second; I will
+      therefore guess odd;’—he guesses odd, and wins. Now, with a
+      simpleton a degree above the first, he would have reasoned thus:
+      ‘This fellow finds that in the first instance I guessed odd, and,
+      in the second, he will propose to himself, upon the first
+      impulse, a simple variation from even to odd, as did the first
+      simpleton; but then a second thought will suggest that this is
+      too simple a variation, and finally he will decide upon putting
+      it even as before. I will therefore guess even;’—he guesses even,
+      and wins. Now this mode of reasoning in the schoolboy, whom his
+      fellows termed ‘lucky,’—what, in its last analysis, is it?”
+
+      “It is merely,” I said, “an identification of the reasoner’s
+      intellect with that of his opponent.”
+
+      “It is,” said Dupin; “and, upon inquiring of the boy by what
+      means he effected the thorough identification in which his
+      success consisted, I received answer as follows: ‘When I wish to
+      find out how wise, or how stupid, or how good, or how wicked is
+      any one, or what are his thoughts at the moment, I fashion the
+      expression of my face, as accurately as possible, in accordance
+      with the expression of his, and then wait to see what thoughts or
+      sentiments arise in my mind or heart, as if to match or
+      correspond with the expression.’ This response of the schoolboy
+      lies at the bottom of all the spurious profundity which has been
+      attributed to Rochefoucault, to La Bougive, to Machiavelli, and
+      to Campanella.”
+
+      “And the identification,” I said, “of the reasoner’s intellect
+      with that of his opponent, depends, if I understand you aright,
+      upon the accuracy with which the opponent’s intellect is
+      admeasured.”
+
+      “For its practical value it depends upon this,” replied Dupin;
+      “and the Prefect and his cohort fail so frequently, first, by
+      default of this identification, and, secondly, by
+      ill-admeasurement, or rather through non-admeasurement, of the
+      intellect with which they are engaged. They consider only their
+      own ideas of ingenuity; and, in searching for anything hidden,
+      advert only to the modes in which they would have hidden it. They
+      are right in this much—that their own ingenuity is a faithful
+      representative of that of the mass; but when the cunning of the
+      individual felon is diverse in character from their own, the
+      felon foils them, of course. This always happens when it is above
+      their own, and very usually when it is below. They have no
+      variation of principle in their investigations; at best, when
+      urged by some unusual emergency—by some extraordinary reward—they
+      extend or exaggerate their old modes of practice, without
+      touching their principles. What, for example, in this case of
+      D——, has been done to vary the principle of action? What is all
+      this boring, and probing, and sounding, and scrutinizing with the
+      microscope and dividing the surface of the building into
+      registered square inches—what is it all but an exaggeration of
+      the application of the one principle or set of principles of
+      search, which are based upon the one set of notions regarding
+      human ingenuity, to which the Prefect, in the long routine of his
+      duty, has been accustomed? Do you not see he has taken it for
+      granted that all men proceed to conceal a letter,—not exactly in
+      a gimlet hole bored in a chair-leg—but, at least, in some
+      out-of-the-way hole or corner suggested by the same tenor of
+      thought which would urge a man to secrete a letter in a
+      gimlet-hole bored in a chair-leg? And do you not see also, that
+      such recherchés nooks for concealment are adapted only for
+      ordinary occasions, and would be adopted only by ordinary
+      intellects; for, in all cases of concealment, a disposal of the
+      article concealed—a disposal of it in this recherché manner,—is,
+      in the very first instance, presumable and presumed; and thus its
+      discovery depends, not at all upon the acumen, but altogether
+      upon the mere care, patience, and determination of the seekers;
+      and where the case is of importance—or, what amounts to the same
+      thing in the political eyes, when the reward is of magnitude,—the
+      qualities in question have never been known to fail. You will now
+      understand what I meant in suggesting that, had the purloined
+      letter been hidden any where within the limits of the Prefect’s
+      examination—in other words, had the principle of its concealment
+      been comprehended within the principles of the Prefect—its
+      discovery would have been a matter altogether beyond question.
+      This functionary, however, has been thoroughly mystified; and the
+      remote source of his defeat lies in the supposition that the
+      Minister is a fool, because he has acquired renown as a poet. All
+      fools are poets; this the Prefect feels; and he is merely guilty
+      of a non distributio medii in thence inferring that all poets are
+      fools.”
+
+      “But is this really the poet?” I asked. “There are two brothers,
+      I know; and both have attained reputation in letters. The
+      Minister I believe has written learnedly on the Differential
+      Calculus. He is a mathematician, and no poet.”
+
+      “You are mistaken; I know him well; he is both. As poet and
+      mathematician, he would reason well; as mere mathematician, he
+      could not have reasoned at all, and thus would have been at the
+      mercy of the Prefect.”
+
+      “You surprise me,” I said, “by these opinions, which have been
+      contradicted by the voice of the world. You do not mean to set at
+      naught the well-digested idea of centuries. The mathematical
+      reason has long been regarded as the reason par excellence.”
+
+      “‘Il y a à parièr,’” replied Dupin, quoting from Chamfort, “‘que
+      toute idée publique, toute convention reçue est une sottise, car
+      elle a convenue au plus grand nombre.’ The mathematicians, I
+      grant you, have done their best to promulgate the popular error
+      to which you allude, and which is none the less an error for its
+      promulgation as truth. With an art worthy a better cause, for
+      example, they have insinuated the term ‘analysis’ into
+      application to algebra. The French are the originators of this
+      particular deception; but if a term is of any importance—if words
+      derive any value from applicability—then ‘analysis’ conveys
+      ‘algebra’ about as much as, in Latin, ‘ambitus’ implies
+      ‘ambition,’ ‘_religio_’ ‘religion,’ or ‘_homines honesti_’ a set
+      of _honorable_ men.”
+
+      “You have a quarrel on hand, I see,” said I, “with some of the
+      algebraists of Paris; but proceed.”
+
+      “I dispute the availability, and thus the value, of that reason
+      which is cultivated in any especial form other than the
+      abstractly logical. I dispute, in particular, the reason educed
+      by mathematical study. The mathematics are the science of form
+      and quantity; mathematical reasoning is merely logic applied to
+      observation upon form and quantity. The great error lies in
+      supposing that even the truths of what is called pure algebra,
+      are abstract or general truths. And this error is so egregious
+      that I am confounded at the universality with which it has been
+      received. Mathematical axioms are not axioms of general truth.
+      What is true of relation—of form and quantity—is often grossly
+      false in regard to morals, for example. In this latter science it
+      is very usually untrue that the aggregated parts are equal to the
+      whole. In chemistry also the axiom fails. In the consideration of
+      motive it fails; for two motives, each of a given value, have
+      not, necessarily, a value when united, equal to the sum of their
+      values apart. There are numerous other mathematical truths which
+      are only truths within the limits of relation. But the
+      mathematician argues, from his finite truths, through habit, as
+      if they were of an absolutely general applicability—as the world
+      indeed imagines them to be. Bryant, in his very learned
+      ‘Mythology,’ mentions an analogous source of error, when he says
+      that ‘although the Pagan fables are not believed, yet we forget
+      ourselves continually, and make inferences from them as existing
+      realities.’ With the algebraists, however, who are Pagans
+      themselves, the ‘Pagan fables’ are believed, and the inferences
+      are made, not so much through lapse of memory, as through an
+      unaccountable addling of the brains. In short, I never yet
+      encountered the mere mathematician who could be trusted out of
+      equal roots, or one who did not clandestinely hold it as a point
+      of his faith that x2+px was absolutely and unconditionally equal
+      to q. Say to one of these gentlemen, by way of experiment, if you
+      please, that you believe occasions may occur where x2+px is not
+      altogether equal to q, and, having made him understand what you
+      mean, get out of his reach as speedily as convenient, for, beyond
+      doubt, he will endeavor to knock you down.
+
+      “I mean to say,” continued Dupin, while I merely laughed at his
+      last observations, “that if the Minister had been no more than a
+      mathematician, the Prefect would have been under no necessity of
+      giving me this check. I know him, however, as both mathematician
+      and poet, and my measures were adapted to his capacity, with
+      reference to the circumstances by which he was surrounded. I knew
+      him as a courtier, too, and as a bold intriguant. Such a man, I
+      considered, could not fail to be aware of the ordinary policial
+      modes of action. He could not have failed to anticipate—and
+      events have proved that he did not fail to anticipate—the
+      waylayings to which he was subjected. He must have foreseen, I
+      reflected, the secret investigations of his premises. His
+      frequent absences from home at night, which were hailed by the
+      Prefect as certain aids to his success, I regarded only as ruses,
+      to afford opportunity for thorough search to the police, and thus
+      the sooner to impress them with the conviction to which G——, in
+      fact, did finally arrive—the conviction that the letter was not
+      upon the premises. I felt, also, that the whole train of thought,
+      which I was at some pains in detailing to you just now,
+      concerning the invariable principle of policial action in
+      searches for articles concealed—I felt that this whole train of
+      thought would necessarily pass through the mind of the Minister.
+      It would imperatively lead him to despise all the ordinary nooks
+      of concealment. He could not, I reflected, be so weak as not to
+      see that the most intricate and remote recess of his hotel would
+      be as open as his commonest closets to the eyes, to the probes,
+      to the gimlets, and to the microscopes of the Prefect. I saw, in
+      fine, that he would be driven, as a matter of course, to
+      simplicity, if not deliberately induced to it as a matter of
+      choice. You will remember, perhaps, how desperately the Prefect
+      laughed when I suggested, upon our first interview, that it was
+      just possible this mystery troubled him so much on account of its
+      being so very self-evident.”
+
+      “Yes,” said I, “I remember his merriment well. I really thought
+      he would have fallen into convulsions.”
+
+      “The material world,” continued Dupin, “abounds with very strict
+      analogies to the immaterial; and thus some color of truth has
+      been given to the rhetorical dogma, that metaphor, or simile, may
+      be made to strengthen an argument, as well as to embellish a
+      description. The principle of the vis inertiæ, for example, seems
+      to be identical in physics and metaphysics. It is not more true
+      in the former, that a large body is with more difficulty set in
+      motion than a smaller one, and that its subsequent momentum is
+      commensurate with this difficulty, than it is, in the latter,
+      that intellects of the vaster capacity, while more forcible, more
+      constant, and more eventful in their movements than those of
+      inferior grade, are yet the less readily moved, and more
+      embarrassed and full of hesitation in the first few steps of
+      their progress. Again: have you ever noticed which of the street
+      signs, over the shop-doors, are the most attractive of
+      attention?”
+
+      “I have never given the matter a thought,” I said.
+
+      “There is a game of puzzles,” he resumed, “which is played upon a
+      map. One party playing requires another to find a given word—the
+      name of town, river, state or empire—any word, in short, upon the
+      motley and perplexed surface of the chart. A novice in the game
+      generally seeks to embarrass his opponents by giving them the
+      most minutely lettered names; but the adept selects such words as
+      stretch, in large characters, from one end of the chart to the
+      other. These, like the over-largely lettered signs and placards
+      of the street, escape observation by dint of being excessively
+      obvious; and here the physical oversight is precisely analogous
+      with the moral inapprehension by which the intellect suffers to
+      pass unnoticed those considerations which are too obtrusively and
+      too palpably self-evident. But this is a point, it appears,
+      somewhat above or beneath the understanding of the Prefect. He
+      never once thought it probable, or possible, that the Minister
+      had deposited the letter immediately beneath the nose of the
+      whole world, by way of best preventing any portion of that world
+      from perceiving it.
+
+      “But the more I reflected upon the daring, dashing, and
+      discriminating ingenuity of D——; upon the fact that the document
+      must always have been at hand, if he intended to use it to good
+      purpose; and upon the decisive evidence, obtained by the Prefect,
+      that it was not hidden within the limits of that dignitary’s
+      ordinary search—the more satisfied I became that, to conceal this
+      letter, the Minister had resorted to the comprehensive and
+      sagacious expedient of not attempting to conceal it at all.
+
+      “Full of these ideas, I prepared myself with a pair of green
+      spectacles, and called one fine morning, quite by accident, at
+      the Ministerial hotel. I found D—— at home, yawning, lounging,
+      and dawdling, as usual, and pretending to be in the last
+      extremity of ennui. He is, perhaps, the most really energetic
+      human being now alive—but that is only when nobody sees him.
+
+      “To be even with him, I complained of my weak eyes, and lamented
+      the necessity of the spectacles, under cover of which I
+      cautiously and thoroughly surveyed the whole apartment, while
+      seemingly intent only upon the conversation of my host.
+
+      “I paid especial attention to a large writing-table near which he
+      sat, and upon which lay confusedly, some miscellaneous letters
+      and other papers, with one or two musical instruments and a few
+      books. Here, however, after a long and very deliberate scrutiny,
+      I saw nothing to excite particular suspicion.
+
+      “At length my eyes, in going the circuit of the room, fell upon a
+      trumpery fillagree card-rack of pasteboard, that hung dangling by
+      a dirty blue ribbon, from a little brass knob just beneath the
+      middle of the mantel-piece. In this rack, which had three or four
+      compartments, were five or six visiting cards and a solitary
+      letter. This last was much soiled and crumpled. It was torn
+      nearly in two, across the middle—as if a design, in the first
+      instance, to tear it entirely up as worthless, had been altered,
+      or stayed, in the second. It had a large black seal, bearing the
+      D—— cipher _very_ conspicuously, and was addressed, in a
+      diminutive female hand, to D——, the minister, himself. It was
+      thrust carelessly, and even, as it seemed, contemptuously, into
+      one of the uppermost divisions of the rack.
+
+      “No sooner had I glanced at this letter, than I concluded it to
+      be that of which I was in search. To be sure, it was, to all
+      appearance, radically different from the one of which the Prefect
+      had read us so minute a description. Here the seal was large and
+      black, with the D—— cipher; there it was small and red, with the
+      ducal arms of the S—— family. Here, the address, to the Minister,
+      diminutive and feminine; there the superscription, to a certain
+      royal personage, was markedly bold and decided; the size alone
+      formed a point of correspondence. But, then, the radicalness of
+      these differences, which was excessive; the dirt; the soiled and
+      torn condition of the paper, so inconsistent with the true
+      methodical habits of D——, and so suggestive of a design to delude
+      the beholder into an idea of the worthlessness of the
+      document—these things, together with the hyper-obtrusive
+      situation of this document, full in the view of every visitor,
+      and thus exactly in accordance with the conclusions to which I
+      had previously arrived; these things, I say, were strongly
+      corroborative of suspicion, in one who came with the intention to
+      suspect.
+
+      “I protracted my visit as long as possible, and, while I
+      maintained a most animated discussion with the Minister upon a
+      topic which I knew well had never failed to interest and excite
+      him, I kept my attention really riveted upon the letter. In this
+      examination, I committed to memory its external appearance and
+      arrangement in the rack; and also fell, at length, upon a
+      discovery which set at rest whatever trivial doubt I might have
+      entertained. In scrutinizing the edges of the paper, I observed
+      them to be more chafed than seemed necessary. They presented the
+      broken appearance which is manifested when a stiff paper, having
+      been once folded and pressed with a folder, is refolded in a
+      reversed direction, in the same creases or edges which had formed
+      the original fold. This discovery was sufficient. It was clear to
+      me that the letter had been turned, as a glove, inside out,
+      re-directed, and re-sealed. I bade the Minister good morning, and
+      took my departure at once, leaving a gold snuff-box upon the
+      table.
+
+      “The next morning I called for the snuff-box, when we resumed,
+      quite eagerly, the conversation of the preceding day. While thus
+      engaged, however, a loud report, as if of a pistol, was heard
+      immediately beneath the windows of the hotel, and was succeeded
+      by a series of fearful screams, and the shoutings of a terrified
+      mob. D—— rushed to a casement, threw it open, and looked out. In
+      the meantime, I stepped to the card-rack, took the letter, put it
+      in my pocket, and replaced it by a fac-simile, (so far as regards
+      externals,) which I had carefully prepared at my
+      lodgings—imitating the D—— cipher, very readily, by means of a
+      seal formed of bread.
+
+      “The disturbance in the street had been occasioned by the frantic
+      behavior of a man with a musket. He had fired it among a crowd of
+      women and children. It proved, however, to have been without
+      ball, and the fellow was suffered to go his way as a lunatic or a
+      drunkard. When he had gone, D—— came from the window, whither I
+      had followed him immediately upon securing the object in view.
+      Soon afterwards I bade him farewell. The pretended lunatic was a
+      man in my own pay.”
+
+      “But what purpose had you,” I asked, “in replacing the letter by
+      a fac-simile? Would it not have been better, at the first visit,
+      to have seized it openly, and departed?”
+
+      “D——,” replied Dupin, “is a desperate man, and a man of nerve.
+      His hotel, too, is not without attendants devoted to his
+      interests. Had I made the wild attempt you suggest, I might never
+      have left the Ministerial presence alive. The good people of
+      Paris might have heard of me no more. But I had an object apart
+      from these considerations. You know my political prepossessions.
+      In this matter, I act as a partisan of the lady concerned. For
+      eighteen months the Minister has had her in his power. She has
+      now him in hers—since, being unaware that the letter is not in
+      his possession, he will proceed with his exactions as if it was.
+      Thus will he inevitably commit himself, at once, to his political
+      destruction. His downfall, too, will not be more precipitate than
+      awkward. It is all very well to talk about the facilis descensus
+      Averni; but in all kinds of climbing, as Catalani said of
+      singing, it is far more easy to get up than to come down. In the
+      present instance I have no sympathy—at least no pity—for him who
+      descends. He is that monstrum horrendum, an unprincipled man of
+      genius. I confess, however, that I should like very well to know
+      the precise character of his thoughts, when, being defied by her
+      whom the Prefect terms ‘a certain personage’ he is reduced to
+      opening the letter which I left for him in the card-rack.”
+
+      “How? did you put any thing particular in it?”
+
+      “Why—it did not seem altogether right to leave the interior
+      blank—that would have been insulting. D——, at Vienna once, did me
+      an evil turn, which I told him, quite good-humoredly, that I
+      should remember. So, as I knew he would feel some curiosity in
+      regard to the identity of the person who had outwitted him, I
+      thought it a pity not to give him a clue. He is well acquainted
+      with my MS., and I just copied into the middle of the blank sheet
+      the words—
+
+      “‘— — Un dessein si funeste,
+      S’il n’est digne d’Atrée, est digne de Thyeste.
+
+      They are to be found in Crébillon’s ‘Atrée.’”
+
+
+
+
+THE THOUSAND-AND-SECOND TALE OF SCHEHERAZADE
+
+
+Truth is stranger than fiction.—_Old Saying_
+
+      Having had occasion, lately, in the course of some Oriental
+      investigations, to consult the Tellmenow Isitsöornot, a work
+      which (like the Zohar of Simeon Jochaides) is scarcely known at
+      all, even in Europe; and which has never been quoted, to my
+      knowledge, by any American—if we except, perhaps, the author of
+      the “Curiosities of American Literature”;—having had occasion, I
+      say, to turn over some pages of the first-mentioned very
+      remarkable work, I was not a little astonished to discover that
+      the literary world has hitherto been strangely in error
+      respecting the fate of the vizier’s daughter, Scheherazade, as
+      that fate is depicted in the “Arabian Nights”; and that the
+      _dénouement_ there given, if not altogether inaccurate, as far as
+      it goes, is at least to blame in not having gone very much
+      farther.
+
+      For full information on this interesting topic, I must refer the
+      inquisitive reader to the “Isitsöornot” itself; but in the
+      meantime, I shall be pardoned for giving a summary of what I
+      there discovered.
+
+      It will be remembered, that, in the usual version of the tales, a
+      certain monarch having good cause to be jealous of his queen, not
+      only puts her to death, but makes a vow, by his beard and the
+      prophet, to espouse each night the most beautiful maiden in his
+      dominions, and the next morning to deliver her up to the
+      executioner.
+
+      Having fulfilled this vow for many years to the letter, and with
+      a religious punctuality and method that conferred great credit
+      upon him as a man of devout feeling and excellent sense, he was
+      interrupted one afternoon (no doubt at his prayers) by a visit
+      from his grand vizier, to whose daughter, it appears, there had
+      occurred an idea.
+
+      Her name was Scheherazade, and her idea was, that she would
+      either redeem the land from the depopulating tax upon its beauty,
+      or perish, after the approved fashion of all heroines, in the
+      attempt.
+
+      Accordingly, and although we do not find it to be leap-year
+      (which makes the sacrifice more meritorious), she deputes her
+      father, the grand vizier, to make an offer to the king of her
+      hand. This hand the king eagerly accepts—(he had intended to take
+      it at all events, and had put off the matter from day to day,
+      only through fear of the vizier),—but, in accepting it now, he
+      gives all parties very distinctly to understand, that, grand
+      vizier or no grand vizier, he has not the slightest design of
+      giving up one iota of his vow or of his privileges. When,
+      therefore, the fair Scheherazade insisted upon marrying the king,
+      and did actually marry him despite her father’s excellent advice
+      not to do any thing of the kind—when she would and did marry him,
+      I say, will I, nill I, it was with her beautiful black eyes as
+      thoroughly open as the nature of the case would allow.
+
+      It seems, however, that this politic damsel (who had been reading
+      Machiavelli, beyond doubt), had a very ingenious little plot in
+      her mind. On the night of the wedding, she contrived, upon I
+      forget what specious pretence, to have her sister occupy a couch
+      sufficiently near that of the royal pair to admit of easy
+      conversation from bed to bed; and, a little before cock-crowing,
+      she took care to awaken the good monarch, her husband (who bore
+      her none the worse will because he intended to wring her neck on
+      the morrow),—she managed to awaken him, I say, (although on
+      account of a capital conscience and an easy digestion, he slept
+      well) by the profound interest of a story (about a rat and a
+      black cat, I think) which she was narrating (all in an undertone,
+      of course) to her sister. When the day broke, it so happened that
+      this history was not altogether finished, and that Scheherazade,
+      in the nature of things could not finish it just then, since it
+      was high time for her to get up and be bowstrung—a thing very
+      little more pleasant than hanging, only a trifle more genteel!
+
+      The king’s curiosity, however, prevailing, I am sorry to say,
+      even over his sound religious principles, induced him for this
+      once to postpone the fulfilment of his vow until next morning,
+      for the purpose and with the hope of hearing that night how it
+      fared in the end with the black cat (a black cat, I think it was)
+      and the rat.
+
+      The night having arrived, however, the lady Scheherazade not only
+      put the finishing stroke to the black cat and the rat (the rat
+      was blue) but before she well knew what she was about, found
+      herself deep in the intricacies of a narration, having reference
+      (if I am not altogether mistaken) to a pink horse (with green
+      wings) that went, in a violent manner, by clockwork, and was
+      wound up with an indigo key. With this history the king was even
+      more profoundly interested than with the other—and, as the day
+      broke before its conclusion (notwithstanding all the queen’s
+      endeavors to get through with it in time for the bowstringing),
+      there was again no resource but to postpone that ceremony as
+      before, for twenty-four hours. The next night there happened a
+      similar accident with a similar result; and then the next—and
+      then again the next; so that, in the end, the good monarch,
+      having been unavoidably deprived of all opportunity to keep his
+      vow during a period of no less than one thousand and one nights,
+      either forgets it altogether by the expiration of this time, or
+      gets himself absolved of it in the regular way, or (what is more
+      probable) breaks it outright, as well as the head of his father
+      confessor. At all events, Scheherazade, who, being lineally
+      descended from Eve, fell heir, perhaps, to the whole seven
+      baskets of talk, which the latter lady, we all know, picked up
+      from under the trees in the garden of Eden; Scheherazade, I say,
+      finally triumphed, and the tariff upon beauty was repealed.
+
+      Now, this conclusion (which is that of the story as we have it
+      upon record) is, no doubt, excessively proper and pleasant—but
+      alas! like a great many pleasant things, is more pleasant than
+      true, and I am indebted altogether to the “Isitsöornot” for the
+      means of correcting the error. “Le mieux,” says a French proverb,
+      “est l’ennemi du bien,” and, in mentioning that Scheherazade had
+      inherited the seven baskets of talk, I should have added that she
+      put them out at compound interest until they amounted to
+      seventy-seven.
+
+      “My dear sister,” said she, on the thousand-and-second night, (I
+      quote the language of the “Isitsöornot” at this point, verbatim)
+      “my dear sister,” said she, “now that all this little difficulty
+      about the bowstring has blown over, and that this odious tax is
+      so happily repealed, I feel that I have been guilty of great
+      indiscretion in withholding from you and the king (who I am sorry
+      to say, snores—a thing no gentleman would do) the full conclusion
+      of Sinbad the sailor. This person went through numerous other and
+      more interesting adventures than those which I related; but the
+      truth is, I felt sleepy on the particular night of their
+      narration, and so was seduced into cutting them short—a grievous
+      piece of misconduct, for which I only trust that Allah will
+      forgive me. But even yet it is not too late to remedy my great
+      neglect—and as soon as I have given the king a pinch or two in
+      order to wake him up so far that he may stop making that horrible
+      noise, I will forthwith entertain you (and him if he pleases)
+      with the sequel of this very remarkable story.”
+
+      Hereupon the sister of Scheherazade, as I have it from the
+      “Isitsöornot,” expressed no very particular intensity of
+      gratification; but the king, having been sufficiently pinched, at
+      length ceased snoring, and finally said, “Hum!” and then “Hoo!”
+      when the queen, understanding these words (which are no doubt
+      Arabic) to signify that he was all attention, and would do his
+      best not to snore any more—the queen, I say, having arranged
+      these matters to her satisfaction, re-entered thus, at once, into
+      the history of Sinbad the sailor:
+
+      “‘At length, in my old age,’ [these are the words of Sinbad
+      himself, as retailed by Scheherazade]—‘at length, in my old age,
+      and after enjoying many years of tranquillity at home, I became
+      once more possessed of a desire of visiting foreign countries;
+      and one day, without acquainting any of my family with my design,
+      I packed up some bundles of such merchandise as was most precious
+      and least bulky, and, engaging a porter to carry them, went with
+      him down to the sea-shore, to await the arrival of any chance
+      vessel that might convey me out of the kingdom into some region
+      which I had not as yet explored.
+
+      “‘Having deposited the packages upon the sands, we sat down
+      beneath some trees, and looked out into the ocean in the hope of
+      perceiving a ship, but during several hours we saw none whatever.
+      At length I fancied that I could hear a singular buzzing or
+      humming sound; and the porter, after listening awhile, declared
+      that he also could distinguish it. Presently it grew louder, and
+      then still louder, so that we could have no doubt that the object
+      which caused it was approaching us. At length, on the edge of the
+      horizon, we discovered a black speck, which rapidly increased in
+      size until we made it out to be a vast monster, swimming with a
+      great part of its body above the surface of the sea. It came
+      toward us with inconceivable swiftness, throwing up huge waves of
+      foam around its breast, and illuminating all that part of the sea
+      through which it passed, with a long line of fire that extended
+      far off into the distance.
+
+      “‘As the thing drew near we saw it very distinctly. Its length
+      was equal to that of three of the loftiest trees that grow, and
+      it was as wide as the great hall of audience in your palace, O
+      most sublime and munificent of the Caliphs. Its body, which was
+      unlike that of ordinary fishes, was as solid as a rock, and of a
+      jetty blackness throughout all that portion of it which floated
+      above the water, with the exception of a narrow blood-red streak
+      that completely begirdled it. The belly, which floated beneath
+      the surface, and of which we could get only a glimpse now and
+      then as the monster rose and fell with the billows, was entirely
+      covered with metallic scales, of a color like that of the moon in
+      misty weather. The back was flat and nearly white, and from it
+      there extended upwards of six spines, about half the length of
+      the whole body.
+
+      “‘This horrible creature had no mouth that we could perceive;
+      but, as if to make up for this deficiency, it was provided with
+      at least four score of eyes, that protruded from their sockets
+      like those of the green dragon-fly, and were arranged all around
+      the body in two rows, one above the other, and parallel to the
+      blood-red streak, which seemed to answer the purpose of an
+      eyebrow. Two or three of these dreadful eyes were much larger
+      than the others, and had the appearance of solid gold.
+
+      “‘Although this beast approached us, as I have before said, with
+      the greatest rapidity, it must have been moved altogether by
+      necromancy—for it had neither fins like a fish nor web-feet like
+      a duck, nor wings like the seashell which is blown along in the
+      manner of a vessel; nor yet did it writhe itself forward as do
+      the eels. Its head and its tail were shaped precisely alike,
+      only, not far from the latter, were two small holes that served
+      for nostrils, and through which the monster puffed out its thick
+      breath with prodigious violence, and with a shrieking,
+      disagreeable noise.
+
+      “‘Our terror at beholding this hideous thing was very great, but
+      it was even surpassed by our astonishment, when upon getting a
+      nearer look, we perceived upon the creature’s back a vast number
+      of animals about the size and shape of men, and altogether much
+      resembling them, except that they wore no garments (as men do),
+      being supplied (by nature, no doubt) with an ugly uncomfortable
+      covering, a good deal like cloth, but fitting so tight to the
+      skin, as to render the poor wretches laughably awkward, and put
+      them apparently to severe pain. On the very tips of their heads
+      were certain square-looking boxes, which, at first sight, I
+      thought might have been intended to answer as turbans, but I soon
+      discovered that they were excessively heavy and solid, and I
+      therefore concluded they were contrivances designed, by their
+      great weight, to keep the heads of the animals steady and safe
+      upon their shoulders. Around the necks of the creatures were
+      fastened black collars, (badges of servitude, no doubt,) such as
+      we keep on our dogs, only much wider and infinitely stiffer, so
+      that it was quite impossible for these poor victims to move their
+      heads in any direction without moving the body at the same time;
+      and thus they were doomed to perpetual contemplation of their
+      noses—a view puggish and snubby in a wonderful, if not positively
+      in an awful degree.
+
+      “‘When the monster had nearly reached the shore where we stood,
+      it suddenly pushed out one of its eyes to a great extent, and
+      emitted from it a terrible flash of fire, accompanied by a dense
+      cloud of smoke, and a noise that I can compare to nothing but
+      thunder. As the smoke cleared away, we saw one of the odd
+      man-animals standing near the head of the large beast with a
+      trumpet in his hand, through which (putting it to his mouth) he
+      presently addressed us in loud, harsh, and disagreeable accents,
+      that, perhaps, we should have mistaken for language, had they not
+      come altogether through the nose.
+
+      “‘Being thus evidently spoken to, I was at a loss how to reply,
+      as I could in no manner understand what was said; and in this
+      difficulty I turned to the porter, who was near swooning through
+      affright, and demanded of him his opinion as to what species of
+      monster it was, what it wanted, and what kind of creatures those
+      were that so swarmed upon its back. To this the porter replied,
+      as well as he could for trepidation, that he had once before
+      heard of this sea-beast; that it was a cruel demon, with bowels
+      of sulphur and blood of fire, created by evil genii as the means
+      of inflicting misery upon mankind; that the things upon its back
+      were vermin, such as sometimes infest cats and dogs, only a
+      little larger and more savage; and that these vermin had their
+      uses, however evil—for, through the torture they caused the beast
+      by their nibbling and stingings, it was goaded into that degree
+      of wrath which was requisite to make it roar and commit ill, and
+      so fulfil the vengeful and malicious designs of the wicked genii.
+
+      “This account determined me to take to my heels, and, without
+      once even looking behind me, I ran at full speed up into the
+      hills, while the porter ran equally fast, although nearly in an
+      opposite direction, so that, by these means, he finally made his
+      escape with my bundles, of which I have no doubt he took
+      excellent care—although this is a point I cannot determine, as I
+      do not remember that I ever beheld him again.
+
+      “‘For myself, I was so hotly pursued by a swarm of the men-vermin
+      (who had come to the shore in boats) that I was very soon
+      overtaken, bound hand and foot, and conveyed to the beast, which
+      immediately swam out again into the middle of the sea.
+
+      “‘I now bitterly repented my folly in quitting a comfortable home
+      to peril my life in such adventures as this; but regret being
+      useless, I made the best of my condition, and exerted myself to
+      secure the goodwill of the man-animal that owned the trumpet, and
+      who appeared to exercise authority over his fellows. I succeeded
+      so well in this endeavor that, in a few days, the creature
+      bestowed upon me various tokens of his favor, and in the end even
+      went to the trouble of teaching me the rudiments of what it was
+      vain enough to denominate its language; so that, at length, I was
+      enabled to converse with it readily, and came to make it
+      comprehend the ardent desire I had of seeing the world.
+
+      “‘Washish squashish squeak, Sinbad, hey-diddle diddle, grunt unt
+      grumble, hiss, fiss, whiss,’ said he to me, one day after
+      dinner—but I beg a thousand pardons, I had forgotten that your
+      majesty is not conversant with the dialect of the Cock-neighs (so
+      the man-animals were called; I presume because their language
+      formed the connecting link between that of the horse and that of
+      the rooster). With your permission, I will translate. ‘Washish
+      squashish,’ and so forth:—that is to say, ‘I am happy to find, my
+      dear Sinbad, that you are really a very excellent fellow; we are
+      now about doing a thing which is called circumnavigating the
+      globe; and since you are so desirous of seeing the world, I will
+      strain a point and give you a free passage upon back of the
+      beast.’”
+
+      When the Lady Scheherazade had proceeded thus far, relates the
+      “Isitsöornot,” the king turned over from his left side to his
+      right, and said:
+
+      “It is, in fact, very surprising, my dear queen, that you
+      omitted, hitherto, these latter adventures of Sinbad. Do you know
+      I think them exceedingly entertaining and strange?”
+
+      The king having thus expressed himself, we are told, the fair
+      Scheherazade resumed her history in the following words:
+
+      “Sinbad went on in this manner with his narrative—‘I thanked the
+      man-animal for its kindness, and soon found myself very much at
+      home on the beast, which swam at a prodigious rate through the
+      ocean; although the surface of the latter is, in that part of the
+      world, by no means flat, but round like a pomegranate, so that we
+      went—so to say—either up hill or down hill all the time.’
+
+      “That I think, was very singular,” interrupted the king.
+
+      “Nevertheless, it is quite true,” replied Scheherazade.
+
+      “I have my doubts,” rejoined the king; “but, pray, be so good as
+      to go on with the story.”
+
+      “I will,” said the queen. “‘The beast,’ continued Sinbad to the
+      caliph, ‘swam, as I have related, up hill and down hill until, at
+      length, we arrived at an island, many hundreds of miles in
+      circumference, but which, nevertheless, had been built in the
+      middle of the sea by a colony of little things like
+      caterpillars.’” (*1)
+
+      “Hum!” said the king.
+
+      “‘Leaving this island,’ said Sinbad—(for Scheherazade, it must be
+      understood, took no notice of her husband’s ill-mannered
+      ejaculation) ‘leaving this island, we came to another where the
+      forests were of solid stone, and so hard that they shivered to
+      pieces the finest-tempered axes with which we endeavoured to cut
+      them down.’” (*2)
+
+      “Hum!” said the king, again; but Scheherazade, paying him no
+      attention, continued in the language of Sinbad.
+
+      “‘Passing beyond this last island, we reached a country where
+      there was a cave that ran to the distance of thirty or forty
+      miles within the bowels of the earth, and that contained a
+      greater number of far more spacious and more magnificent palaces
+      than are to be found in all Damascus and Bagdad. From the roofs
+      of these palaces there hung myriads of gems, like diamonds, but
+      larger than men; and in among the streets of towers and pyramids
+      and temples, there flowed immense rivers as black as ebony, and
+      swarming with fish that had no eyes.’” (*3)
+
+      “Hum!” said the king.
+
+      “‘We then swam into a region of the sea where we found a lofty
+      mountain, down whose sides there streamed torrents of melted
+      metal, some of which were twelve miles wide and sixty miles long
+      (*4); while from an abyss on the summit, issued so vast a
+      quantity of ashes that the sun was entirely blotted out from the
+      heavens, and it became darker than the darkest midnight; so that
+      when we were even at the distance of a hundred and fifty miles
+      from the mountain, it was impossible to see the whitest object,
+      however close we held it to our eyes.’” (*5)
+
+      “Hum!” said the king.
+
+      “‘After quitting this coast, the beast continued his voyage until
+      we met with a land in which the nature of things seemed
+      reversed—for we here saw a great lake, at the bottom of which,
+      more than a hundred feet beneath the surface of the water, there
+      flourished in full leaf a forest of tall and luxuriant trees.’”
+      (*6)
+
+      “Hoo!” said the king.
+
+      “Some hundred miles farther on brought us to a climate where the
+      atmosphere was so dense as to sustain iron or steel, just as our
+      own does feather.’” (*7)
+
+      “Fiddle de dee,” said the king.
+
+      “Proceeding still in the same direction, we presently arrived at
+      the most magnificent region in the whole world. Through it there
+      meandered a glorious river for several thousands of miles. This
+      river was of unspeakable depth, and of a transparency richer than
+      that of amber. It was from three to six miles in width; and its
+      banks which arose on either side to twelve hundred feet in
+      perpendicular height, were crowned with ever-blossoming trees and
+      perpetual sweet-scented flowers, that made the whole territory
+      one gorgeous garden; but the name of this luxuriant land was the
+      Kingdom of Horror, and to enter it was inevitable death.’” (*8)
+
+      “Humph!” said the king.
+
+      “‘We left this kingdom in great haste, and, after some days, came
+      to another, where we were astonished to perceive myriads of
+      monstrous animals with horns resembling scythes upon their heads.
+      These hideous beasts dig for themselves vast caverns in the soil,
+      of a funnel shape, and line the sides of them with rocks, so
+      disposed one upon the other that they fall instantly, when
+      trodden upon by other animals, thus precipitating them into the
+      monster’s dens, where their blood is immediately sucked, and
+      their carcasses afterwards hurled contemptuously out to an
+      immense distance from “the caverns of death."’” (*9)
+
+      “Pooh!” said the king.
+
+      “‘Continuing our progress, we perceived a district with
+      vegetables that grew not upon any soil but in the air. (*10)
+      There were others that sprang from the substance of other
+      vegetables; (*11) others that derived their substance from the
+      bodies of living animals; (*12) and then again, there were others
+      that glowed all over with intense fire; (*13) others that moved
+      from place to place at pleasure, (*14) and what was still more
+      wonderful, we discovered flowers that lived and breathed and
+      moved their limbs at will and had, moreover, the detestable
+      passion of mankind for enslaving other creatures, and confining
+      them in horrid and solitary prisons until the fulfillment of
+      appointed tasks.’” (*15)
+
+      “Pshaw!” said the king.
+
+      “‘Quitting this land, we soon arrived at another in which the
+      bees and the birds are mathematicians of such genius and
+      erudition, that they give daily instructions in the science of
+      geometry to the wise men of the empire. The king of the place
+      having offered a reward for the solution of two very difficult
+      problems, they were solved upon the spot—the one by the bees, and
+      the other by the birds; but the king keeping their solution a
+      secret, it was only after the most profound researches and labor,
+      and the writing of an infinity of big books, during a long series
+      of years, that the men-mathematicians at length arrived at the
+      identical solutions which had been given upon the spot by the
+      bees and by the birds.’” (*16)
+
+      “Oh my!” said the king.
+
+      “‘We had scarcely lost sight of this empire when we found
+      ourselves close upon another, from whose shores there flew over
+      our heads a flock of fowls a mile in breadth, and two hundred and
+      forty miles long; so that, although they flew a mile during every
+      minute, it required no less than four hours for the whole flock
+      to pass over us—in which there were several millions of millions
+      of fowl.’” (*17)
+
+      “Oh fy!” said the king.
+
+      “‘No sooner had we got rid of these birds, which occasioned us
+      great annoyance, than we were terrified by the appearance of a
+      fowl of another kind, and infinitely larger than even the rocs
+      which I met in my former voyages; for it was bigger than the
+      biggest of the domes on your seraglio, oh, most Munificent of
+      Caliphs. This terrible fowl had no head that we could perceive,
+      but was fashioned entirely of belly, which was of a prodigious
+      fatness and roundness, of a soft-looking substance, smooth,
+      shining and striped with various colors. In its talons, the
+      monster was bearing away to his eyrie in the heavens, a house
+      from which it had knocked off the roof, and in the interior of
+      which we distinctly saw human beings, who, beyond doubt, were in
+      a state of frightful despair at the horrible fate which awaited
+      them. We shouted with all our might, in the hope of frightening
+      the bird into letting go of its prey, but it merely gave a snort
+      or puff, as if of rage and then let fall upon our heads a heavy
+      sack which proved to be filled with sand!’”
+
+      “Stuff!” said the king.
+
+      “‘It was just after this adventure that we encountered a
+      continent of immense extent and prodigious solidity, but which,
+      nevertheless, was supported entirely upon the back of a sky-blue
+      cow that had no fewer than four hundred horns.’” (*18)
+
+      “That, now, I believe,” said the king, “because I have read
+      something of the kind before, in a book.”
+
+      “‘We passed immediately beneath this continent, (swimming in
+      between the legs of the cow), and, after some hours, found
+      ourselves in a wonderful country indeed, which, I was informed by
+      the man-animal, was his own native land, inhabited by things of
+      his own species. This elevated the man-animal very much in my
+      esteem, and in fact, I now began to feel ashamed of the
+      contemptuous familiarity with which I had treated him; for I
+      found that the man-animals in general were a nation of the most
+      powerful magicians, who lived with worms in their brain, (*19)
+      which, no doubt, served to stimulate them by their painful
+      writhings and wrigglings to the most miraculous efforts of
+      imagination!’”
+
+      “Nonsense!” said the king.
+
+      “‘Among the magicians, were domesticated several animals of very
+      singular kinds; for example, there was a huge horse whose bones
+      were iron and whose blood was boiling water. In place of corn, he
+      had black stones for his usual food; and yet, in spite of so hard
+      a diet, he was so strong and swift that he would drag a load more
+      weighty than the grandest temple in this city, at a rate
+      surpassing that of the flight of most birds.’” (*20)
+
+      “Twattle!” said the king.
+
+      “‘I saw, also, among these people a hen without feathers, but
+      bigger than a camel; instead of flesh and bone she had iron and
+      brick; her blood, like that of the horse, (to whom, in fact, she
+      was nearly related,) was boiling water; and like him she ate
+      nothing but wood or black stones. This hen brought forth very
+      frequently, a hundred chickens in the day; and, after birth, they
+      took up their residence for several weeks within the stomach of
+      their mother.’” (*21)
+
+      “Fal lal!” said the king.
+
+      “‘One of this nation of mighty conjurors created a man out of
+      brass and wood, and leather, and endowed him with such ingenuity
+      that he would have beaten at chess, all the race of mankind with
+      the exception of the great Caliph, Haroun Alraschid. (*22)
+      Another of these magi constructed (of like material) a creature
+      that put to shame even the genius of him who made it; for so
+      great were its reasoning powers that, in a second, it performed
+      calculations of so vast an extent that they would have required
+      the united labor of fifty thousand fleshy men for a year. (*23)
+      But a still more wonderful conjuror fashioned for himself a
+      mighty thing that was neither man nor beast, but which had brains
+      of lead, intermixed with a black matter like pitch, and fingers
+      that it employed with such incredible speed and dexterity that it
+      would have had no trouble in writing out twenty thousand copies
+      of the Koran in an hour, and this with so exquisite a precision,
+      that in all the copies there should not be found one to vary from
+      another by the breadth of the finest hair. This thing was of
+      prodigious strength, so that it erected or overthrew the
+      mightiest empires at a breath; but its powers were exercised
+      equally for evil and for good.’”
+
+      “Ridiculous!” said the king.
+
+      “‘Among this nation of necromancers there was also one who had in
+      his veins the blood of the salamanders; for he made no scruple of
+      sitting down to smoke his chibouc in a red-hot oven until his
+      dinner was thoroughly roasted upon its floor. (*24) Another had
+      the faculty of converting the common metals into gold, without
+      even looking at them during the process. (*25) Another had such a
+      delicacy of touch that he made a wire so fine as to be invisible.
+      (*26) Another had such quickness of perception that he counted
+      all the separate motions of an elastic body, while it was
+      springing backward and forward at the rate of nine hundred
+      millions of times in a second.’” (*27)
+
+      “Absurd!” said the king.
+
+      “‘Another of these magicians, by means of a fluid that nobody
+      ever yet saw, could make the corpses of his friends brandish
+      their arms, kick out their legs, fight, or even get up and dance
+      at his will. (*28) Another had cultivated his voice to so great
+      an extent that he could have made himself heard from one end of
+      the world to the other. (*29) Another had so long an arm that he
+      could sit down in Damascus and indite a letter at Bagdad—or
+      indeed at any distance whatsoever. (*30) Another commanded the
+      lightning to come down to him out of the heavens, and it came at
+      his call; and served him for a plaything when it came. Another
+      took two loud sounds and out of them made a silence. Another
+      constructed a deep darkness out of two brilliant lights. (*31)
+      Another made ice in a red-hot furnace. (*32) Another directed the
+      sun to paint his portrait, and the sun did. (*33) Another took
+      this luminary with the moon and the planets, and having first
+      weighed them with scrupulous accuracy, probed into their depths
+      and found out the solidity of the substance of which they were
+      made. But the whole nation is, indeed, of so surprising a
+      necromantic ability, that not even their infants, nor their
+      commonest cats and dogs have any difficulty in seeing objects
+      that do not exist at all, or that for twenty millions of years
+      before the birth of the nation itself had been blotted out from
+      the face of creation.’” (*34)
+
+      “Preposterous!” said the king.
+
+      “‘The wives and daughters of these incomparably great and wise
+      magi,’” continued Scheherazade, without being in any manner
+      disturbed by these frequent and most ungentlemanly interruptions
+      on the part of her husband—“‘the wives and daughters of these
+      eminent conjurers are every thing that is accomplished and
+      refined; and would be every thing that is interesting and
+      beautiful, but for an unhappy fatality that besets them, and from
+      which not even the miraculous powers of their husbands and
+      fathers has, hitherto, been adequate to save. Some fatalities
+      come in certain shapes, and some in others—but this of which I
+      speak has come in the shape of a crotchet.’”
+
+      “A what?” said the king.
+
+      “‘A crotchet’” said Scheherazade. “‘One of the evil genii, who
+      are perpetually upon the watch to inflict ill, has put it into
+      the heads of these accomplished ladies that the thing which we
+      describe as personal beauty consists altogether in the
+      protuberance of the region which lies not very far below the
+      small of the back. Perfection of loveliness, they say, is in the
+      direct ratio of the extent of this lump. Having been long
+      possessed of this idea, and bolsters being cheap in that country,
+      the days have long gone by since it was possible to distinguish a
+      woman from a dromedary—’”
+
+      “Stop!” said the king—“I can’t stand that, and I won’t. You have
+      already given me a dreadful headache with your lies. The day,
+      too, I perceive, is beginning to break. How long have we been
+      married?—my conscience is getting to be troublesome again. And
+      then that dromedary touch—do you take me for a fool? Upon the
+      whole, you might as well get up and be throttled.”
+
+      These words, as I learn from the “Isitsöornot,” both grieved and
+      astonished Scheherazade; but, as she knew the king to be a man of
+      scrupulous integrity, and quite unlikely to forfeit his word, she
+      submitted to her fate with a good grace. She derived, however,
+      great consolation, (during the tightening of the bowstring,) from
+      the reflection that much of the history remained still untold,
+      and that the petulance of her brute of a husband had reaped for
+      him a most righteous reward, in depriving him of many
+      inconceivable adventures.
+
+
+
+
+A DESCENT INTO THE MAELSTROM.
+
+
+  The ways of God in Nature, as in Providence, are not as our ways; 
+  nor are the models that we frame any way commensurate to the
+  vastness, profundity, and unsearchableness of His works, _which have
+  a depth in them greater than the well of Democritus_.
+
+—_Joseph Glanville_.
+
+      We had now reached the summit of the loftiest crag. For some
+      minutes the old man seemed too much exhausted to speak.
+
+      “Not long ago,” said he at length, “and I could have guided you
+      on this route as well as the youngest of my sons; but, about
+      three years past, there happened to me an event such as never
+      happened to mortal man—or at least such as no man ever survived
+      to tell of—and the six hours of deadly terror which I then
+      endured have broken me up body and soul. You suppose me a _very_
+      old man—but I am not. It took less than a single day to change
+      these hairs from a jetty black to white, to weaken my limbs, and
+      to unstring my nerves, so that I tremble at the least exertion,
+      and am frightened at a shadow. Do you know I can scarcely look
+      over this little cliff without getting giddy?”
+
+      The “little cliff,” upon whose edge he had so carelessly thrown
+      himself down to rest that the weightier portion of his body hung
+      over it, while he was only kept from falling by the tenure of his
+      elbow on its extreme and slippery edge—this “little cliff” arose,
+      a sheer unobstructed precipice of black shining rock, some
+      fifteen or sixteen hundred feet from the world of crags beneath
+      us. Nothing would have tempted me to within half a dozen yards of
+      its brink. In truth so deeply was I excited by the perilous
+      position of my companion, that I fell at full length upon the
+      ground, clung to the shrubs around me, and dared not even glance
+      upward at the sky—while I struggled in vain to divest myself of
+      the idea that the very foundations of the mountain were in danger
+      from the fury of the winds. It was long before I could reason
+      myself into sufficient courage to sit up and look out into the
+      distance.
+
+      “You must get over these fancies,” said the guide, “for I have
+      brought you here that you might have the best possible view of
+      the scene of that event I mentioned—and to tell you the whole
+      story with the spot just under your eye.”
+
+      “We are now,” he continued, in that particularizing manner which
+      distinguished him—“we are now close upon the Norwegian coast—in
+      the sixty-eighth degree of latitude—in the great province of
+      Nordland—and in the dreary district of Lofoden. The mountain upon
+      whose top we sit is Helseggen, the Cloudy. Now raise yourself up
+      a little higher—hold on to the grass if you feel giddy—so—and
+      look out, beyond the belt of vapor beneath us, into the sea.”
+
+      I looked dizzily, and beheld a wide expanse of ocean, whose
+      waters wore so inky a hue as to bring at once to my mind the
+      Nubian geographer’s account of the _Mare Tenebrarum_. A panorama
+      more deplorably desolate no human imagination can conceive. To
+      the right and left, as far as the eye could reach, there lay
+      outstretched, like ramparts of the world, lines of horridly black
+      and beetling cliff, whose character of gloom was but the more
+      forcibly illustrated by the surf which reared high up against its
+      white and ghastly crest, howling and shrieking forever. Just
+      opposite the promontory upon whose apex we were placed, and at a
+      distance of some five or six miles out at sea, there was visible
+      a small, bleak-looking island; or, more properly, its position
+      was discernible through the wilderness of surge in which it was
+      enveloped. About two miles nearer the land, arose another of
+      smaller size, hideously craggy and barren, and encompassed at
+      various intervals by a cluster of dark rocks.
+
+      The appearance of the ocean, in the space between the more
+      distant island and the shore, had something very unusual about
+      it. Although, at the time, so strong a gale was blowing landward
+      that a brig in the remote offing lay to under a double-reefed
+      trysail, and constantly plunged her whole hull out of sight,
+      still there was here nothing like a regular swell, but only a
+      short, quick, angry cross dashing of water in every direction—as
+      well in the teeth of the wind as otherwise. Of foam there was
+      little except in the immediate vicinity of the rocks.
+
+      “The island in the distance,” resumed the old man, “is called by
+      the Norwegians Vurrgh. The one midway is Moskoe. That a mile to
+      the northward is Ambaaren. Yonder are Islesen, Hotholm,
+      Keildhelm, Suarven, and Buckholm. Farther off—between Moskoe and
+      Vurrgh—are Otterholm, Flimen, Sandflesen, and Stockholm. These
+      are the true names of the places—but why it has been thought
+      necessary to name them at all, is more than either you or I can
+      understand. Do you hear anything? Do you see any change in the
+      water?”
+
+      We had now been about ten minutes upon the top of Helseggen, to
+      which we had ascended from the interior of Lofoden, so that we
+      had caught no glimpse of the sea until it had burst upon us from
+      the summit. As the old man spoke, I became aware of a loud and
+      gradually increasing sound, like the moaning of a vast herd of
+      buffaloes upon an American prairie; and at the same moment I
+      perceived that what seamen term the _chopping_ character of the
+      ocean beneath us, was rapidly changing into a current which set
+      to the eastward. Even while I gazed, this current acquired a
+      monstrous velocity. Each moment added to its speed—to its
+      headlong impetuosity. In five minutes the whole sea, as far as
+      Vurrgh, was lashed into ungovernable fury; but it was between
+      Moskoe and the coast that the main uproar held its sway. Here the
+      vast bed of the waters, seamed and scarred into a thousand
+      conflicting channels, burst suddenly into phrensied
+      convulsion—heaving, boiling, hissing—gyrating in gigantic and
+      innumerable vortices, and all whirling and plunging on to the
+      eastward with a rapidity which water never elsewhere assumes
+      except in precipitous descents.
+
+      In a few minutes more, there came over the scene another radical
+      alteration. The general surface grew somewhat more smooth, and
+      the whirlpools, one by one, disappeared, while prodigious streaks
+      of foam became apparent where none had been seen before. These
+      streaks, at length, spreading out to a great distance, and
+      entering into combination, took unto themselves the gyratory
+      motion of the subsided vortices, and seemed to form the germ of
+      another more vast. Suddenly—very suddenly—this assumed a distinct
+      and definite existence, in a circle of more than a mile in
+      diameter. The edge of the whirl was represented by a broad belt
+      of gleaming spray; but no particle of this slipped into the mouth
+      of the terrific funnel, whose interior, as far as the eye could
+      fathom it, was a smooth, shining, and jet-black wall of water,
+      inclined to the horizon at an angle of some forty-five degrees,
+      speeding dizzily round and round with a swaying and sweltering
+      motion, and sending forth to the winds an appalling voice, half
+      shriek, half roar, such as not even the mighty cataract of
+      Niagara ever lifts up in its agony to Heaven.
+
+      The mountain trembled to its very base, and the rock rocked. I
+      threw myself upon my face, and clung to the scant herbage in an
+      excess of nervous agitation.
+
+      “This,” said I at length, to the old man—“this _can_ be nothing
+      else than the great whirlpool of the Maelström.”
+
+      “So it is sometimes termed,” said he. “We Norwegians call it the
+      Moskoe-ström, from the island of Moskoe in the midway.”
+
+      The ordinary accounts of this vortex had by no means prepared me
+      for what I saw. That of Jonas Ramus, which is perhaps the most
+      circumstantial of any, cannot impart the faintest conception
+      either of the magnificence, or of the horror of the scene—or of
+      the wild bewildering sense of _the novel_ which confounds the
+      beholder. I am not sure from what point of view the writer in
+      question surveyed it, nor at what time; but it could neither have
+      been from the summit of Helseggen, nor during a storm. There are
+      some passages of his description, nevertheless, which may be
+      quoted for their details, although their effect is exceedingly
+      feeble in conveying an impression of the spectacle.
+
+      “Between Lofoden and Moskoe,” he says, “the depth of the water is
+      between thirty-six and forty fathoms; but on the other side,
+      toward Ver (Vurrgh) this depth decreases so as not to afford a
+      convenient passage for a vessel, without the risk of splitting on
+      the rocks, which happens even in the calmest weather. When it is
+      flood, the stream runs up the country between Lofoden and Moskoe
+      with a boisterous rapidity; but the roar of its impetuous ebb to
+      the sea is scarce equalled by the loudest and most dreadful
+      cataracts; the noise being heard several leagues off, and the
+      vortices or pits are of such an extent and depth, that if a ship
+      comes within its attraction, it is inevitably absorbed and
+      carried down to the bottom, and there beat to pieces against the
+      rocks; and when the water relaxes, the fragments thereof are
+      thrown up again. But these intervals of tranquility are only at
+      the turn of the ebb and flood, and in calm weather, and last but
+      a quarter of an hour, its violence gradually returning. When the
+      stream is most boisterous, and its fury heightened by a storm, it
+      is dangerous to come within a Norway mile of it. Boats, yachts,
+      and ships have been carried away by not guarding against it
+      before they were within its reach. It likewise happens
+      frequently, that whales come too near the stream, and are
+      overpowered by its violence; and then it is impossible to
+      describe their howlings and bellowings in their fruitless
+      struggles to disengage themselves. A bear once, attempting to
+      swim from Lofoden to Moskoe, was caught by the stream and borne
+      down, while he roared terribly, so as to be heard on shore. Large
+      stocks of firs and pine trees, after being absorbed by the
+      current, rise again broken and torn to such a degree as if
+      bristles grew upon them. This plainly shows the bottom to consist
+      of craggy rocks, among which they are whirled to and fro. This
+      stream is regulated by the flux and reflux of the sea—it being
+      constantly high and low water every six hours. In the year 1645,
+      early in the morning of Sexagesima Sunday, it raged with such
+      noise and impetuosity that the very stones of the houses on the
+      coast fell to the ground.”
+
+      In regard to the depth of the water, I could not see how this
+      could have been ascertained at all in the immediate vicinity of
+      the vortex. The “forty fathoms” must have reference only to
+      portions of the channel close upon the shore either of Moskoe or
+      Lofoden. The depth in the centre of the Moskoe-ström must be
+      immeasurably greater; and no better proof of this fact is
+      necessary than can be obtained from even the sidelong glance into
+      the abyss of the whirl which may be had from the highest crag of
+      Helseggen. Looking down from this pinnacle upon the howling
+      Phlegethon below, I could not help smiling at the simplicity with
+      which the honest Jonas Ramus records, as a matter difficult of
+      belief, the anecdotes of the whales and the bears; for it
+      appeared to me, in fact, a self-evident thing, that the largest
+      ship of the line in existence, coming within the influence of
+      that deadly attraction, could resist it as little as a feather
+      the hurricane, and must disappear bodily and at once.
+
+      The attempts to account for the phenomenon—some of which, I
+      remember, seemed to me sufficiently plausible in perusal—now wore
+      a very different and unsatisfactory aspect. The idea generally
+      received is that this, as well as three smaller vortices among
+      the Ferroe islands, “have no other cause than the collision of
+      waves rising and falling, at flux and reflux, against a ridge of
+      rocks and shelves, which confines the water so that it
+      precipitates itself like a cataract; and thus the higher the
+      flood rises, the deeper must the fall be, and the natural result
+      of all is a whirlpool or vortex, the prodigious suction of which
+      is sufficiently known by lesser experiments.”—These are the words
+      of the Encyclopædia Britannica. Kircher and others imagine that
+      in the centre of the channel of the Maelström is an abyss
+      penetrating the globe, and issuing in some very remote part—the
+      Gulf of Bothnia being somewhat decidedly named in one instance.
+      This opinion, idle in itself, was the one to which, as I gazed,
+      my imagination most readily assented; and, mentioning it to the
+      guide, I was rather surprised to hear him say that, although it
+      was the view almost universally entertained of the subject by the
+      Norwegians, it nevertheless was not his own. As to the former
+      notion he confessed his inability to comprehend it; and here I
+      agreed with him—for, however conclusive on paper, it becomes
+      altogether unintelligible, and even absurd, amid the thunder of
+      the abyss.
+
+      “You have had a good look at the whirl now,” said the old man,
+      “and if you will creep round this crag, so as to get in its lee,
+      and deaden the roar of the water, I will tell you a story that
+      will convince you I ought to know something of the Moskoe-ström.”
+
+      I placed myself as desired, and he proceeded.
+
+      “Myself and my two brothers once owned a schooner-rigged smack of
+      about seventy tons burthen, with which we were in the habit of
+      fishing among the islands beyond Moskoe, nearly to Vurrgh. In all
+      violent eddies at sea there is good fishing, at proper
+      opportunities, if one has only the courage to attempt it; but
+      among the whole of the Lofoden coastmen, we three were the only
+      ones who made a regular business of going out to the islands, as
+      I tell you. The usual grounds are a great way lower down to the
+      southward. There fish can be got at all hours, without much risk,
+      and therefore these places are preferred. The choice spots over
+      here among the rocks, however, not only yield the finest variety,
+      but in far greater abundance; so that we often got in a single
+      day, what the more timid of the craft could not scrape together
+      in a week. In fact, we made it a matter of desperate
+      speculation—the risk of life standing instead of labor, and
+      courage answering for capital.
+
+      “We kept the smack in a cove about five miles higher up the coast
+      than this; and it was our practice, in fine weather, to take
+      advantage of the fifteen minutes’ slack to push across the main
+      channel of the Moskoe-ström, far above the pool, and then drop
+      down upon anchorage somewhere near Otterholm, or Sandflesen,
+      where the eddies are not so violent as elsewhere. Here we used to
+      remain until nearly time for slack-water again, when we weighed
+      and made for home. We never set out upon this expedition without
+      a steady side wind for going and coming—one that we felt sure
+      would not fail us before our return—and we seldom made a
+      mis-calculation upon this point. Twice, during six years, we were
+      forced to stay all night at anchor on account of a dead calm,
+      which is a rare thing indeed just about here; and once we had to
+      remain on the grounds nearly a week, starving to death, owing to
+      a gale which blew up shortly after our arrival, and made the
+      channel too boisterous to be thought of. Upon this occasion we
+      should have been driven out to sea in spite of everything, (for
+      the whirlpools threw us round and round so violently, that, at
+      length, we fouled our anchor and dragged it) if it had not been
+      that we drifted into one of the innumerable cross currents—here
+      to-day and gone to-morrow—which drove us under the lee of Flimen,
+      where, by good luck, we brought up.
+
+      “I could not tell you the twentieth part of the difficulties we
+      encountered ‘on the grounds’—it is a bad spot to be in, even in
+      good weather—but we made shift always to run the gauntlet of the
+      Moskoe-ström itself without accident; although at times my heart
+      has been in my mouth when we happened to be a minute or so behind
+      or before the slack. The wind sometimes was not as strong as we
+      thought it at starting, and then we made rather less way than we
+      could wish, while the current rendered the smack unmanageable. My
+      eldest brother had a son eighteen years old, and I had two stout
+      boys of my own. These would have been of great assistance at such
+      times, in using the sweeps, as well as afterward in fishing—but,
+      somehow, although we ran the risk ourselves, we had not the heart
+      to let the young ones get into the danger—for, after all is said
+      and done, it _was_ a horrible danger, and that is the truth.
+
+      “It is now within a few days of three years since what I am going
+      to tell you occurred. It was on the tenth day of July, 18—, a day
+      which the people of this part of the world will never forget—for
+      it was one in which blew the most terrible hurricane that ever
+      came out of the heavens. And yet all the morning, and indeed
+      until late in the afternoon, there was a gentle and steady breeze
+      from the south-west, while the sun shone brightly, so that the
+      oldest seaman among us could not have foreseen what was to
+      follow.
+
+      “The three of us—my two brothers and myself—had crossed over to
+      the islands about two o’clock P. M., and had soon nearly loaded
+      the smack with fine fish, which, we all remarked, were more
+      plenty that day than we had ever known them. It was just seven,
+      _by my watch_, when we weighed and started for home, so as to
+      make the worst of the Ström at slack water, which we knew would
+      be at eight.
+
+      “We set out with a fresh wind on our starboard quarter, and for
+      some time spanked along at a great rate, never dreaming of
+      danger, for indeed we saw not the slightest reason to apprehend
+      it. All at once we were taken aback by a breeze from over
+      Helseggen. This was most unusual—something that had never
+      happened to us before—and I began to feel a little uneasy,
+      without exactly knowing why. We put the boat on the wind, but
+      could make no headway at all for the eddies, and I was upon the
+      point of proposing to return to the anchorage, when, looking
+      astern, we saw the whole horizon covered with a singular
+      copper-colored cloud that rose with the most amazing velocity.
+
+      “In the meantime the breeze that had headed us off fell away, and
+      we were dead becalmed, drifting about in every direction. This
+      state of things, however, did not last long enough to give us
+      time to think about it. In less than a minute the storm was upon
+      us—in less than two the sky was entirely overcast—and what with
+      this and the driving spray, it became suddenly so dark that we
+      could not see each other in the smack.
+
+      “Such a hurricane as then blew it is folly to attempt describing.
+      The oldest seaman in Norway never experienced any thing like it.
+      We had let our sails go by the run before it cleverly took us;
+      but, at the first puff, both our masts went by the board as if
+      they had been sawed off—the mainmast taking with it my youngest
+      brother, who had lashed himself to it for safety.
+
+      “Our boat was the lightest feather of a thing that ever sat upon
+      water. It had a complete flush deck, with only a small hatch near
+      the bow, and this hatch it had always been our custom to batten
+      down when about to cross the Ström, by way of precaution against
+      the chopping seas. But for this circumstance we should have
+      foundered at once—for we lay entirely buried for some moments.
+      How my elder brother escaped destruction I cannot say, for I
+      never had an opportunity of ascertaining. For my part, as soon as
+      I had let the foresail run, I threw myself flat on deck, with my
+      feet against the narrow gunwale of the bow, and with my hands
+      grasping a ring-bolt near the foot of the fore-mast. It was mere
+      instinct that prompted me to do this—which was undoubtedly the
+      very best thing I could have done—for I was too much flurried to
+      think.
+
+      “For some moments we were completely deluged, as I say, and all
+      this time I held my breath, and clung to the bolt. When I could
+      stand it no longer I raised myself upon my knees, still keeping
+      hold with my hands, and thus got my head clear. Presently our
+      little boat gave herself a shake, just as a dog does in coming
+      out of the water, and thus rid herself, in some measure, of the
+      seas. I was now trying to get the better of the stupor that had
+      come over me, and to collect my senses so as to see what was to
+      be done, when I felt somebody grasp my arm. It was my elder
+      brother, and my heart leaped for joy, for I had made sure that he
+      was overboard—but the next moment all this joy was turned into
+      horror—for he put his mouth close to my ear, and screamed out the
+      word ‘_Moskoe-ström!_’
+
+      “No one ever will know what my feelings were at that moment. I
+      shook from head to foot as if I had had the most violent fit of
+      the ague. I knew what he meant by that one word well enough—I
+      knew what he wished to make me understand. With the wind that now
+      drove us on, we were bound for the whirl of the Ström, and
+      nothing could save us!
+
+      “You perceive that in crossing the Ström _channel_, we always
+      went a long way up above the whirl, even in the calmest weather,
+      and then had to wait and watch carefully for the slack—but now we
+      were driving right upon the pool itself, and in such a hurricane
+      as this! ‘To be sure,’ I thought, ‘we shall get there just about
+      the slack—there is some little hope in that’—but in the next
+      moment I cursed myself for being so great a fool as to dream of
+      hope at all. I knew very well that we were doomed, had we been
+      ten times a ninety-gun ship.
+
+      “By this time the first fury of the tempest had spent itself, or
+      perhaps we did not feel it so much, as we scudded before it, but
+      at all events the seas, which at first had been kept down by the
+      wind, and lay flat and frothing, now got up into absolute
+      mountains. A singular change, too, had come over the heavens.
+      Around in every direction it was still as black as pitch, but
+      nearly overhead there burst out, all at once, a circular rift of
+      clear sky—as clear as I ever saw—and of a deep bright blue—and
+      through it there blazed forth the full moon with a lustre that I
+      never before knew her to wear. She lit up every thing about us
+      with the greatest distinctness—but, oh God, what a scene it was
+      to light up!
+
+      “I now made one or two attempts to speak to my brother—but, in
+      some manner which I could not understand, the din had so
+      increased that I could not make him hear a single word, although
+      I screamed at the top of my voice in his ear. Presently he shook
+      his head, looking as pale as death, and held up one of his
+      fingers, as if to say _‘listen! ‘_
+
+      “At first I could not make out what he meant—but soon a hideous
+      thought flashed upon me. I dragged my watch from its fob. It was
+      not going. I glanced at its face by the moonlight, and then burst
+      into tears as I flung it far away into the ocean. _It had run
+      down at seven o’clock! We were behind the time of the slack, and
+      the whirl of the Ström was in full fury!_
+
+      “When a boat is well built, properly trimmed, and not deep laden,
+      the waves in a strong gale, when she is going large, seem always
+      to slip from beneath her—which appears very strange to a
+      landsman—and this is what is called _riding_, in sea phrase.
+
+      “Well, so far we had ridden the swells very cleverly; but
+      presently a gigantic sea happened to take us right under the
+      counter, and bore us with it as it rose—up—up—as if into the sky.
+      I would not have believed that any wave could rise so high. And
+      then down we came with a sweep, a slide, and a plunge, that made
+      me feel sick and dizzy, as if I was falling from some lofty
+      mountain-top in a dream. But while we were up I had thrown a
+      quick glance around—and that one glance was all sufficient. I saw
+      our exact position in an instant. The Moskoe-Ström whirlpool was
+      about a quarter of a mile dead ahead—but no more like the
+      every-day Moskoe-Ström than the whirl as you now see it, is like
+      a mill-race. If I had not known where we were, and what we had to
+      expect, I should not have recognised the place at all. As it was,
+      I involuntarily closed my eyes in horror. The lids clenched
+      themselves together as if in a spasm.
+
+      “It could not have been more than two minutes afterward until we
+      suddenly felt the waves subside, and were enveloped in foam. The
+      boat made a sharp half turn to larboard, and then shot off in its
+      new direction like a thunderbolt. At the same moment the roaring
+      noise of the water was completely drowned in a kind of shrill
+      shriek—such a sound as you might imagine given out by the
+      waste-pipes of many thousand steam-vessels, letting off their
+      steam all together. We were now in the belt of surf that always
+      surrounds the whirl; and I thought, of course, that another
+      moment would plunge us into the abyss, down which we could only
+      see indistinctly on account of the amazing velocity with which we
+      wore borne along. The boat did not seem to sink into the water at
+      all, but to skim like an air-bubble upon the surface of the
+      surge. Her starboard side was next the whirl, and on the larboard
+      arose the world of ocean we had left. It stood like a huge
+      writhing wall between us and the horizon.
+
+      “It may appear strange, but now, when we were in the very jaws of
+      the gulf, I felt more composed than when we were only approaching
+      it. Having made up my mind to hope no more, I got rid of a great
+      deal of that terror which unmanned me at first. I suppose it was
+      despair that strung my nerves.
+
+      “It may look like boasting—but what I tell you is truth—I began
+      to reflect how magnificent a thing it was to die in such a
+      manner, and how foolish it was in me to think of so paltry a
+      consideration as my own individual life, in view of so wonderful
+      a manifestation of God’s power. I do believe that I blushed with
+      shame when this idea crossed my mind. After a little while I
+      became possessed with the keenest curiosity about the whirl
+      itself. I positively felt a _wish_ to explore its depths, even at
+      the sacrifice I was going to make; and my principal grief was
+      that I should never be able to tell my old companions on shore
+      about the mysteries I should see. These, no doubt, were singular
+      fancies to occupy a man’s mind in such extremity—and I have often
+      thought since, that the revolutions of the boat around the pool
+      might have rendered me a little light-headed.
+
+      “There was another circumstance which tended to restore my
+      self-possession; and this was the cessation of the wind, which
+      could not reach us in our present situation—for, as you saw
+      yourself, the belt of surf is considerably lower than the general
+      bed of the ocean, and this latter now towered above us, a high,
+      black, mountainous ridge. If you have never been at sea in a
+      heavy gale, you can form no idea of the confusion of mind
+      occasioned by the wind and spray together. They blind, deafen,
+      and strangle you, and take away all power of action or
+      reflection. But we were now, in a great measure, rid of these
+      annoyances—just as death-condemned felons in prison are allowed
+      petty indulgences, forbidden them while their doom is yet
+      uncertain.
+
+      “How often we made the circuit of the belt it is impossible to
+      say. We careered round and round for perhaps an hour, flying
+      rather than floating, getting gradually more and more into the
+      middle of the surge, and then nearer and nearer to its horrible
+      inner edge. All this time I had never let go of the ring-bolt. My
+      brother was at the stern, holding on to a small empty water-cask
+      which had been securely lashed under the coop of the counter, and
+      was the only thing on deck that had not been swept overboard when
+      the gale first took us. As we approached the brink of the pit he
+      let go his hold upon this, and made for the ring, from which, in
+      the agony of his terror, he endeavored to force my hands, as it
+      was not large enough to afford us both a secure grasp. I never
+      felt deeper grief than when I saw him attempt this act—although I
+      knew he was a madman when he did it—a raving maniac through sheer
+      fright. I did not care, however, to contest the point with him. I
+      knew it could make no difference whether either of us held on at
+      all; so I let him have the bolt, and went astern to the cask.
+      This there was no great difficulty in doing; for the smack flew
+      round steadily enough, and upon an even keel—only swaying to and
+      fro, with the immense sweeps and swelters of the whirl. Scarcely
+      had I secured myself in my new position, when we gave a wild
+      lurch to starboard, and rushed headlong into the abyss. I
+      muttered a hurried prayer to God, and thought all was over.
+
+      “As I felt the sickening sweep of the descent, I had
+      instinctively tightened my hold upon the barrel, and closed my
+      eyes. For some seconds I dared not open them—while I expected
+      instant destruction, and wondered that I was not already in my
+      death-struggles with the water. But moment after moment elapsed.
+      I still lived. The sense of falling had ceased; and the motion of
+      the vessel seemed much as it had been before, while in the belt
+      of foam, with the exception that she now lay more along. I took
+      courage, and looked once again upon the scene.
+
+      “Never shall I forget the sensations of awe, horror, and
+      admiration with which I gazed about me. The boat appeared to be
+      hanging, as if by magic, midway down, upon the interior surface
+      of a funnel vast in circumference, prodigious in depth, and whose
+      perfectly smooth sides might have been mistaken for ebony, but
+      for the bewildering rapidity with which they spun around, and for
+      the gleaming and ghastly radiance they shot forth, as the rays of
+      the full moon, from that circular rift amid the clouds which I
+      have already described, streamed in a flood of golden glory along
+      the black walls, and far away down into the inmost recesses of
+      the abyss.
+
+      “At first I was too much confused to observe anything accurately.
+      The general burst of terrific grandeur was all that I beheld.
+      When I recovered myself a little, however, my gaze fell
+      instinctively downward. In this direction I was able to obtain an
+      unobstructed view, from the manner in which the smack hung on the
+      inclined surface of the pool. She was quite upon an even
+      keel—that is to say, her deck lay in a plane parallel with that
+      of the water—but this latter sloped at an angle of more than
+      forty-five degrees, so that we seemed to be lying upon our
+      beam-ends. I could not help observing, nevertheless, that I had
+      scarcely more difficulty in maintaining my hold and footing in
+      this situation, than if we had been upon a dead level; and this,
+      I suppose, was owing to the speed at which we revolved.
+
+      “The rays of the moon seemed to search the very bottom of the
+      profound gulf; but still I could make out nothing distinctly, on
+      account of a thick mist in which everything there was enveloped,
+      and over which there hung a magnificent rainbow, like that narrow
+      and tottering bridge which Mussulmen say is the only pathway
+      between Time and Eternity. This mist, or spray, was no doubt
+      occasioned by the clashing of the great walls of the funnel, as
+      they all met together at the bottom—but the yell that went up to
+      the Heavens from out of that mist, I dare not attempt to
+      describe.
+
+      “Our first slide into the abyss itself, from the belt of foam
+      above, had carried us a great distance down the slope; but our
+      farther descent was by no means proportionate. Round and round we
+      swept—not with any uniform movement—but in dizzying swings and
+      jerks, that sent us sometimes only a few hundred yards—sometimes
+      nearly the complete circuit of the whirl. Our progress downward,
+      at each revolution, was slow, but very perceptible.
+
+      “Looking about me upon the wide waste of liquid ebony on which we
+      were thus borne, I perceived that our boat was not the only
+      object in the embrace of the whirl. Both above and below us were
+      visible fragments of vessels, large masses of building timber and
+      trunks of trees, with many smaller articles, such as pieces of
+      house furniture, broken boxes, barrels and staves. I have already
+      described the unnatural curiosity which had taken the place of my
+      original terrors. It appeared to grow upon me as I drew nearer
+      and nearer to my dreadful doom. I now began to watch, with a
+      strange interest, the numerous things that floated in our
+      company. I _must_ have been delirious, for I even sought
+      _amusement_ in speculating upon the relative velocities of their
+      several descents toward the foam below. ‘This fir tree,’ I found
+      myself at one time saying, ‘will certainly be the next thing that
+      takes the awful plunge and disappears,’—and then I was
+      disappointed to find that the wreck of a Dutch merchant ship
+      overtook it and went down before. At length, after making several
+      guesses of this nature, and being deceived in all—this fact—the
+      fact of my invariable miscalculation, set me upon a train of
+      reflection that made my limbs again tremble, and my heart beat
+      heavily once more.
+
+      “It was not a new terror that thus affected me, but the dawn of a
+      more exciting _hope_. This hope arose partly from memory, and
+      partly from present observation. I called to mind the great
+      variety of buoyant matter that strewed the coast of Lofoden,
+      having been absorbed and then thrown forth by the Moskoe-ström.
+      By far the greater number of the articles were shattered in the
+      most extraordinary way—so chafed and roughened as to have the
+      appearance of being stuck full of splinters—but then I distinctly
+      recollected that there were _some_ of them which were not
+      disfigured at all. Now I could not account for this difference
+      except by supposing that the roughened fragments were the only
+      ones which had been _completely absorbed_—that the others had
+      entered the whirl at so late a period of the tide, or, for some
+      reason, had descended so slowly after entering, that they did not
+      reach the bottom before the turn of the flood came, or of the
+      ebb, as the case might be. I conceived it possible, in either
+      instance, that they might thus be whirled up again to the level
+      of the ocean, without undergoing the fate of those which had been
+      drawn in more early, or absorbed more rapidly. I made, also,
+      three important observations. The first was, that, as a general
+      rule, the larger the bodies were, the more rapid their
+      descent—the second, that, between two masses of equal extent, the
+      one spherical, and the other _of any other shape_, the
+      superiority in speed of descent was with the sphere—the third,
+      that, between two masses of equal size, the one cylindrical, and
+      the other of any other shape, the cylinder was absorbed the more
+      slowly. Since my escape, I have had several conversations on this
+      subject with an old school-master of the district; and it was
+      from him that I learned the use of the words ‘cylinder’ and
+      ‘sphere.’ He explained to me—although I have forgotten the
+      explanation—how what I observed was, in fact, the natural
+      consequence of the forms of the floating fragments—and showed me
+      how it happened that a cylinder, swimming in a vortex, offered
+      more resistance to its suction, and was drawn in with greater
+      difficulty than an equally bulky body, of any form whatever. (*1)
+
+      “There was one startling circumstance which went a great way in
+      enforcing these observations, and rendering me anxious to turn
+      them to account, and this was that, at every revolution, we
+      passed something like a barrel, or else the yard or the mast of a
+      vessel, while many of these things, which had been on our level
+      when I first opened my eyes upon the wonders of the whirlpool,
+      were now high up above us, and seemed to have moved but little
+      from their original station.
+
+      “I no longer hesitated what to do. I resolved to lash myself
+      securely to the water cask upon which I now held, to cut it loose
+      from the counter, and to throw myself with it into the water. I
+      attracted my brother’s attention by signs, pointed to the
+      floating barrels that came near us, and did everything in my
+      power to make him understand what I was about to do. I thought at
+      length that he comprehended my design—but, whether this was the
+      case or not, he shook his head despairingly, and refused to move
+      from his station by the ring-bolt. It was impossible to reach
+      him; the emergency admitted of no delay; and so, with a bitter
+      struggle, I resigned him to his fate, fastened myself to the cask
+      by means of the lashings which secured it to the counter, and
+      precipitated myself with it into the sea, without another
+      moment’s hesitation.
+
+      “The result was precisely what I had hoped it might be. As it is
+      myself who now tell you this tale—as you see that I _did_
+      escape—and as you are already in possession of the mode in which
+      this escape was effected, and must therefore anticipate all that
+      I have farther to say—I will bring my story quickly to
+      conclusion. It might have been an hour, or thereabout, after my
+      quitting the smack, when, having descended to a vast distance
+      beneath me, it made three or four wild gyrations in rapid
+      succession, and, bearing my loved brother with it, plunged
+      headlong, at once and forever, into the chaos of foam below. The
+      barrel to which I was attached sunk very little farther than half
+      the distance between the bottom of the gulf and the spot at which
+      I leaped overboard, before a great change took place in the
+      character of the whirlpool. The slope of the sides of the vast
+      funnel became momently less and less steep. The gyrations of the
+      whirl grew, gradually, less and less violent. By degrees, the
+      froth and the rainbow disappeared, and the bottom of the gulf
+      seemed slowly to uprise. The sky was clear, the winds had gone
+      down, and the full moon was setting radiantly in the west, when I
+      found myself on the surface of the ocean, in full view of the
+      shores of Lofoden, and above the spot where the pool of the
+      Moskoe-ström _had been_. It was the hour of the slack—but the sea
+      still heaved in mountainous waves from the effects of the
+      hurricane. I was borne violently into the channel of the Ström,
+      and in a few minutes was hurried down the coast into the
+      ‘grounds’ of the fishermen. A boat picked me up—exhausted from
+      fatigue—and (now that the danger was removed) speechless from the
+      memory of its horror. Those who drew me on board were my old
+      mates and daily companions—but they knew me no more than they
+      would have known a traveller from the spirit-land. My hair which
+      had been raven-black the day before, was as white as you see it
+      now. They say too that the whole expression of my countenance had
+      changed. I told them my story—they did not believe it. I now tell
+      it to _you_—and I can scarcely expect you to put more faith in it
+      than did the merry fishermen of Lofoden.”
+
+
+
+
+VON KEMPELEN AND HIS DISCOVERY
+
+
+      After the very minute and elaborate paper by Arago, to say
+      nothing of the summary in ‘Silliman’s Journal,’ with the detailed
+      statement just published by Lieutenant Maury, it will not be
+      supposed, of course, that in offering a few hurried remarks in
+      reference to Von Kempelen’s discovery, I have any design to look
+      at the subject in a scientific point of view. My object is
+      simply, in the first place, to say a few words of Von Kempelen
+      himself (with whom, some years ago, I had the honor of a slight
+      personal acquaintance), since every thing which concerns him must
+      necessarily, at this moment, be of interest; and, in the second
+      place, to look in a general way, and speculatively, at the
+      results of the discovery.
+
+      It may be as well, however, to premise the cursory observations
+      which I have to offer, by denying, very decidedly, what seems to
+      be a general impression (gleaned, as usual in a case of this
+      kind, from the newspapers), viz.: that this discovery, astounding
+      as it unquestionably is, is unanticipated.
+
+      By reference to the ‘Diary of Sir Humphrey Davy’ (Cottle and
+      Munroe, London, pp. 150), it will be seen at pp. 53 and 82, that
+      this illustrious chemist had not only conceived the idea now in
+      question, but had actually made no inconsiderable progress,
+      experimentally, in the very identical analysis now so
+      triumphantly brought to an issue by Von Kempelen, who although he
+      makes not the slightest allusion to it, is, without doubt (I say
+      it unhesitatingly, and can prove it, if required), indebted to
+      the ‘Diary’ for at least the first hint of his own undertaking.
+
+      The paragraph from the ‘Courier and Enquirer,’ which is now going
+      the rounds of the press, and which purports to claim the
+      invention for a Mr. Kissam, of Brunswick, Maine, appears to me, I
+      confess, a little apocryphal, for several reasons; although there
+      is nothing either impossible or very improbable in the statement
+      made. I need not go into details. My opinion of the paragraph is
+      founded principally upon its manner. It does not look true.
+      Persons who are narrating facts, are seldom so particular as Mr.
+      Kissam seems to be, about day and date and precise location.
+      Besides, if Mr. Kissam actually did come upon the discovery he
+      says he did, at the period designated—nearly eight years ago—how
+      happens it that he took no steps, on the instant, to reap the
+      immense benefits which the merest bumpkin must have known would
+      have resulted to him individually, if not to the world at large,
+      from the discovery? It seems to me quite incredible that any man
+      of common understanding could have discovered what Mr. Kissam
+      says he did, and yet have subsequently acted so like a baby—so
+      like an owl—as Mr. Kissam admits that he did. By-the-way, who is
+      Mr. Kissam? and is not the whole paragraph in the ‘Courier and
+      Enquirer’ a fabrication got up to ‘make a talk’? It must be
+      confessed that it has an amazingly moon-hoaxy-air. Very little
+      dependence is to be placed upon it, in my humble opinion; and if
+      I were not well aware, from experience, how very easily men of
+      science are mystified, on points out of their usual range of
+      inquiry, I should be profoundly astonished at finding so eminent
+      a chemist as Professor Draper, discussing Mr. Kissam’s (or is it
+      Mr. Quizzem’s?) pretensions to the discovery, in so serious a
+      tone.
+
+      But to return to the ‘Diary’ of Sir Humphrey Davy. This pamphlet
+      was not designed for the public eye, even upon the decease of the
+      writer, as any person at all conversant with authorship may
+      satisfy himself at once by the slightest inspection of the style.
+      At page 13, for example, near the middle, we read, in reference
+      to his researches about the protoxide of azote: ‘In less than
+      half a minute the respiration being continued, diminished
+      gradually and were succeeded by analogous to gentle pressure on
+      all the muscles.’ That the respiration was not ‘diminished,’ is
+      not only clear by the subsequent context, but by the use of the
+      plural, ‘were.’ The sentence, no doubt, was thus intended: ‘In
+      less than half a minute, the respiration [being continued, these
+      feelings] diminished gradually, and were succeeded by [a
+      sensation] analogous to gentle pressure on all the muscles.’ A
+      hundred similar instances go to show that the MS. so
+      inconsiderately published, was merely a rough note-book, meant
+      only for the writer’s own eye, but an inspection of the pamphlet
+      will convince almost any thinking person of the truth of my
+      suggestion. The fact is, Sir Humphrey Davy was about the last man
+      in the world to commit himself on scientific topics. Not only had
+      he a more than ordinary dislike to quackery, but he was morbidly
+      afraid of appearing empirical; so that, however fully he might
+      have been convinced that he was on the right track in the matter
+      now in question, he would never have spoken out, until he had
+      every thing ready for the most practical demonstration. I verily
+      believe that his last moments would have been rendered wretched,
+      could he have suspected that his wishes in regard to burning this
+      ‘Diary’ (full of crude speculations) would have been unattended
+      to; as, it seems, they were. I say ‘his wishes,’ for that he
+      meant to include this note-book among the miscellaneous papers
+      directed ‘to be burnt,’ I think there can be no manner of doubt.
+      Whether it escaped the flames by good fortune or by bad, yet
+      remains to be seen. That the passages quoted above, with the
+      other similar ones referred to, gave Von Kempelen the hint, I do
+      not in the slightest degree question; but I repeat, it yet
+      remains to be seen whether this momentous discovery itself
+      (momentous under any circumstances) will be of service or
+      disservice to mankind at large. That Von Kempelen and his
+      immediate friends will reap a rich harvest, it would be folly to
+      doubt for a moment. They will scarcely be so weak as not to
+      ‘realize,’ in time, by large purchases of houses and land, with
+      other property of intrinsic value.
+
+      In the brief account of Von Kempelen which appeared in the ‘Home
+      Journal,’ and has since been extensively copied, several
+      misapprehensions of the German original seem to have been made by
+      the translator, who professes to have taken the passage from a
+      late number of the Presburg ‘Schnellpost.’ ‘Viele’ has evidently
+      been misconceived (as it often is), and what the translator
+      renders by ‘sorrows,’ is probably ‘lieden,’ which, in its true
+      version, ‘sufferings,’ would give a totally different complexion
+      to the whole account; but, of course, much of this is merely
+      guess, on my part.
+
+      Von Kempelen, however, is by no means ‘a misanthrope,’ in
+      appearance, at least, whatever he may be in fact. My acquaintance
+      with him was casual altogether; and I am scarcely warranted in
+      saying that I know him at all; but to have seen and conversed
+      with a man of so _prodigious_ a notoriety as he has attained, or
+      _will_ attain in a few days, is not a small matter, as times go.
+
+      “The Literary World” speaks of him, confidently, as a native of
+      Presburg (misled, perhaps, by the account in “The Home Journal”)
+      but I am pleased in being able to state _positively_, since I
+      have it from his own lips, that he was born in Utica, in the
+      State of New York, although both his parents, I believe, are of
+      Presburg descent. The family is connected, in some way, with
+      Mäelzel, of Automaton-chess-player memory. In person, he is short
+      and stout, with large, _fat_, blue eyes, sandy hair and whiskers,
+      a wide but pleasing mouth, fine teeth, and I think a Roman nose.
+      There is some defect in one of his feet. His address is frank,
+      and his whole manner noticeable for bonhomie. Altogether, he
+      looks, speaks, and acts as little like ‘a misanthrope’ as any man
+      I ever saw. We were fellow-sojourners for a week about six years
+      ago, at Earl’s Hotel, in Providence, Rhode Island; and I presume
+      that I conversed with him, at various times, for some three or
+      four hours altogether. His principal topics were those of the
+      day; and nothing that fell from him led me to suspect his
+      scientific attainments. He left the hotel before me, intending to
+      go to New York, and thence to Bremen; it was in the latter city
+      that his great discovery was first made public; or, rather, it
+      was there that he was first suspected of having made it. This is
+      about all that I personally know of the now immortal Von
+      Kempelen; but I have thought that even these few details would
+      have interest for the public.
+
+      There can be little question that most of the marvellous rumors
+      afloat about this affair are pure inventions, entitled to about
+      as much credit as the story of Aladdin’s lamp; and yet, in a case
+      of this kind, as in the case of the discoveries in California, it
+      is clear that the truth may be stranger than fiction. The
+      following anecdote, at least, is so well authenticated, that we
+      may receive it implicitly.
+
+      Von Kempelen had never been even tolerably well off during his
+      residence at Bremen; and often, it was well known, he had been
+      put to extreme shifts in order to raise trifling sums. When the
+      great excitement occurred about the forgery on the house of
+      Gutsmuth & Co., suspicion was directed toward Von Kempelen, on
+      account of his having purchased a considerable property in
+      Gasperitch Lane, and his refusing, when questioned, to explain
+      how he became possessed of the purchase money. He was at length
+      arrested, but nothing decisive appearing against him, was in the
+      end set at liberty. The police, however, kept a strict watch upon
+      his movements, and thus discovered that he left home frequently,
+      taking always the same road, and invariably giving his watchers
+      the slip in the neighborhood of that labyrinth of narrow and
+      crooked passages known by the flash name of the ‘Dondergat.’
+      Finally, by dint of great perseverance, they traced him to a
+      garret in an old house of seven stories, in an alley called
+      Flatzplatz,—and, coming upon him suddenly, found him, as they
+      imagined, in the midst of his counterfeiting operations. His
+      agitation is represented as so excessive that the officers had
+      not the slightest doubt of his guilt. After hand-cuffing him,
+      they searched his room, or rather rooms, for it appears he
+      occupied all the mansarde.
+
+      Opening into the garret where they caught him, was a closet, ten
+      feet by eight, fitted up with some chemical apparatus, of which
+      the object has not yet been ascertained. In one corner of the
+      closet was a very small furnace, with a glowing fire in it, and
+      on the fire a kind of duplicate crucible—two crucibles connected
+      by a tube. One of these crucibles was nearly full of lead in a
+      state of fusion, but not reaching up to the aperture of the tube,
+      which was close to the brim. The other crucible had some liquid
+      in it, which, as the officers entered, seemed to be furiously
+      dissipating in vapor. They relate that, on finding himself taken,
+      Kempelen seized the crucibles with both hands (which were encased
+      in gloves that afterwards turned out to be asbestic), and threw
+      the contents on the tiled floor. It was now that they hand-cuffed
+      him; and before proceeding to ransack the premises they searched
+      his person, but nothing unusual was found about him, excepting a
+      paper parcel, in his coat-pocket, containing what was afterward
+      ascertained to be a mixture of antimony and some unknown
+      substance, in nearly, but not quite, equal proportions. All
+      attempts at analyzing the unknown substance have, so far, failed,
+      but that it will ultimately be analyzed, is not to be doubted.
+
+      Passing out of the closet with their prisoner, the officers went
+      through a sort of ante-chamber, in which nothing material was
+      found, to the chemist’s sleeping-room. They here rummaged some
+      drawers and boxes, but discovered only a few papers, of no
+      importance, and some good coin, silver and gold. At length,
+      looking under the bed, they saw a large, common hair trunk,
+      without hinges, hasp, or lock, and with the top lying carelessly
+      across the bottom portion. Upon attempting to draw this trunk out
+      from under the bed, they found that, with their united strength
+      (there were three of them, all powerful men), they ‘could not
+      stir it one inch.’ Much astonished at this, one of them crawled
+      under the bed, and looking into the trunk, said:
+
+      ‘No wonder we couldn’t move it—why it’s full to the brim of old
+      bits of brass!’
+
+      Putting his feet, now, against the wall so as to get a good
+      purchase, and pushing with all his force, while his companions
+      pulled with all theirs, the trunk, with much difficulty, was slid
+      out from under the bed, and its contents examined. The supposed
+      brass with which it was filled was all in small, smooth pieces,
+      varying from the size of a pea to that of a dollar; but the
+      pieces were irregular in shape, although more or less
+      flat-looking, upon the whole, “very much as lead looks when
+      thrown upon the ground in a molten state, and there suffered to
+      grow cool.” Now, not one of these officers for a moment suspected
+      this metal to be anything _but_ brass. The idea of its being
+      _gold_ never entered their brains, of course; how _could_ such a
+      wild fancy have entered it? And their astonishment may be well
+      conceived, when the next day it became known, all over Bremen,
+      that the “lot of brass” which they had carted so contemptuously
+      to the police office, without putting themselves to the trouble
+      of pocketing the smallest scrap, was not only gold—real gold—but
+      gold far finer than any employed in coinage—gold, in fact,
+      absolutely pure, virgin, without the slightest appreciable alloy.
+
+      I need not go over the details of Von Kempelen’s confession (as
+      far as it went) and release, for these are familiar to the
+      public. That he has actually realized, in spirit and in effect,
+      if not to the letter, the old chimaera of the philosopher’s
+      stone, no sane person is at liberty to doubt. The opinions of
+      Arago are, of course, entitled to the greatest consideration; but
+      he is by no means infallible; and what he says of bismuth, in his
+      report to the Academy, must be taken _cum grano salis_. The
+      simple truth is, that up to this period all analysis has failed;
+      and until Von Kempelen chooses to let us have the key to his own
+      published enigma, it is more than probable that the matter will
+      remain, for years, in statu quo. All that as yet can fairly be
+      said to be known is, that ‘Pure gold can be made at will, and
+      very readily from lead in connection with certain other
+      substances, in kind and in proportions, unknown.’
+
+      Speculation, of course, is busy as to the immediate and ultimate
+      results of this discovery—a discovery which few thinking persons
+      will hesitate in referring to an increased interest in the matter
+      of gold generally, by the late developments in California; and
+      this reflection brings us inevitably to another—the exceeding
+      inopportuneness of Von Kempelen’s analysis. If many were
+      prevented from adventuring to California, by the mere
+      apprehension that gold would so materially diminish in value, on
+      account of its plentifulness in the mines there, as to render the
+      speculation of going so far in search of it a doubtful one—what
+      impression will be wrought now, upon the minds of those about to
+      emigrate, and especially upon the minds of those actually in the
+      mineral region, by the announcement of this astounding discovery
+      of Von Kempelen? a discovery which declares, in so many words,
+      that beyond its intrinsic worth for manufacturing purposes
+      (whatever that worth may be), gold now is, or at least soon will
+      be (for it cannot be supposed that Von Kempelen can long retain
+      his secret), of no greater value than lead, and of far inferior
+      value to silver. It is, indeed, exceedingly difficult to
+      speculate prospectively upon the consequences of the discovery,
+      but one thing may be positively maintained—that the announcement
+      of the discovery six months ago would have had material influence
+      in regard to the settlement of California.
+
+      In Europe, as yet, the most noticeable results have been a rise
+      of two hundred per cent. in the price of lead, and nearly
+      twenty-five per cent. that of silver.
+
+
+
+
+MESMERIC REVELATION
+
+
+Whatever doubt may still envelop the _rationale_ of mesmerism, its
+startling _facts_ are now almost universally admitted. Of these latter,
+those who doubt, are your mere doubters by profession—an unprofitable
+and disreputable tribe. There can be no more absolute waste of time
+than the attempt to _prove_, at the present day, that man, by mere
+exercise of will, can so impress his fellow, as to cast him into an
+abnormal condition, of which the phenomena resemble very closely those
+of _death_, or at least resemble them more nearly than they do the
+phenomena of any other normal condition within our cognizance; that,
+while in this state, the person so impressed employs only with effort,
+and then feebly, the external organs of sense, yet perceives, with
+keenly refined perception, and through channels supposed unknown,
+matters beyond the scope of the physical organs; that, moreover, his
+intellectual faculties are wonderfully exalted and invigorated; that
+his sympathies with the person so impressing him are profound; and,
+finally, that his susceptibility to the impression increases with its
+frequency, while, in the same proportion, the peculiar phenomena
+elicited are more extended and more _pronounced_.
+
+I say that these—which are the laws of mesmerism in its general
+features—it would be supererogation to demonstrate; nor shall I inflict
+upon my readers so needless a demonstration; to-day. My purpose at
+present is a very different one indeed. I am impelled, even in the
+teeth of a world of prejudice, to detail without comment the very
+remarkable substance of a colloquy, occurring between a sleep-waker and
+myself.
+
+I had been long in the habit of mesmerizing the person in question (Mr.
+Vankirk), and the usual acute susceptibility and exaltation of the
+mesmeric perception had supervened. For many months he had been
+laboring under confirmed phthisis, the more distressing effects of
+which had been relieved by my manipulations; and on the night of
+Wednesday, the fifteenth instant, I was summoned to his bedside.
+
+The invalid was suffering with acute pain in the region of the heart,
+and breathed with great difficulty, having all the ordinary symptoms of
+asthma. In spasms such as these he had usually found relief from the
+application of mustard to the nervous centres, but to-night this had
+been attempted in vain.
+
+As I entered his room he greeted me with a cheerful smile, and although
+evidently in much bodily pain, appeared to be, mentally, quite at ease.
+
+“I sent for you to-night,” he said, “not so much to administer to my
+bodily ailment, as to satisfy me concerning certain psychal impressions
+which, of late, have occasioned me much anxiety and surprise. I need
+not tell you how sceptical I have hitherto been on the topic of the
+soul’s immortality. I cannot deny that there has always existed, as if
+in that very soul which I have been denying, a vague half-sentiment of
+its own existence. But this half-sentiment at no time amounted to
+conviction. With it my reason had nothing to do. All attempts at
+logical inquiry resulted, indeed, in leaving me more sceptical than
+before. I had been advised to study Cousin. I studied him in his own
+works as well as in those of his European and American echoes. The
+‘Charles Elwood’ of Mr. Brownson, for example, was placed in my hands.
+I read it with profound attention. Throughout I found it logical, but
+the portions which were not _merely_ logical were unhappily the initial
+arguments of the disbelieving hero of the book. In his summing up it
+seemed evident to me that the reasoner had not even succeeded in
+convincing himself. His end had plainly forgotten his beginning, like
+the government of Trinculo. In short, I was not long in perceiving that
+if man is to be intellectually convinced of his own immortality, he
+will never be so convinced by the mere abstractions which have been so
+long the fashion of the moralists of England, of France, and of
+Germany. Abstractions may amuse and exercise, but take no hold on the
+mind. Here upon earth, at least, philosophy, I am persuaded, will
+always in vain call upon us to look upon qualities as things. The will
+may assent—the soul—the intellect, never.
+
+“I repeat, then, that I only half felt, and never intellectually
+believed. But latterly there has been a certain deepening of the
+feeling, until it has come so nearly to resemble the acquiescence of
+reason, that I find it difficult to distinguish between the two. I am
+enabled, too, plainly to trace this effect to the mesmeric influence. I
+cannot better explain my meaning than by the hypothesis that the
+mesmeric exaltation enables me to perceive a train of ratiocination
+which, in my abnormal existence, convinces, but which, in full
+accordance with the mesmeric phenomena, does not extend, except through
+its _effect_, into my normal condition. In sleep-waking, the reasoning
+and its conclusion—the cause and its effect—are present together. In my
+natural state, the cause vanishing, the effect only, and perhaps only
+partially, remains.
+
+“These considerations have led me to think that some good results might
+ensue from a series of well-directed questions propounded to me while
+mesmerized. You have often observed the profound self-cognizance
+evinced by the sleep-waker—the extensive knowledge he displays upon all
+points relating to the mesmeric condition itself; and from this
+self-cognizance may be deduced hints for the proper conduct of a
+catechism.”
+
+I consented of course to make this experiment.  A few passes threw Mr.
+Vankirk into the mesmeric sleep. His breathing became immediately more
+easy, and he seemed to suffer no physical uneasiness. The following
+conversation then ensued:—V. in the dialogue representing the patient,
+and P. myself.
+
+      _P._ Are you asleep?
+
+      _V._ Yes—no; I would rather sleep more soundly.
+
+      _P._ [_After a few more passes._] Do you sleep now?
+
+      _V._ Yes.
+
+      _P._ How do you think your present illness will result?
+
+      _V._ [_After a long hesitation and speaking as if with effort_.]
+      I must die.
+
+      _P._ Does the idea of death afflict you?
+
+      _V._ [_Very quickly_.] No—no!
+
+      _P._ Are you pleased with the prospect?
+
+      _V._ If I were awake I should like to die, but now it is no
+      matter. The mesmeric condition is so near death as to content me.
+
+      _P._ I wish you would explain yourself, Mr. Vankirk.
+
+      _V._ I am willing to do so, but it requires more effort than I
+      feel able to make. You do not question me properly.
+
+      _P._ What then shall I ask?
+
+      _V._ You must begin at the beginning.
+
+      _P._ The beginning! But where is the beginning?
+
+      _V._ You know that the beginning is GOD. [_This was said in a
+      low, fluctuating tone, and with every sign of the most profound
+      veneration_.]
+
+      _P._ What then, is God?
+
+      _V._ [_Hesitating for many minutes._] I cannot tell.
+
+      _P._ Is not God spirit?
+
+      _V._ While I was awake I knew what you meant by “spirit,” but now
+      it seems only a word—such, for instance, as truth, beauty—a
+      quality, I mean.
+
+      _P._ Is not God immaterial?
+
+      _V._ There is no immateriality—it is a mere word. That which is
+      not matter, is not at all—unless qualities are things.
+
+      _P._ Is God, then, material?
+
+      _V._ No. [_This reply startled me very much._]
+
+      _P._ What, then, is he?
+
+      _V._ [_After a long pause, and mutteringly._] I see—but it is a
+      thing difficult to tell. [_Another long pause._] He is not
+      spirit, for he exists. Nor is he matter, as _you understand it_.
+      But there are _gradations_ of matter of which man knows nothing;
+      the grosser impelling the finer, the finer pervading the grosser.
+      The atmosphere, for example, impels the electric principle, while
+      the electric principle permeates the atmosphere. These gradations
+      of matter increase in rarity or fineness, until we arrive at a
+      matter _unparticled_—without particles—indivisible—_one;_ and
+      here the law of impulsion and permeation is modified. The
+      ultimate, or unparticled matter, not only permeates all things
+      but impels all things; and thus _is_ all things within itself.
+      This matter is God. What men attempt to embody in the word
+      “thought,” is this matter in motion.
+
+      _P._ The metaphysicians maintain that all action is reducible to
+      motion and thinking, and that the latter is the origin of the
+      former.
+
+      _V._ Yes; and I now see the confusion of idea. Motion is the
+      action of _mind_, not of _thinking_. The unparticled matter, or
+      God, in quiescence, is (as nearly as we can conceive it) what men
+      call mind. And the power of self-movement (equivalent in effect
+      to human volition) is, in the unparticled matter, the result of
+      its unity and omniprevalence; _how_ I know not, and now clearly
+      see that I shall never know. But the unparticled matter, set in
+      motion by a law, or quality, existing within itself, is thinking.
+
+      _P._ Can you give me no more precise idea of what you term the
+      unparticled matter?
+
+      _V._ The matters of which man is cognizant escape the senses in
+      gradation. We have, for example, a metal, a piece of wood, a drop
+      of water, the atmosphere, a gas, caloric, electricity, the
+      luminiferous ether. Now we call all these things matter, and
+      embrace all matter in one general definition; but in spite of
+      this, there can be no two ideas more essentially distinct than
+      that which we attach to a metal, and that which we attach to the
+      luminiferous ether. When we reach the latter, we feel an almost
+      irresistible inclination to class it with spirit, or with
+      nihility. The only consideration which restrains us is our
+      conception of its atomic constitution; and here, even, we have to
+      seek aid from our notion of an atom, as something possessing in
+      infinite minuteness, solidity, palpability, weight. Destroy the
+      idea of the atomic constitution and we should no longer be able
+      to regard the ether as an entity, or at least as matter. For want
+      of a better word we might term it spirit. Take, now, a step
+      beyond the luminiferous ether—conceive a matter as much more rare
+      than the ether, as this ether is more rare than the metal, and we
+      arrive at once (in spite of all the school dogmas) at a unique
+      mass—an unparticled matter. For although we may admit infinite
+      littleness in the atoms themselves, the infinitude of littleness
+      in the spaces between them is an absurdity. There will be a
+      point—there will be a degree of rarity, at which, if the atoms
+      are sufficiently numerous, the interspaces must vanish, and the
+      mass absolutely coalesce. But the consideration of the atomic
+      constitution being now taken away, the nature of the mass
+      inevitably glides into what we conceive of spirit. It is clear,
+      however, that it is as fully matter as before. The truth is, it
+      is impossible to conceive spirit, since it is impossible to
+      imagine what is not. When we flatter ourselves that we have
+      formed its conception, we have merely deceived our understanding
+      by the consideration of infinitely rarified matter.
+
+      _P._ There seems to me an insurmountable objection to the idea of
+      absolute coalescence;—and that is the very slight resistance
+      experienced by the heavenly bodies in their revolutions through
+      space—a resistance now ascertained, it is true, to exist in
+      _some_ degree, but which is, nevertheless, so slight as to have
+      been quite overlooked by the sagacity even of Newton. We know
+      that the resistance of bodies is, chiefly, in proportion to their
+      density. Absolute coalescence is absolute density. Where there
+      are no interspaces, there can be no yielding. An ether,
+      absolutely dense, would put an infinitely more effectual stop to
+      the progress of a star than would an ether of adamant or of iron.
+
+      _V._ Your objection is answered with an ease which is nearly in
+      the ratio of its apparent unanswerability.—As regards the
+      progress of the star, it can make no difference whether the star
+      passes through the ether _or the ether through it_. There is no
+      astronomical error more unaccountable than that which reconciles
+      the known retardation of the comets with the idea of their
+      passage through an ether: for, however rare this ether be
+      supposed, it would put a stop to all sidereal revolution in a
+      very far briefer period than has been admitted by those
+      astronomers who have endeavored to slur over a point which they
+      found it impossible to comprehend. The retardation actually
+      experienced is, on the other hand, about that which might be
+      expected from the _friction_ of the ether in the instantaneous
+      passage through the orb. In the one case, the retarding force is
+      momentary and complete within itself—in the other it is endlessly
+      accumulative.
+
+      _P._ But in all this—in this identification of mere matter with
+      God—is there nothing of irreverence? [_I was forced to repeat
+      this question before the sleep-waker fully comprehended my
+      meaning_.]
+
+      _V._ Can you say _why_ matter should be less reverenced than
+      mind? But you forget that the matter of which I speak is, in all
+      respects, the very “mind” or “spirit” of the schools, so far as
+      regards its high capacities, and is, moreover, the “matter” of
+      these schools at the same time. God, with all the powers
+      attributed to spirit, is but the perfection of matter.
+
+      _P._ You assert, then, that the unparticled matter, in motion, is
+      thought?
+
+      _V._ In general, this motion is the universal thought of the
+      universal mind. This thought creates. All created things are but
+      the thoughts of God.
+
+      _P._ You say, “in general.”
+
+      _V._ Yes. The universal mind is God. For new individualities,
+      _matter_ is necessary.
+
+      _P._ But you now speak of “mind” and “matter” as do the
+      metaphysicians.
+
+      _V._ Yes—to avoid confusion. When I say “mind,” I mean the
+      unparticled or ultimate matter; by “matter,” I intend all else.
+
+      _P._ You were saying that “for new individualities matter is
+      necessary.”
+
+      _V._ Yes; for mind, existing unincorporate, is merely God. To
+      create individual, thinking beings, it was necessary to incarnate
+      portions of the divine mind. Thus man is individualized. Divested
+      of corporate investiture, he were God. Now, the particular motion
+      of the incarnated portions of the unparticled matter is the
+      thought of man; as the motion of the whole is that of God.
+
+      _P._ You say that divested of the body man will be God?
+
+      _V._ [_After much hesitation._] I could not have said this; it is
+      an absurdity.
+
+      _P._ [_Referring to my notes._] You _did_ say that “divested of
+      corporate investiture man were God.”
+
+      _V._ And this is true. Man thus divested _would be_ God—would be
+      unindividualized. But he can never be thus divested—at least
+      never _will be_—else we must imagine an action of God returning
+      upon itself—a purposeless and futile action. Man is a creature.
+      Creatures are thoughts of God. It is the nature of thought to be
+      irrevocable.
+
+      _P._ I do not comprehend. You say that man will never put off the
+      body?
+
+      _V._ I say that he will never be bodiless.
+
+      _P._ Explain.
+
+      _V._ There are two bodies—the rudimental and the complete;
+      corresponding with the two conditions of the worm and the
+      butterfly. What we call “death,” is but the painful
+      metamorphosis. Our present incarnation is progressive,
+      preparatory, temporary. Our future is perfected, ultimate,
+      immortal. The ultimate life is the full design.
+
+      _P._ But of the worm’s metamorphosis we are palpably cognizant.
+
+      _V._ _We_, certainly—but not the worm. The matter of which our
+      rudimental body is composed, is within the ken of the organs of
+      that body; or, more distinctly, our rudimental organs are adapted
+      to the matter of which is formed the rudimental body; but not to
+      that of which the ultimate is composed. The ultimate body thus
+      escapes our rudimental senses, and we perceive only the shell
+      which falls, in decaying, from the inner form; not that inner
+      form itself; but this inner form, as well as the shell, is
+      appreciable by those who have already acquired the ultimate life.
+
+      _P._ You have often said that the mesmeric state very nearly
+      resembles death. How is this?
+
+      _V._ When I say that it resembles death, I mean that it resembles
+      the ultimate life; for when I am entranced the senses of my
+      rudimental life are in abeyance, and I perceive external things
+      directly, without organs, through a medium which I shall employ
+      in the ultimate, unorganized life.
+
+      _P._ Unorganized?
+
+      _V._ Yes; organs are contrivances by which the individual is
+      brought into sensible relation with particular classes and forms
+      of matter, to the exclusion of other classes and forms. The
+      organs of man are adapted to his rudimental condition, and to
+      that only; his ultimate condition, being unorganized, is of
+      unlimited comprehension in all points but one—the nature of the
+      volition of God—that is to say, the motion of the unparticled
+      matter. You will have a distinct idea of the ultimate body by
+      conceiving it to be entire brain. This it is _not_; but a
+      conception of this nature will bring you near a comprehension of
+      what it _is_. A luminous body imparts vibration to the
+      luminiferous ether. The vibrations generate similar ones within
+      the retina; these again communicate similar ones to the optic
+      nerve. The nerve conveys similar ones to the brain; the brain,
+      also, similar ones to the unparticled matter which permeates it.
+      The motion of this latter is thought, of which perception is the
+      first undulation. This is the mode by which the mind of the
+      rudimental life communicates with the external world; and this
+      external world is, to the rudimental life, limited, through the
+      idiosyncrasy of its organs. But in the ultimate, unorganized
+      life, the external world reaches the whole body, (which is of a
+      substance having affinity to brain, as I have said,) with no
+      other intervention than that of an infinitely rarer ether than
+      even the luminiferous; and to this ether—in unison with it—the
+      whole body vibrates, setting in motion the unparticled matter
+      which permeates it. It is to the absence of idiosyncratic organs,
+      therefore, that we must attribute the nearly unlimited perception
+      of the ultimate life. To rudimental beings, organs are the cages
+      necessary to confine them until fledged.
+
+      _P._ You speak of rudimental “beings.” Are there other rudimental
+      thinking beings than man?
+
+      _V._ The multitudinous conglomeration of rare matter into nebulæ,
+      planets, suns, and other bodies which are neither nebulæ, suns,
+      nor planets, is for the sole purpose of supplying _pabulum_ for
+      the idiosyncrasy of the organs of an infinity of rudimental
+      beings. But for the necessity of the rudimental, prior to the
+      ultimate life, there would have been no bodies such as these.
+      Each of these is tenanted by a distinct variety of organic,
+      rudimental, thinking creatures. In all, the organs vary with the
+      features of the place tenanted. At death, or metamorphosis, these
+      creatures, enjoying the ultimate life—immortality—and cognizant
+      of all secrets but _the one_, act all things and pass everywhere
+      by mere volition:—indwelling, not the stars, which to us seem the
+      sole palpabilities, and for the accommodation of which we blindly
+      deem space created—but that SPACE itself—that infinity of which
+      the truly substantive vastness swallows up the
+      star-shadows—blotting them out as non-entities from the
+      perception of the angels.
+
+      _P._ You say that “but for the _necessity_ of the rudimental
+      life” there would have been no stars. But why this necessity?
+
+      _V._ In the inorganic life, as well as in the inorganic matter
+      generally, there is nothing to impede the action of one simple
+      _unique_ law—the Divine Volition. With the view of producing
+      impediment, the organic life and matter, (complex, substantial,
+      and law-encumbered,) were contrived.
+
+      _P._ But again—why need this impediment have been produced?
+
+      _V._ The result of law inviolate is perfection—right—negative
+      happiness. The result of law violate is imperfection, wrong,
+      positive pain. Through the impediments afforded by the number,
+      complexity, and substantiality of the laws of organic life and
+      matter, the violation of law is rendered, to a certain extent,
+      practicable. Thus pain, which in the inorganic life is
+      impossible, is possible in the organic.
+
+      _P._ But to what good end is pain thus rendered possible?
+
+      _V._ All things are either good or bad by comparison. A
+      sufficient analysis will show that pleasure, in all cases, is but
+      the contrast of pain. _Positive_ pleasure is a mere idea. To be
+      happy at any one point we must have suffered at the same. Never
+      to suffer would have been never to have been blessed. But it has
+      been shown that, in the inorganic life, pain cannot be thus the
+      necessity for the organic. The pain of the primitive life of
+      Earth, is the sole basis of the bliss of the ultimate life in
+      Heaven.
+
+      _P._ Still, there is one of your expressions which I find it
+      impossible to comprehend—“the truly _substantive_ vastness of
+      infinity.”
+
+      _V._ This, probably, is because you have no sufficiently generic
+      conception of the term “_substance_” itself. We must not regard
+      it as a quality, but as a sentiment:—it is the perception, in
+      thinking beings, of the adaptation of matter to their
+      organization. There are many things on the Earth, which would be
+      nihility to the inhabitants of Venus—many things visible and
+      tangible in Venus, which we could not be brought to appreciate as
+      existing at all. But to the inorganic beings—to the angels—the
+      whole of the unparticled matter is substance—that is to say, the
+      whole of what we term “space” is to them the truest
+      substantiality;—the stars, meantime, through what we consider
+      their materiality, escaping the angelic sense, just in proportion
+      as the unparticled matter, through what we consider its
+      immateriality, eludes the organic.
+
+      As the sleep-waker pronounced these latter words, in a feeble
+      tone, I observed on his countenance a singular expression, which
+      somewhat alarmed me, and induced me to awake him at once. No
+      sooner had I done this, than, with a bright smile irradiating all
+      his features, he fell back upon his pillow and expired. I noticed
+      that in less than a minute afterward his corpse had all the stern
+      rigidity of stone. His brow was of the coldness of ice. Thus,
+      ordinarily, should it have appeared, only after long pressure
+      from Azrael’s hand. Had the sleep-waker, indeed, during the
+      latter portion of his discourse, been addressing me from out the
+      region of the shadows?
+
+
+
+
+THE FACTS IN THE CASE OF M. VALDEMAR
+
+
+      Of course I shall not pretend to consider it any matter for
+      wonder, that the extraordinary case of M. Valdemar has excited
+      discussion. It would have been a miracle had it not—especially
+      under the circumstances. Through the desire of all parties
+      concerned, to keep the affair from the public, at least for the
+      present, or until we had farther opportunities for
+      investigation—through our endeavors to effect this—a garbled or
+      exaggerated account made its way into society, and became the
+      source of many unpleasant misrepresentations; and, very
+      naturally, of a great deal of disbelief.
+
+      It is now rendered necessary that I give the facts—as far as I
+      comprehend them myself. They are, succinctly, these:
+
+      My attention, for the last three years, had been repeatedly drawn
+      to the subject of Mesmerism; and, about nine months ago it
+      occurred to me, quite suddenly, that in the series of experiments
+      made hitherto, there had been a very remarkable and most
+      unaccountable omission:—no person had as yet been mesmerized in
+      articulo mortis. It remained to be seen, first, whether, in such
+      condition, there existed in the patient any susceptibility to the
+      magnetic influence; secondly, whether, if any existed, it was
+      impaired or increased by the condition; thirdly, to what extent,
+      or for how long a period, the encroachments of Death might be
+      arrested by the process. There were other points to be
+      ascertained, but these most excited my curiosity—the last in
+      especial, from the immensely important character of its
+      consequences.
+
+      In looking around me for some subject by whose means I might test
+      these particulars, I was brought to think of my friend, M. Ernest
+      Valdemar, the well-known compiler of the “Bibliotheca Forensica,”
+      and author (under the nom de plume of Issachar Marx) of the
+      Polish versions of “Wallenstein” and “Gargantua.” M. Valdemar,
+      who has resided principally at Harlem, N.Y., since the year 1839,
+      is (or was) particularly noticeable for the extreme spareness of
+      his person—his lower limbs much resembling those of John
+      Randolph; and, also, for the whiteness of his whiskers, in
+      violent contrast to the blackness of his hair—the latter, in
+      consequence, being very generally mistaken for a wig. His
+      temperament was markedly nervous, and rendered him a good subject
+      for mesmeric experiment. On two or three occasions I had put him
+      to sleep with little difficulty, but was disappointed in other
+      results which his peculiar constitution had naturally led me to
+      anticipate. His will was at no period positively, or thoroughly,
+      under my control, and in regard to clairvoyance, I could
+      accomplish with him nothing to be relied upon. I always
+      attributed my failure at these points to the disordered state of
+      his health. For some months previous to my becoming acquainted
+      with him, his physicians had declared him in a confirmed
+      phthisis. It was his custom, indeed, to speak calmly of his
+      approaching dissolution, as of a matter neither to be avoided nor
+      regretted.
+
+      When the ideas to which I have alluded first occurred to me, it
+      was of course very natural that I should think of M. Valdemar. I
+      knew the steady philosophy of the man too well to apprehend any
+      scruples from him; and he had no relatives in America who would
+      be likely to interfere. I spoke to him frankly upon the subject;
+      and, to my surprise, his interest seemed vividly excited. I say
+      to my surprise, for, although he had always yielded his person
+      freely to my experiments, he had never before given me any tokens
+      of sympathy with what I did. His disease was of that character
+      which would admit of exact calculation in respect to the epoch of
+      its termination in death; and it was finally arranged between us
+      that he would send for me about twenty-four hours before the
+      period announced by his physicians as that of his decease.
+
+      It is now rather more than seven months since I received, from M.
+      Valdemar himself, the subjoined note:
+
+      MY DEAR P——,
+
+      You may as well come now. D—— and F—— are agreed that I cannot
+      hold out beyond to-morrow midnight; and I think they have hit the
+      time very nearly.
+
+      VALDEMAR
+
+      I received this note within half an hour after it was written,
+      and in fifteen minutes more I was in the dying man’s chamber. I
+      had not seen him for ten days, and was appalled by the fearful
+      alteration which the brief interval had wrought in him. His face
+      wore a leaden hue; the eyes were utterly lustreless; and the
+      emaciation was so extreme that the skin had been broken through
+      by the cheek-bones. His expectoration was excessive. The pulse
+      was barely perceptible. He retained, nevertheless, in a very
+      remarkable manner, both his mental power and a certain degree of
+      physical strength. He spoke with distinctness—took some
+      palliative medicines without aid—and, when I entered the room,
+      was occupied in penciling memoranda in a pocket-book. He was
+      propped up in the bed by pillows. Doctors D—— and F—— were in
+      attendance.
+
+      After pressing Valdemar’s hand, I took these gentlemen aside, and
+      obtained from them a minute account of the patient’s condition.
+      The left lung had been for eighteen months in a semi-osseous or
+      cartilaginous state, and was, of course, entirely useless for all
+      purposes of vitality. The right, in its upper portion, was also
+      partially, if not thoroughly, ossified, while the lower region
+      was merely a mass of purulent tubercles, running one into
+      another. Several extensive perforations existed; and, at one
+      point, permanent adhesion to the ribs had taken place. These
+      appearances in the right lobe were of comparatively recent date.
+      The ossification had proceeded with very unusual rapidity; no
+      sign of it had been discovered a month before, and the adhesion
+      had only been observed during the three previous days.
+      Independently of the phthisis, the patient was suspected of
+      aneurism of the aorta; but on this point the osseous symptoms
+      rendered an exact diagnosis impossible. It was the opinion of
+      both physicians that M. Valdemar would die about midnight on the
+      morrow (Sunday). It was then seven o’clock on Saturday evening.
+
+      On quitting the invalid’s bed-side to hold conversation with
+      myself, Doctors D—— and F—— had bidden him a final farewell. It
+      had not been their intention to return; but, at my request, they
+      agreed to look in upon the patient about ten the next night.
+
+      When they had gone, I spoke freely with M. Valdemar on the
+      subject of his approaching dissolution, as well as, more
+      particularly, of the experiment proposed. He still professed
+      himself quite willing and even anxious to have it made, and urged
+      me to commence it at once. A male and a female nurse were in
+      attendance; but I did not feel myself altogether at liberty to
+      engage in a task of this character with no more reliable
+      witnesses than these people, in case of sudden accident, might
+      prove. I therefore postponed operations until about eight the
+      next night, when the arrival of a medical student with whom I had
+      some acquaintance, (Mr. Theodore L—l,) relieved me from farther
+      embarrassment. It had been my design, originally, to wait for the
+      physicians; but I was induced to proceed, first, by the urgent
+      entreaties of M. Valdemar, and secondly, by my conviction that I
+      had not a moment to lose, as he was evidently sinking fast.
+
+      Mr. L—l was so kind as to accede to my desire that he would take
+      notes of all that occurred, and it is from his memoranda that
+      what I now have to relate is, for the most part, either condensed
+      or copied verbatim.
+
+      It wanted about five minutes of eight when, taking the patient’s
+      hand, I begged him to state, as distinctly as he could, to Mr.
+      L—l, whether he (M. Valdemar) was entirely willing that I should
+      make the experiment of mesmerizing him in his then condition.
+
+      He replied feebly, yet quite audibly, “Yes, I wish to be. I fear
+      you have mesmerized”—adding immediately afterwards: “I fear you
+      have deferred it too long.”
+
+      While he spoke thus, I commenced the passes which I had already
+      found most effectual in subduing him. He was evidently influenced
+      with the first lateral stroke of my hand across his forehead; but
+      although I exerted all my powers, no further perceptible effect
+      was induced until some minutes after ten o’clock, when Doctors
+      D—— and F—— called, according to appointment. I explained to
+      them, in a few words, what I designed, and as they opposed no
+      objection, saying that the patient was already in the death
+      agony, I proceeded without hesitation—exchanging, however, the
+      lateral passes for downward ones, and directing my gaze entirely
+      into the right eye of the sufferer.
+
+      By this time his pulse was imperceptible and his breathing was
+      stertorous, and at intervals of half a minute.
+
+      This condition was nearly unaltered for a quarter of an hour. At
+      the expiration of this period, however, a natural although a very
+      deep sigh escaped the bosom of the dying man, and the stertorous
+      breathing ceased—that is to say, its stertorousness was no longer
+      apparent; the intervals were undiminished. The patient’s
+      extremities were of an icy coldness.
+
+      At five minutes before eleven I perceived unequivocal signs of
+      the mesmeric influence. The glassy roll of the eye was changed
+      for that expression of uneasy inward examination which is never
+      seen except in cases of sleep-waking, and which it is quite
+      impossible to mistake. With a few rapid lateral passes I made the
+      lids quiver, as in incipient sleep, and with a few more I closed
+      them altogether. I was not satisfied, however, with this, but
+      continued the manipulations vigorously, and with the fullest
+      exertion of the will, until I had completely stiffened the limbs
+      of the slumberer, after placing them in a seemingly easy
+      position. The legs were at full length; the arms were nearly so,
+      and reposed on the bed at a moderate distance from the loin. The
+      head was very slightly elevated.
+
+      When I had accomplished this, it was fully midnight, and I
+      requested the gentlemen present to examine M. Valdemar’s
+      condition. After a few experiments, they admitted him to be an
+      unusually perfect state of mesmeric trance. The curiosity of both
+      the physicians was greatly excited. Dr. D—— resolved at once to
+      remain with the patient all night, while Dr. F—— took leave with
+      a promise to return at daybreak. Mr. L—l and the nurses remained.
+
+      We left M. Valdemar entirely undisturbed until about three
+      o’clock in the morning, when I approached him and found him in
+      precisely the same condition as when Dr. F—— went away—that is to
+      say, he lay in the same position; the pulse was imperceptible;
+      the breathing was gentle (scarcely noticeable, unless through the
+      application of a mirror to the lips); the eyes were closed
+      naturally; and the limbs were as rigid and as cold as marble.
+      Still, the general appearance was certainly not that of death.
+
+      As I approached M. Valdemar I made a kind of half effort to
+      influence his right arm into pursuit of my own, as I passed the
+      latter gently to and fro above his person. In such experiments
+      with this patient, I had never perfectly succeeded before, and
+      assuredly I had little thought of succeeding now; but to my
+      astonishment, his arm very readily, although feebly, followed
+      every direction I assigned it with mine. I determined to hazard a
+      few words of conversation.
+
+      “M. Valdemar,” I said, “are you asleep?” He made no answer, but I
+      perceived a tremor about the lips, and was thus induced to repeat
+      the question, again and again. At its third repetition, his whole
+      frame was agitated by a very slight shivering; the eyelids
+      unclosed themselves so far as to display a white line of the
+      ball; the lips moved sluggishly, and from between them, in a
+      barely audible whisper, issued the words:
+
+      “Yes;—asleep now. Do not wake me!—let me die so!”
+
+      I here felt the limbs and found them as rigid as ever. The right
+      arm, as before, obeyed the direction of my hand. I questioned the
+      sleep-waker again:
+
+      “Do you still feel pain in the breast, M. Valdemar?”
+
+      The answer now was immediate, but even less audible than before:
+
+      “No pain—I am dying.”
+
+      I did not think it advisable to disturb him farther just then,
+      and nothing more was said or done until the arrival of Dr. F——,
+      who came a little before sunrise, and expressed unbounded
+      astonishment at finding the patient still alive. After feeling
+      the pulse and applying a mirror to the lips, he requested me to
+      speak to the sleep-waker again. I did so, saying:
+
+      “M. Valdemar, do you still sleep?”
+
+      As before, some minutes elapsed ere a reply was made; and during
+      the interval the dying man seemed to be collecting his energies
+      to speak. At my fourth repetition of the question, he said very
+      faintly, almost inaudibly:
+
+      “Yes; still asleep—dying.”
+
+      It was now the opinion, or rather the wish, of the physicians,
+      that M. Valdemar should be suffered to remain undisturbed in his
+      present apparently tranquil condition, until death should
+      supervene—and this, it was generally agreed, must now take place
+      within a few minutes. I concluded, however, to speak to him once
+      more, and merely repeated my previous question.
+
+      While I spoke, there came a marked change over the countenance of
+      the sleep-waker. The eyes rolled themselves slowly open, the
+      pupils disappearing upwardly; the skin generally assumed a
+      cadaverous hue, resembling not so much parchment as white paper;
+      and the circular hectic spots which, hitherto, had been strongly
+      defined in the centre of each cheek, went out at once. I use this
+      expression, because the suddenness of their departure put me in
+      mind of nothing so much as the extinguishment of a candle by a
+      puff of the breath. The upper lip, at the same time, writhed
+      itself away from the teeth, which it had previously covered
+      completely; while the lower jaw fell with an audible jerk,
+      leaving the mouth widely extended, and disclosing in full view
+      the swollen and blackened tongue. I presume that no member of the
+      party then present had been unaccustomed to death-bed horrors;
+      but so hideous beyond conception was the appearance of M.
+      Valdemar at this moment, that there was a general shrinking back
+      from the region of the bed.
+
+      I now feel that I have reached a point of this narrative at which
+      every reader will be startled into positive disbelief. It is my
+      business, however, simply to proceed.
+
+      There was no longer the faintest sign of vitality in M. Valdemar;
+      and concluding him to be dead, we were consigning him to the
+      charge of the nurses, when a strong vibratory motion was
+      observable in the tongue. This continued for perhaps a minute. At
+      the expiration of this period, there issued from the distended
+      and motionless jaws a voice—such as it would be madness in me to
+      attempt describing. There are, indeed, two or three epithets
+      which might be considered as applicable to it in part; I might
+      say, for example, that the sound was harsh, and broken and
+      hollow; but the hideous whole is indescribable, for the simple
+      reason that no similar sounds have ever jarred upon the ear of
+      humanity. There were two particulars, nevertheless, which I
+      thought then, and still think, might fairly be stated as
+      characteristic of the intonation—as well adapted to convey some
+      idea of its unearthly peculiarity. In the first place, the voice
+      seemed to reach our ears—at least mine—from a vast distance, or
+      from some deep cavern within the earth. In the second place, it
+      impressed me (I fear, indeed, that it will be impossible to make
+      myself comprehended) as gelatinous or glutinous matters impress
+      the sense of touch.
+
+      I have spoken both of “sound” and of “voice.” I mean to say that
+      the sound was one of distinct—of even wonderfully, thrillingly
+      distinct—syllabification. M. Valdemar spoke—obviously in reply to
+      the question I had propounded to him a few minutes before. I had
+      asked him, it will be remembered, if he still slept. He now said:
+
+      “Yes;—no;—I have been sleeping—and now—now—I am dead.”
+
+      No person present even affected to deny, or attempted to repress,
+      the unutterable, shuddering horror which these few words, thus
+      uttered, were so well calculated to convey. Mr. L—l (the student)
+      swooned. The nurses immediately left the chamber, and could not
+      be induced to return. My own impressions I would not pretend to
+      render intelligible to the reader. For nearly an hour, we busied
+      ourselves, silently—without the utterance of a word—in endeavors
+      to revive Mr. L—l. When he came to himself, we addressed
+      ourselves again to an investigation of M. Valdemar’s condition.
+
+      It remained in all respects as I have last described it, with the
+      exception that the mirror no longer afforded evidence of
+      respiration. An attempt to draw blood from the arm failed. I
+      should mention, too, that this limb was no farther subject to my
+      will. I endeavored in vain to make it follow the direction of my
+      hand. The only real indication, indeed, of the mesmeric
+      influence, was now found in the vibratory movement of the tongue,
+      whenever I addressed M. Valdemar a question. He seemed to be
+      making an effort to reply, but had no longer sufficient volition.
+      To queries put to him by any other person than myself he seemed
+      utterly insensible—although I endeavored to place each member of
+      the company in mesmeric rapport with him. I believe that I have
+      now related all that is necessary to an understanding of the
+      sleep-waker’s state at this epoch. Other nurses were procured;
+      and at ten o’clock I left the house in company with the two
+      physicians and Mr. L—l.
+
+      In the afternoon we all called again to see the patient. His
+      condition remained precisely the same. We had now some discussion
+      as to the propriety and feasibility of awakening him; but we had
+      little difficulty in agreeing that no good purpose would be
+      served by so doing. It was evident that, so far, death (or what
+      is usually termed death) had been arrested by the mesmeric
+      process. It seemed clear to us all that to awaken M. Valdemar
+      would be merely to insure his instant, or at least his speedy,
+      dissolution.
+
+      From this period until the close of last week—an interval of
+      nearly seven months—we continued to make daily calls at M.
+      Valdemar’s house, accompanied, now and then, by medical and other
+      friends. All this time the sleeper-waker remained _exactly_ as I
+      have last described him. The nurses’ attentions were continual.
+
+      It was on Friday last that we finally resolved to make the
+      experiment of awakening, or attempting to awaken him; and it is
+      the (perhaps) unfortunate result of this latter experiment which
+      has given rise to so much discussion in private circles—to so
+      much of what I cannot help thinking unwarranted popular feeling.
+
+      For the purpose of relieving M. Valdemar from the mesmeric
+      trance, I made use of the customary passes. These, for a time,
+      were unsuccessful. The first indication of revival was afforded
+      by a partial descent of the iris. It was observed, as especially
+      remarkable, that this lowering of the pupil was accompanied by
+      the profuse out-flowing of a yellowish ichor (from beneath the
+      lids) of a pungent and highly offensive odor.
+
+      It was now suggested that I should attempt to influence the
+      patient’s arm, as heretofore. I made the attempt and failed. Dr.
+      F—— then intimated a desire to have me put a question. I did so,
+      as follows:
+
+      “M. Valdemar, can you explain to us what are your feelings or
+      wishes now?”
+
+      There was an instant return of the hectic circles on the cheeks;
+      the tongue quivered, or rather rolled violently in the mouth
+      (although the jaws and lips remained rigid as before), and at
+      length the same hideous voice which I have already described,
+      broke forth:
+
+      “For God’s sake!—quick!—quick!—put me to sleep—or, quick!—waken
+      me!—quick!—I say to you that I am dead!”
+
+      I was thoroughly unnerved, and for an instant remained undecided
+      what to do. At first I made an endeavor to recompose the patient;
+      but, failing in this through total abeyance of the will, I
+      retraced my steps and as earnestly struggled to awaken him. In
+      this attempt I soon saw that I should be successful—or at least I
+      soon fancied that my success would be complete—and I am sure that
+      all in the room were prepared to see the patient awaken.
+
+      For what really occurred, however, it is quite impossible that
+      any human being could have been prepared.
+
+      As I rapidly made the mesmeric passes, amid ejaculations of
+      “dead! dead!” absolutely bursting from the tongue and not from
+      the lips of the sufferer, his whole frame at once—within the
+      space of a single minute, or even less,
+      shrunk—crumbled—absolutely rotted away beneath my hands. Upon the
+      bed, before that whole company, there lay a nearly liquid mass of
+      loathsome—of detestable putrescence.
+
+
+
+
+THE BLACK CAT.
+
+
+      For the most wild, yet most homely narrative which I am about to
+      pen, I neither expect nor solicit belief. Mad indeed would I be
+      to expect it, in a case where my very senses reject their own
+      evidence. Yet, mad am I not—and very surely do I not dream. But
+      to-morrow I die, and to-day I would unburthen my soul. My
+      immediate purpose is to place before the world, plainly,
+      succinctly, and without comment, a series of mere household
+      events. In their consequences, these events have terrified—have
+      tortured—have destroyed me. Yet I will not attempt to expound
+      them. To me, they have presented little but horror—to many they
+      will seem less terrible than _barroques_. Hereafter, perhaps,
+      some intellect may be found which will reduce my phantasm to the
+      common-place—some intellect more calm, more logical, and far less
+      excitable than my own, which will perceive, in the circumstances
+      I detail with awe, nothing more than an ordinary succession of
+      very natural causes and effects.
+
+      From my infancy I was noted for the docility and humanity of my
+      disposition. My tenderness of heart was even so conspicuous as to
+      make me the jest of my companions. I was especially fond of
+      animals, and was indulged by my parents with a great variety of
+      pets. With these I spent most of my time, and never was so happy
+      as when feeding and caressing them. This peculiarity of character
+      grew with my growth, and in my manhood, I derived from it one of
+      my principal sources of pleasure. To those who have cherished an
+      affection for a faithful and sagacious dog, I need hardly be at
+      the trouble of explaining the nature or the intensity of the
+      gratification thus derivable. There is something in the unselfish
+      and self-sacrificing love of a brute, which goes directly to the
+      heart of him who has had frequent occasion to test the paltry
+      friendship and gossamer fidelity of mere _Man_.
+
+      I married early, and was happy to find in my wife a disposition
+      not uncongenial with my own. Observing my partiality for domestic
+      pets, she lost no opportunity of procuring those of the most
+      agreeable kind. We had birds, gold-fish, a fine dog, rabbits, a
+      small monkey, and _a cat_.
+
+      This latter was a remarkably large and beautiful animal, entirely
+      black, and sagacious to an astonishing degree. In speaking of his
+      intelligence, my wife, who at heart was not a little tinctured
+      with superstition, made frequent allusion to the ancient popular
+      notion, which regarded all black cats as witches in disguise. Not
+      that she was ever _serious_ upon this point—and I mention the
+      matter at all for no better reason than that it happens, just
+      now, to be remembered.
+
+      Pluto—this was the cat’s name—was my favorite pet and playmate. I
+      alone fed him, and he attended me wherever I went about the
+      house. It was even with difficulty that I could prevent him from
+      following me through the streets.
+
+      Our friendship lasted, in this manner, for several years, during
+      which my general temperament and character—through the
+      instrumentality of the Fiend Intemperance—had (I blush to confess
+      it) experienced a radical alteration for the worse. I grew, day
+      by day, more moody, more irritable, more regardless of the
+      feelings of others. I suffered myself to use intemperate language
+      to my wife. At length, I even offered her personal violence. My
+      pets, of course, were made to feel the change in my disposition.
+      I not only neglected, but ill-used them. For Pluto, however, I
+      still retained sufficient regard to restrain me from maltreating
+      him, as I made no scruple of maltreating the rabbits, the monkey,
+      or even the dog, when by accident, or through affection, they
+      came in my way. But my disease grew upon me—for what disease is
+      like Alcohol!—and at length even Pluto, who was now becoming old,
+      and consequently somewhat peevish—even Pluto began to experience
+      the effects of my ill temper.
+
+      One night, returning home, much intoxicated, from one of my
+      haunts about town, I fancied that the cat avoided my presence. I
+      seized him; when, in his fright at my violence, he inflicted a
+      slight wound upon my hand with his teeth. The fury of a demon
+      instantly possessed me. I knew myself no longer. My original soul
+      seemed, at once, to take its flight from my body and a more than
+      fiendish malevolence, gin-nurtured, thrilled every fibre of my
+      frame. I took from my waistcoat-pocket a pen-knife, opened it,
+      grasped the poor beast by the throat, and deliberately cut one of
+      its eyes from the socket! I blush, I burn, I shudder, while I pen
+      the damnable atrocity.
+
+      When reason returned with the morning—when I had slept off the
+      fumes of the night’s debauch—I experienced a sentiment half of
+      horror, half of remorse, for the crime of which I had been
+      guilty; but it was, at best, a feeble and equivocal feeling, and
+      the soul remained untouched. I again plunged into excess, and
+      soon drowned in wine all memory of the deed.
+
+      In the meantime the cat slowly recovered. The socket of the lost
+      eye presented, it is true, a frightful appearance, but he no
+      longer appeared to suffer any pain. He went about the house as
+      usual, but, as might be expected, fled in extreme terror at my
+      approach. I had so much of my old heart left, as to be at first
+      grieved by this evident dislike on the part of a creature which
+      had once so loved me. But this feeling soon gave place to
+      irritation. And then came, as if to my final and irrevocable
+      overthrow, the spirit of PERVERSENESS. Of this spirit philosophy
+      takes no account. Yet I am not more sure that my soul lives, than
+      I am that perverseness is one of the primitive impulses of the
+      human heart—one of the indivisible primary faculties, or
+      sentiments, which give direction to the character of Man. Who has
+      not, a hundred times, found himself committing a vile or a silly
+      action, for no other reason than because he knows he should not?
+      Have we not a perpetual inclination, in the teeth of our best
+      judgment, to violate that which is _Law_, merely because we
+      understand it to be such? This spirit of perverseness, I say,
+      came to my final overthrow. It was this unfathomable longing of
+      the soul _to vex itself_—to offer violence to its own nature—to
+      do wrong for the wrong’s sake only—that urged me to continue and
+      finally to consummate the injury I had inflicted upon the
+      unoffending brute. One morning, in cool blood, I slipped a noose
+      about its neck and hung it to the limb of a tree;—hung it with
+      the tears streaming from my eyes, and with the bitterest remorse
+      at my heart;—hung it _because_ I knew that it had loved me, and
+      _because_ I felt it had given me no reason of offence;—hung it
+      _because_ I knew that in so doing I was committing a sin—a deadly
+      sin that would so jeopardize my immortal soul as to place it—if
+      such a thing wore possible—even beyond the reach of the infinite
+      mercy of the Most Merciful and Most Terrible God.
+
+      On the night of the day on which this cruel deed was done, I was
+      aroused from sleep by the cry of fire. The curtains of my bed
+      were in flames. The whole house was blazing. It was with great
+      difficulty that my wife, a servant, and myself, made our escape
+      from the conflagration. The destruction was complete. My entire
+      worldly wealth was swallowed up, and I resigned myself
+      thenceforward to despair.
+
+      I am above the weakness of seeking to establish a sequence of
+      cause and effect, between the disaster and the atrocity. But I am
+      detailing a chain of facts—and wish not to leave even a possible
+      link imperfect. On the day succeeding the fire, I visited the
+      ruins. The walls, with one exception, had fallen in. This
+      exception was found in a compartment wall, not very thick, which
+      stood about the middle of the house, and against which had rested
+      the head of my bed. The plastering had here, in great measure,
+      resisted the action of the fire—a fact which I attributed to its
+      having been recently spread. About this wall a dense crowd were
+      collected, and many persons seemed to be examining a particular
+      portion of it with very minute and eager attention. The words
+      “strange!” “singular!” and other similar expressions, excited my
+      curiosity. I approached and saw, as if graven in _bas relief_
+      upon the white surface, the figure of a gigantic _cat_. The
+      impression was given with an accuracy truly marvellous. There was
+      a rope about the animal’s neck.
+
+      When I first beheld this apparition—for I could scarcely regard
+      it as less—my wonder and my terror were extreme. But at length
+      reflection came to my aid. The cat, I remembered, had been hung
+      in a garden adjacent to the house. Upon the alarm of fire, this
+      garden had been immediately filled by the crowd—by some one of
+      whom the animal must have been cut from the tree and thrown,
+      through an open window, into my chamber. This had probably been
+      done with the view of arousing me from sleep. The falling of
+      other walls had compressed the victim of my cruelty into the
+      substance of the freshly-spread plaster; the lime of which, with
+      the flames, and the _ammonia_ from the carcass, had then
+      accomplished the portraiture as I saw it.
+
+      Although I thus readily accounted to my reason, if not altogether
+      to my conscience, for the startling fact just detailed, it did
+      not the less fail to make a deep impression upon my fancy. For
+      months I could not rid myself of the phantasm of the cat; and,
+      during this period, there came back into my spirit a
+      half-sentiment that seemed, but was not, remorse. I went so far
+      as to regret the loss of the animal, and to look about me, among
+      the vile haunts which I now habitually frequented, for another
+      pet of the same species, and of somewhat similar appearance, with
+      which to supply its place.
+
+      One night as I sat, half stupefied, in a den of more than infamy,
+      my attention was suddenly drawn to some black object, reposing
+      upon the head of one of the immense hogsheads of gin, or of rum,
+      which constituted the chief furniture of the apartment. I had
+      been looking steadily at the top of this hogshead for some
+      minutes, and what now caused me surprise was the fact that I had
+      not sooner perceived the object thereupon. I approached it, and
+      touched it with my hand. It was a black cat—a very large
+      one—fully as large as Pluto, and closely resembling him in every
+      respect but one. Pluto had not a white hair upon any portion of
+      his body; but this cat had a large, although indefinite splotch
+      of white, covering nearly the whole region of the breast. Upon my
+      touching him, he immediately arose, purred loudly, rubbed against
+      my hand, and appeared delighted with my notice. This, then, was
+      the very creature of which I was in search. I at once offered to
+      purchase it of the landlord; but this person made no claim to
+      it—knew nothing of it—had never seen it before.
+
+      I continued my caresses, and, when I prepared to go home, the
+      animal evinced a disposition to accompany me. I permitted it to
+      do so; occasionally stooping and patting it as I proceeded. When
+      it reached the house it domesticated itself at once, and became
+      immediately a great favorite with my wife.
+
+      For my own part, I soon found a dislike to it arising within me.
+      This was just the reverse of what I had anticipated; but—I know
+      not how or why it was—its evident fondness for myself rather
+      disgusted and annoyed. By slow degrees, these feelings of disgust
+      and annoyance rose into the bitterness of hatred. I avoided the
+      creature; a certain sense of shame, and the remembrance of my
+      former deed of cruelty, preventing me from physically abusing it.
+      I did not, for some weeks, strike, or otherwise violently ill use
+      it; but gradually—very gradually—I came to look upon it with
+      unutterable loathing, and to flee silently from its odious
+      presence, as from the breath of a pestilence.
+
+      What added, no doubt, to my hatred of the beast, was the
+      discovery, on the morning after I brought it home, that, like
+      Pluto, it also had been deprived of one of its eyes. This
+      circumstance, however, only endeared it to my wife, who, as I
+      have already said, possessed, in a high degree, that humanity of
+      feeling which had once been my distinguishing trait, and the
+      source of many of my simplest and purest pleasures.
+
+      With my aversion to this cat, however, its partiality for myself
+      seemed to increase. It followed my footsteps with a pertinacity
+      which it would be difficult to make the reader comprehend.
+      Whenever I sat, it would crouch beneath my chair, or spring upon
+      my knees, covering me with its loathsome caresses. If I arose to
+      walk it would get between my feet and thus nearly throw me down,
+      or, fastening its long and sharp claws in my dress, clamber, in
+      this manner, to my breast. At such times, although I longed to
+      destroy it with a blow, I was yet withheld from so doing, partly
+      by a memory of my former crime, but chiefly—let me confess it at
+      once—by absolute dread of the beast.
+
+      This dread was not exactly a dread of physical evil—and yet I
+      should be at a loss how otherwise to define it. I am almost
+      ashamed to own—yes, even in this felon’s cell, I am almost
+      ashamed to own—that the terror and horror with which the animal
+      inspired me, had been heightened by one of the merest chimaeras
+      it would be possible to conceive. My wife had called my
+      attention, more than once, to the character of the mark of white
+      hair, of which I have spoken, and which constituted the sole
+      visible difference between the strange beast and the one I had
+      destroyed. The reader will remember that this mark, although
+      large, had been originally very indefinite; but, by slow
+      degrees—degrees nearly imperceptible, and which for a long time
+      my reason struggled to reject as fanciful—it had, at length,
+      assumed a rigorous distinctness of outline. It was now the
+      representation of an object that I shudder to name—and for this,
+      above all, I loathed, and dreaded, and would have rid myself of
+      the monster _had I dared_—it was now, I say, the image of a
+      hideous—of a ghastly thing—of the GALLOWS!—oh, mournful and
+      terrible engine of Horror and of Crime—of Agony and of Death!
+
+      And now was I indeed wretched beyond the wretchedness of mere
+      Humanity. And _a brute beast _—whose fellow I had contemptuously
+      destroyed—_a brute beast_ to work out for _me_—for me a man,
+      fashioned in the image of the High God—so much of insufferable
+      woe! Alas! neither by day nor by night knew I the blessing of
+      rest any more! During the former the creature left me no moment
+      alone, and in the latter I started hourly from dreams of
+      unutterable fear to find the hot breath of _the thing_ upon my
+      face, and its vast weight—an incarnate nightmare that I had no
+      power to shake off—incumbent eternally upon my _heart!_
+
+      Beneath the pressure of torments such as these, the feeble
+      remnant of the good within me succumbed. Evil thoughts became my
+      sole intimates—the darkest and most evil of thoughts. The
+      moodiness of my usual temper increased to hatred of all things
+      and of all mankind; while, from the sudden, frequent, and
+      ungovernable outbursts of a fury to which I now blindly abandoned
+      myself, my uncomplaining wife, alas, was the most usual and the
+      most patient of sufferers.
+
+      One day she accompanied me, upon some household errand, into the
+      cellar of the old building which our poverty compelled us to
+      inhabit. The cat followed me down the steep stairs, and, nearly
+      throwing me headlong, exasperated me to madness. Uplifting an
+      axe, and forgetting, in my wrath, the childish dread which had
+      hitherto stayed my hand, I aimed a blow at the animal which, of
+      course, would have proved instantly fatal had it descended as I
+      wished. But this blow was arrested by the hand of my wife.
+      Goaded, by the interference, into a rage more than demoniacal, I
+      withdrew my arm from her grasp and buried the axe in her brain.
+      She fell dead upon the spot, without a groan.
+
+      This hideous murder accomplished, I set myself forthwith, and
+      with entire deliberation, to the task of concealing the body. I
+      knew that I could not remove it from the house, either by day or
+      by night, without the risk of being observed by the neighbors.
+      Many projects entered my mind. At one period I thought of cutting
+      the corpse into minute fragments, and destroying them by fire. At
+      another, I resolved to dig a grave for it in the floor of the
+      cellar. Again, I deliberated about casting it in the well in the
+      yard—about packing it in a box, as if merchandise, with the usual
+      arrangements, and so getting a porter to take it from the house.
+      Finally I hit upon what I considered a far better expedient than
+      either of these. I determined to wall it up in the cellar—as the
+      monks of the middle ages are recorded to have walled up their
+      victims.
+
+      For a purpose such as this the cellar was well adapted. Its walls
+      were loosely constructed, and had lately been plastered
+      throughout with a rough plaster, which the dampness of the
+      atmosphere had prevented from hardening. Moreover, in one of the
+      walls was a projection, caused by a false chimney, or fireplace,
+      that had been filled up, and made to resemble the red of the
+      cellar. I made no doubt that I could readily displace the bricks
+      at this point, insert the corpse, and wall the whole up as
+      before, so that no eye could detect any thing suspicious. And in
+      this calculation I was not deceived. By means of a crow-bar I
+      easily dislodged the bricks, and, having carefully deposited the
+      body against the inner wall, I propped it in that position,
+      while, with little trouble, I re-laid the whole structure as it
+      originally stood. Having procured mortar, sand, and hair, with
+      every possible precaution, I prepared a plaster which could not
+      be distinguished from the old, and with this I very carefully
+      went over the new brickwork. When I had finished, I felt
+      satisfied that all was right. The wall did not present the
+      slightest appearance of having been disturbed. The rubbish on the
+      floor was picked up with the minutest care. I looked around
+      triumphantly, and said to myself: “Here at least, then, my labor
+      has not been in vain.”
+
+      My next step was to look for the beast which had been the cause
+      of so much wretchedness; for I had, at length, firmly resolved to
+      put it to death. Had I been able to meet with it, at the moment,
+      there could have been no doubt of its fate; but it appeared that
+      the crafty animal had been alarmed at the violence of my previous
+      anger, and forebore to present itself in my present mood. It is
+      impossible to describe, or to imagine, the deep, the blissful
+      sense of relief which the absence of the detested creature
+      occasioned in my bosom. It did not make its appearance during the
+      night; and thus for one night at least, since its introduction
+      into the house, I soundly and tranquilly slept; aye, slept even
+      with the burden of murder upon my soul!
+
+      The second and the third day passed, and still my tormentor came
+      not. Once again I breathed as a freeman. The monster, in terror,
+      had fled the premises forever! I should behold it no more! My
+      happiness was supreme! The guilt of my dark deed disturbed me but
+      little. Some few inquiries had been made, but these had been
+      readily answered. Even a search had been instituted—but of course
+      nothing was to be discovered. I looked upon my future felicity as
+      secured.
+
+      Upon the fourth day of the assassination, a party of the police
+      came, very unexpectedly, into the house, and proceeded again to
+      make rigorous investigation of the premises. Secure, however, in
+      the inscrutability of my place of concealment, I felt no
+      embarrassment whatever. The officers bade me accompany them in
+      their search. They left no nook or corner unexplored. At length,
+      for the third or fourth time, they descended into the cellar. I
+      quivered not in a muscle. My heart beat calmly as that of one who
+      slumbers in innocence. I walked the cellar from end to end. I
+      folded my arms upon my bosom, and roamed easily to and fro. The
+      police were thoroughly satisfied and prepared to depart. The glee
+      at my heart was too strong to be restrained. I burned to say if
+      but one word, by way of triumph, and to render doubly sure their
+      assurance of my guiltlessness.
+
+      “Gentlemen,” I said at last, as the party ascended the steps, “I
+      delight to have allayed your suspicions. I wish you all health,
+      and a little more courtesy. By the bye, gentlemen, this—this is a
+      very well-constructed house.” (In the rabid desire to say
+      something easily, I scarcely knew what I uttered at all.)—“I may
+      say an _excellently_ well-constructed house. These walls—are you
+      going, gentlemen?—these walls are solidly put together;” and
+      here, through the mere phrenzy of bravado, I rapped heavily, with
+      a cane which I held in my hand, upon that very portion of the
+      brick-work behind which stood the corpse of the wife of my bosom.
+
+      But may God shield and deliver me from the fangs of the
+      Arch-Fiend! No sooner had the reverberation of my blows sunk into
+      silence, than I was answered by a voice from within the tomb!—by
+      a cry, at first muffled and broken, like the sobbing of a child,
+      and then quickly swelling into one long, loud, and continuous
+      scream, utterly anomalous and inhuman—a howl—a wailing shriek,
+      half of horror and half of triumph, such as might have arisen
+      only out of hell, conjointly from the throats of the damned in
+      their agony and of the demons that exult in the damnation.
+
+      Of my own thoughts it is folly to speak. Swooning, I staggered to
+      the opposite wall. For one instant the party upon the stairs
+      remained motionless, through extremity of terror and of awe. In
+      the next, a dozen stout arms were toiling at the wall. It fell
+      bodily. The corpse, already greatly decayed and clotted with
+      gore, stood erect before the eyes of the spectators. Upon its
+      head, with red extended mouth and solitary eye of fire, sat the
+      hideous beast whose craft had seduced me into murder, and whose
+      informing voice had consigned me to the hangman. I had walled the
+      monster up within the tomb!
+
+
+
+
+THE FALL OF THE HOUSE OF USHER
+
+
+     Son cœur est un luth suspendu;
+     Sitôt qu’on le touche il résonne..
+
+—_De Béranger_.
+
+      During the whole of a dull, dark, and soundless day in the autumn
+      of the year, when the clouds hung oppressively low in the
+      heavens, I had been passing alone, on horseback, through a
+      singularly dreary tract of country; and at length found myself,
+      as the shades of the evening drew on, within view of the
+      melancholy House of Usher. I know not how it was—but, with the
+      first glimpse of the building, a sense of insufferable gloom
+      pervaded my spirit. I say insufferable; for the feeling was
+      unrelieved by any of that half-pleasurable, because poetic,
+      sentiment, with which the mind usually receives even the sternest
+      natural images of the desolate or terrible. I looked upon the
+      scene before me—upon the mere house, and the simple landscape
+      features of the domain—upon the bleak walls—upon the vacant
+      eye-like windows—upon a few rank sedges—and upon a few white
+      trunks of decayed trees—with an utter depression of soul which I
+      can compare to no earthly sensation more properly than to the
+      after-dream of the reveller upon opium—the bitter lapse into
+      everyday life—the hideous dropping off of the veil. There was an
+      iciness, a sinking, a sickening of the heart—an unredeemed
+      dreariness of thought which no goading of the imagination could
+      torture into aught of the sublime. What was it—I paused to
+      think—what was it that so unnerved me in the contemplation of the
+      House of Usher? It was a mystery all insoluble; nor could I
+      grapple with the shadowy fancies that crowded upon me as I
+      pondered. I was forced to fall back upon the unsatisfactory
+      conclusion, that while, beyond doubt, there _are_ combinations of
+      very simple natural objects which have the power of thus
+      affecting us, still the analysis of this power lies among
+      considerations beyond our depth. It was possible, I reflected,
+      that a mere different arrangement of the particulars of the
+      scene, of the details of the picture, would be sufficient to
+      modify, or perhaps to annihilate its capacity for sorrowful
+      impression; and, acting upon this idea, I reined my horse to the
+      precipitous brink of a black and lurid tarn that lay in unruffled
+      lustre by the dwelling, and gazed down—but with a shudder even
+      more thrilling than before—upon the remodelled and inverted
+      images of the gray sedge, and the ghastly tree-stems, and the
+      vacant and eye-like windows.
+
+      Nevertheless, in this mansion of gloom I now proposed to myself a
+      sojourn of some weeks. Its proprietor, Roderick Usher, had been
+      one of my boon companions in boyhood; but many years had elapsed
+      since our last meeting. A letter, however, had lately reached me
+      in a distant part of the country—a letter from him—which, in its
+      wildly importunate nature, had admitted of no other than a
+      personal reply. The MS. gave evidence of nervous agitation. The
+      writer spoke of acute bodily illness—of a mental disorder which
+      oppressed him—and of an earnest desire to see me, as his best,
+      and indeed his only personal friend, with a view of attempting,
+      by the cheerfulness of my society, some alleviation of his
+      malady. It was the manner in which all this, and much more, was
+      said—it was the apparent _heart_ that went with his request—which
+      allowed me no room for hesitation; and I accordingly obeyed
+      forthwith what I still considered a very singular summons.
+
+      Although, as boys, we had been even intimate associates, yet I
+      really knew little of my friend. His reserve had been always
+      excessive and habitual. I was aware, however, that his very
+      ancient family had been noted, time out of mind, for a peculiar
+      sensibility of temperament, displaying itself, through long ages,
+      in many works of exalted art, and manifested, of late, in
+      repeated deeds of munificent yet unobtrusive charity, as well as
+      in a passionate devotion to the intricacies, perhaps even more
+      than to the orthodox and easily recognisable beauties, of musical
+      science. I had learned, too, the very remarkable fact, that the
+      stem of the Usher race, all time-honored as it was, had put
+      forth, at no period, any enduring branch; in other words, that
+      the entire family lay in the direct line of descent, and had
+      always, with very trifling and very temporary variation, so lain.
+      It was this deficiency, I considered, while running over in
+      thought the perfect keeping of the character of the premises with
+      the accredited character of the people, and while speculating
+      upon the possible influence which the one, in the long lapse of
+      centuries, might have exercised upon the other—it was this
+      deficiency, perhaps, of collateral issue, and the consequent
+      undeviating transmission, from sire to son, of the patrimony with
+      the name, which had, at length, so identified the two as to merge
+      the original title of the estate in the quaint and equivocal
+      appellation of the “House of Usher”—an appellation which seemed
+      to include, in the minds of the peasantry who used it, both the
+      family and the family mansion.
+
+      I have said that the sole effect of my somewhat childish
+      experiment—that of looking down within the tarn—had been to
+      deepen the first singular impression. There can be no doubt that
+      the consciousness of the rapid increase of my superstition—for
+      why should I not so term it?—served mainly to accelerate the
+      increase itself. Such, I have long known, is the paradoxical law
+      of all sentiments having terror as a basis. And it might have
+      been for this reason only, that, when I again uplifted my eyes to
+      the house itself, from its image in the pool, there grew in my
+      mind a strange fancy—a fancy so ridiculous, indeed, that I but
+      mention it to show the vivid force of the sensations which
+      oppressed me. I had so worked upon my imagination as really to
+      believe that about the whole mansion and domain there hung an
+      atmosphere peculiar to themselves and their immediate vicinity—an
+      atmosphere which had no affinity with the air of heaven, but
+      which had reeked up from the decayed trees, and the gray wall,
+      and the silent tarn—a pestilent and mystic vapor, dull, sluggish,
+      faintly discernible, and leaden-hued.
+
+      Shaking off from my spirit what _must_ have been a dream, I
+      scanned more narrowly the real aspect of the building. Its
+      principal feature seemed to be that of an excessive antiquity.
+      The discoloration of ages had been great. Minute fungi overspread
+      the whole exterior, hanging in a fine tangled web-work from the
+      eaves. Yet all this was apart from any extraordinary
+      dilapidation. No portion of the masonry had fallen; and there
+      appeared to be a wild inconsistency between its still perfect
+      adaptation of parts, and the crumbling condition of the
+      individual stones. In this there was much that reminded me of the
+      specious totality of old wood-work which has rotted for long
+      years in some neglected vault, with no disturbance from the
+      breath of the external air. Beyond this indication of extensive
+      decay, however, the fabric gave little token of instability.
+      Perhaps the eye of a scrutinizing observer might have discovered
+      a barely perceptible fissure, which, extending from the roof of
+      the building in front, made its way down the wall in a zigzag
+      direction, until it became lost in the sullen waters of the tarn.
+
+      Noticing these things, I rode over a short causeway to the house.
+      A servant in waiting took my horse, and I entered the Gothic
+      archway of the hall. A valet, of stealthy step, thence conducted
+      me, in silence, through many dark and intricate passages in my
+      progress to the _studio_ of his master. Much that I encountered
+      on the way contributed, I know not how, to heighten the vague
+      sentiments of which I have already spoken. While the objects
+      around me—while the carvings of the ceilings, the sombre
+      tapestries of the walls, the ebon blackness of the floors, and
+      the phantasmagoric armorial trophies which rattled as I strode,
+      were but matters to which, or to such as which, I had been
+      accustomed from my infancy—while I hesitated not to acknowledge
+      how familiar was all this—I still wondered to find how unfamiliar
+      were the fancies which ordinary images were stirring up. On one
+      of the staircases, I met the physician of the family. His
+      countenance, I thought, wore a mingled expression of low cunning
+      and perplexity. He accosted me with trepidation and passed on.
+      The valet now threw open a door and ushered me into the presence
+      of his master.
+
+      The room in which I found myself was very large and lofty. The
+      windows were long, narrow, and pointed, and at so vast a distance
+      from the black oaken floor as to be altogether inaccessible from
+      within. Feeble gleams of encrimsoned light made their way through
+      the trellissed panes, and served to render sufficiently distinct
+      the more prominent objects around; the eye, however, struggled in
+      vain to reach the remoter angles of the chamber, or the recesses
+      of the vaulted and fretted ceiling. Dark draperies hung upon the
+      walls. The general furniture was profuse, comfortless, antique,
+      and tattered. Many books and musical instruments lay scattered
+      about, but failed to give any vitality to the scene. I felt that
+      I breathed an atmosphere of sorrow. An air of stern, deep, and
+      irredeemable gloom hung over and pervaded all.
+
+      Upon my entrance, Usher arose from a sofa on which he had been
+      lying at full length, and greeted me with a vivacious warmth
+      which had much in it, I at first thought, of an overdone
+      cordiality—of the constrained effort of the _ennuyé_ man of the
+      world. A glance, however, at his countenance, convinced me of his
+      perfect sincerity. We sat down; and for some moments, while he
+      spoke not, I gazed upon him with a feeling half of pity, half of
+      awe. Surely, man had never before so terribly altered, in so
+      brief a period, as had Roderick Usher! It was with difficulty
+      that I could bring myself to admit the identity of the wan being
+      before me with the companion of my early boyhood. Yet the
+      character of his face had been at all times remarkable. A
+      cadaverousness of complexion; an eye large, liquid, and luminous
+      beyond comparison; lips somewhat thin and very pallid, but of a
+      surpassingly beautiful curve; a nose of a delicate Hebrew model,
+      but with a breadth of nostril unusual in similar formations; a
+      finely moulded chin, speaking, in its want of prominence, of a
+      want of moral energy; hair of a more than web-like softness and
+      tenuity; these features, with an inordinate expansion above the
+      regions of the temple, made up altogether a countenance not
+      easily to be forgotten. And now in the mere exaggeration of the
+      prevailing character of these features, and of the expression
+      they were wont to convey, lay so much of change that I doubted to
+      whom I spoke. The now ghastly pallor of the skin, and the now
+      miraculous lustre of the eye, above all things startled and even
+      awed me. The silken hair, too, had been suffered to grow all
+      unheeded, and as, in its wild gossamer texture, it floated rather
+      than fell about the face, I could not, even with effort, connect
+      its Arabesque expression with any idea of simple humanity.
+
+      In the manner of my friend I was at once struck with an
+      incoherence—an inconsistency; and I soon found this to arise from
+      a series of feeble and futile struggles to overcome an habitual
+      trepidancy—an excessive nervous agitation. For something of this
+      nature I had indeed been prepared, no less by his letter, than by
+      reminiscences of certain boyish traits, and by conclusions
+      deduced from his peculiar physical conformation and temperament.
+      His action was alternately vivacious and sullen. His voice varied
+      rapidly from a tremulous indecision (when the animal spirits
+      seemed utterly in abeyance) to that species of energetic
+      concision—that abrupt, weighty, unhurried, and hollow-sounding
+      enunciation—that leaden, self-balanced and perfectly modulated
+      guttural utterance, which may be observed in the lost drunkard,
+      or the irreclaimable eater of opium, during the periods of his
+      most intense excitement.
+
+      It was thus that he spoke of the object of my visit, of his
+      earnest desire to see me, and of the solace he expected me to
+      afford him. He entered, at some length, into what he conceived to
+      be the nature of his malady. It was, he said, a constitutional
+      and a family evil, and one for which he despaired to find a
+      remedy—a mere nervous affection, he immediately added, which
+      would undoubtedly soon pass off. It displayed itself in a host of
+      unnatural sensations. Some of these, as he detailed them,
+      interested and bewildered me; although, perhaps, the terms, and
+      the general manner of the narration had their weight. He suffered
+      much from a morbid acuteness of the senses; the most insipid food
+      was alone endurable; he could wear only garments of certain
+      texture; the odors of all flowers were oppressive; his eyes were
+      tortured by even a faint light; and there were but peculiar
+      sounds, and these from stringed instruments, which did not
+      inspire him with horror.
+
+      To an anomalous species of terror I found him a bounden slave. “I
+      shall perish,” said he, “I must perish in this deplorable folly.
+      Thus, thus, and not otherwise, shall I be lost. I dread the
+      events of the future, not in themselves, but in their results. I
+      shudder at the thought of any, even the most trivial, incident,
+      which may operate upon this intolerable agitation of soul. I
+      have, indeed, no abhorrence of danger, except in its absolute
+      effect—in terror. In this unnerved—in this pitiable condition—I
+      feel that the period will sooner or later arrive when I must
+      abandon life and reason together, in some struggle with the grim
+      phantasm, FEAR.”
+
+      I learned, moreover, at intervals, and through broken and
+      equivocal hints, another singular feature of his mental
+      condition. He was enchained by certain superstitious impressions
+      in regard to the dwelling which he tenanted, and whence, for many
+      years, he had never ventured forth—in regard to an influence
+      whose supposititious force was conveyed in terms too shadowy here
+      to be re-stated—an influence which some peculiarities in the mere
+      form and substance of his family mansion, had, by dint of long
+      sufferance, he said, obtained over his spirit—an effect which the
+      _physique_ of the gray walls and turrets, and of the dim tarn
+      into which they all looked down, had, at length, brought about
+      upon the _morale_ of his existence.
+
+      He admitted, however, although with hesitation, that much of the
+      peculiar gloom which thus afflicted him could be traced to a more
+      natural and far more palpable origin—to the severe and
+      long-continued illness—indeed to the evidently approaching
+      dissolution—of a tenderly beloved sister—his sole companion for
+      long years—his last and only relative on earth. “Her decease,” he
+      said, with a bitterness which I can never forget, “would leave
+      him (him the hopeless and the frail) the last of the ancient race
+      of the Ushers.” While he spoke, the lady Madeline (for so was she
+      called) passed slowly through a remote portion of the apartment,
+      and, without having noticed my presence, disappeared. I regarded
+      her with an utter astonishment not unmingled with dread—and yet I
+      found it impossible to account for such feelings. A sensation of
+      stupor oppressed me, as my eyes followed her retreating steps.
+      When a door, at length, closed upon her, my glance sought
+      instinctively and eagerly the countenance of the brother—but he
+      had buried his face in his hands, and I could only perceive that
+      a far more than ordinary wanness had overspread the emaciated
+      fingers through which trickled many passionate tears.
+
+      The disease of the lady Madeline had long baffled the skill of
+      her physicians. A settled apathy, a gradual wasting away of the
+      person, and frequent although transient affections of a partially
+      cataleptical character, were the unusual diagnosis. Hitherto she
+      had steadily borne up against the pressure of her malady, and had
+      not betaken herself finally to bed; but, on the closing in of the
+      evening of my arrival at the house, she succumbed (as her brother
+      told me at night with inexpressible agitation) to the prostrating
+      power of the destroyer; and I learned that the glimpse I had
+      obtained of her person would thus probably be the last I should
+      obtain—that the lady, at least while living, would be seen by me
+      no more.
+
+      For several days ensuing, her name was unmentioned by either
+      Usher or myself; and during this period I was busied in earnest
+      endeavors to alleviate the melancholy of my friend. We painted
+      and read together; or I listened, as if in a dream, to the wild
+      improvisations of his speaking guitar. And thus, as a closer and
+      still closer intimacy admitted me more unreservedly into the
+      recesses of his spirit, the more bitterly did I perceive the
+      futility of all attempt at cheering a mind from which darkness,
+      as if an inherent positive quality, poured forth upon all objects
+      of the moral and physical universe, in one unceasing radiation of
+      gloom.
+
+      I shall ever bear about me a memory of the many solemn hours I
+      thus spent alone with the master of the House of Usher. Yet I
+      should fail in any attempt to convey an idea of the exact
+      character of the studies, or of the occupations, in which he
+      involved me, or led me the way. An excited and highly distempered
+      ideality threw a sulphureous lustre over all. His long improvised
+      dirges will ring forever in my ears. Among other things, I hold
+      painfully in mind a certain singular perversion and amplification
+      of the wild air of the last waltz of Von Weber. From the
+      paintings over which his elaborate fancy brooded, and which grew,
+      touch by touch, into vaguenesses at which I shuddered the more
+      thrillingly, because I shuddered knowing not why—from these
+      paintings (vivid as their images now are before me) I would in
+      vain endeavor to educe more than a small portion which should lie
+      within the compass of merely written words. By the utter
+      simplicity, by the nakedness of his designs, he arrested and
+      overawed attention. If ever mortal painted an idea, that mortal
+      was Roderick Usher. For me at least—in the circumstances then
+      surrounding me—there arose out of the pure abstractions which the
+      hypochondriac contrived to throw upon his canvass, an intensity
+      of intolerable awe, no shadow of which felt I ever yet in the
+      contemplation of the certainly glowing yet too concrete reveries
+      of Fuseli.
+
+      One of the phantasmagoric conceptions of my friend, partaking not
+      so rigidly of the spirit of abstraction, may be shadowed forth,
+      although feebly, in words. A small picture presented the interior
+      of an immensely long and rectangular vault or tunnel, with low
+      walls, smooth, white, and without interruption or device. Certain
+      accessory points of the design served well to convey the idea
+      that this excavation lay at an exceeding depth below the surface
+      of the earth. No outlet was observed in any portion of its vast
+      extent, and no torch, or other artificial source of light was
+      discernible; yet a flood of intense rays rolled throughout, and
+      bathed the whole in a ghastly and inappropriate splendor.
+
+      I have just spoken of that morbid condition of the auditory nerve
+      which rendered all music intolerable to the sufferer, with the
+      exception of certain effects of stringed instruments. It was,
+      perhaps, the narrow limits to which he thus confined himself upon
+      the guitar, which gave birth, in great measure, to the fantastic
+      character of his performances. But the fervid _facility_ of his
+      _impromptus_ could not be so accounted for. They must have been,
+      and were, in the notes, as well as in the words of his wild
+      fantasias (for he not unfrequently accompanied himself with
+      rhymed verbal improvisations), the result of that intense mental
+      collectedness and concentration to which I have previously
+      alluded as observable only in particular moments of the highest
+      artificial excitement. The words of one of these rhapsodies I
+      have easily remembered. I was, perhaps, the more forcibly
+      impressed with it, as he gave it, because, in the under or mystic
+      current of its meaning, I fancied that I perceived, and for the
+      first time, a full consciousness on the part of Usher of the
+      tottering of his lofty reason upon her throne. The verses, which
+      were entitled “The Haunted Palace,” ran very nearly, if not
+      accurately, thus:
+
+                        I.
+     In the greenest of our valleys,
+    By good angels tenanted,
+     Once a fair and stately palace—
+    Radiant palace—reared its head.
+     In the monarch Thought’s dominion—
+    It stood there!
+     Never seraph spread a pinion
+    Over fabric half so fair.
+
+                        II.
+     Banners yellow, glorious, golden,
+    On its roof did float and flow;
+     (This—all this—was in the olden
+    Time long ago)
+     And every gentle air that dallied,
+    In that sweet day,
+     Along the ramparts plumed and pallid,
+    A winged odor went away.
+
+                        III.
+     Wanderers in that happy valley
+    Through two luminous windows saw
+     Spirits moving musically
+    To a lute’s well-tunéd law,
+     Round about a throne, where sitting
+    (Porphyrogene!)
+     In state his glory well befitting,
+    The ruler of the realm was seen.
+
+                        IV.
+     And all with pearl and ruby glowing
+    Was the fair palace door,
+     Through which came flowing, flowing, flowing,
+    And sparkling evermore,
+     A troop of Echoes whose sweet duty
+    Was but to sing,
+     In voices of surpassing beauty,
+    The wit and wisdom of their king.
+
+                        V.
+     But evil things, in robes of sorrow,
+    Assailed the monarch’s high estate;
+     (Ah, let us mourn, for never morrow
+    Shall dawn upon him, desolate!)
+     And, round about his home, the glory
+    That blushed and bloomed
+     Is but a dim-remembered story
+    Of the old time entombed.
+
+                        VI.
+     And travellers now within that valley,
+    Through the red-litten windows, see
+     Vast forms that move fantastically
+    To a discordant melody;
+     While, like a rapid ghastly river,
+    Through the pale door,
+     A hideous throng rush out forever,
+    And laugh—but smile no more.
+
+      I well remember that suggestions arising from this ballad, led us
+      into a train of thought wherein there became manifest an opinion
+      of Usher’s which I mention not so much on account of its novelty,
+      (for other men * have thought thus,) as on account of the
+      pertinacity with which he maintained it. This opinion, in its
+      general form, was that of the sentience of all vegetable things.
+      But, in his disordered fancy, the idea had assumed a more daring
+      character, and trespassed, under certain conditions, upon the
+      kingdom of inorganization. I lack words to express the full
+      extent, or the earnest _abandon_ of his persuasion. The belief,
+      however, was connected (as I have previously hinted) with the
+      gray stones of the home of his forefathers. The conditions of the
+      sentience had been here, he imagined, fulfilled in the method of
+      collocation of these stones—in the order of their arrangement, as
+      well as in that of the many _fungi_ which overspread them, and of
+      the decayed trees which stood around—above all, in the long
+      undisturbed endurance of this arrangement, and in its
+      reduplication in the still waters of the tarn. Its evidence—the
+      evidence of the sentience—was to be seen, he said, (and I here
+      started as he spoke,) in the gradual yet certain condensation of
+      an atmosphere of their own about the waters and the walls. The
+      result was discoverable, he added, in that silent, yet
+      importunate and terrible influence which for centuries had
+      moulded the destinies of his family, and which made _him_ what I
+      now saw him—what he was. Such opinions need no comment, and I
+      will make none.
+
+      * Watson, Dr. Percival, Spallanzani, and especially the Bishop of
+      Landaff.—See “Chemical Essays,” vol v.
+
+      Our books—the books which, for years, had formed no small portion
+      of the mental existence of the invalid—were, as might be
+      supposed, in strict keeping with this character of phantasm. We
+      pored together over such works as the Ververt et Chartreuse of
+      Gresset; the Belphegor of Machiavelli; the Heaven and Hell of
+      Swedenborg; the Subterranean Voyage of Nicholas Klimm by Holberg;
+      the Chiromancy of Robert Flud, of Jean D’Indaginé, and of De la
+      Chambre; the Journey into the Blue Distance of Tieck; and the
+      City of the Sun of Campanella. One favorite volume was a small
+      octavo edition of the _Directorium Inquisitorium_, by the
+      Dominican Eymeric de Gironne; and there were passages in
+      Pomponius Mela, about the old African Satyrs and OEgipans, over
+      which Usher would sit dreaming for hours. His chief delight,
+      however, was found in the perusal of an exceedingly rare and
+      curious book in quarto Gothic—the manual of a forgotten
+      church—the _Vigiliae Mortuorum secundum Chorum Ecclesiae
+      Maguntinae_.
+
+      I could not help thinking of the wild ritual of this work, and of
+      its probable influence upon the hypochondriac, when, one evening,
+      having informed me abruptly that the lady Madeline was no more,
+      he stated his intention of preserving her corpse for a fortnight,
+      (previously to its final interment,) in one of the numerous
+      vaults within the main walls of the building. The worldly reason,
+      however, assigned for this singular proceeding, was one which I
+      did not feel at liberty to dispute. The brother had been led to
+      his resolution (so he told me) by consideration of the unusual
+      character of the malady of the deceased, of certain obtrusive and
+      eager inquiries on the part of her medical men, and of the remote
+      and exposed situation of the burial-ground of the family. I will
+      not deny that when I called to mind the sinister countenance of
+      the person whom I met upon the staircase, on the day of my
+      arrival at the house, I had no desire to oppose what I regarded
+      as at best but a harmless, and by no means an unnatural,
+      precaution.
+
+      At the request of Usher, I personally aided him in the
+      arrangements for the temporary entombment. The body having been
+      encoffined, we two alone bore it to its rest. The vault in which
+      we placed it (and which had been so long unopened that our
+      torches, half smothered in its oppressive atmosphere, gave us
+      little opportunity for investigation) was small, damp, and
+      entirely without means of admission for light; lying, at great
+      depth, immediately beneath that portion of the building in which
+      was my own sleeping apartment. It had been used, apparently, in
+      remote feudal times, for the worst purposes of a donjon-keep,
+      and, in later days, as a place of deposit for powder, or some
+      other highly combustible substance, as a portion of its floor,
+      and the whole interior of a long archway through which we reached
+      it, were carefully sheathed with copper. The door, of massive
+      iron, had been, also, similarly protected. Its immense weight
+      caused an unusually sharp grating sound, as it moved upon its
+      hinges.
+
+      Having deposited our mournful burden upon tressels within this
+      region of horror, we partially turned aside the yet unscrewed lid
+      of the coffin, and looked upon the face of the tenant. A striking
+      similitude between the brother and sister now first arrested my
+      attention; and Usher, divining, perhaps, my thoughts, murmured
+      out some few words from which I learned that the deceased and
+      himself had been twins, and that sympathies of a scarcely
+      intelligible nature had always existed between them. Our glances,
+      however, rested not long upon the dead—for we could not regard
+      her unawed. The disease which had thus entombed the lady in the
+      maturity of youth, had left, as usual in all maladies of a
+      strictly cataleptical character, the mockery of a faint blush
+      upon the bosom and the face, and that suspiciously lingering
+      smile upon the lip which is so terrible in death. We replaced and
+      screwed down the lid, and, having secured the door of iron, made
+      our way, with toil, into the scarcely less gloomy apartments of
+      the upper portion of the house.
+
+      And now, some days of bitter grief having elapsed, an observable
+      change came over the features of the mental disorder of my
+      friend. His ordinary manner had vanished. His ordinary
+      occupations were neglected or forgotten. He roamed from chamber
+      to chamber with hurried, unequal, and objectless step. The pallor
+      of his countenance had assumed, if possible, a more ghastly
+      hue—but the luminousness of his eye had utterly gone out. The
+      once occasional huskiness of his tone was heard no more; and a
+      tremulous quaver, as if of extreme terror, habitually
+      characterized his utterance. There were times, indeed, when I
+      thought his unceasingly agitated mind was laboring with some
+      oppressive secret, to divulge which he struggled for the
+      necessary courage. At times, again, I was obliged to resolve all
+      into the mere inexplicable vagaries of madness, for I beheld him
+      gazing upon vacancy for long hours, in an attitude of the
+      profoundest attention, as if listening to some imaginary sound.
+      It was no wonder that his condition terrified—that it infected
+      me. I felt creeping upon me, by slow yet certain degrees, the
+      wild influences of his own fantastic yet impressive
+      superstitions.
+
+      It was, especially, upon retiring to bed late in the night of the
+      seventh or eighth day after the placing of the lady Madeline
+      within the donjon, that I experienced the full power of such
+      feelings. Sleep came not near my couch—while the hours waned and
+      waned away. I struggled to reason off the nervousness which had
+      dominion over me. I endeavored to believe that much, if not all
+      of what I felt, was due to the bewildering influence of the
+      gloomy furniture of the room—of the dark and tattered draperies,
+      which, tortured into motion by the breath of a rising tempest,
+      swayed fitfully to and fro upon the walls, and rustled uneasily
+      about the decorations of the bed. But my efforts were fruitless.
+      An irrepressible tremor gradually pervaded my frame; and, at
+      length, there sat upon my very heart an incubus of utterly
+      causeless alarm. Shaking this off with a gasp and a struggle, I
+      uplifted myself upon the pillows, and, peering earnestly within
+      the intense darkness of the chamber, harkened—I know not why,
+      except that an instinctive spirit prompted me—to certain low and
+      indefinite sounds which came, through the pauses of the storm, at
+      long intervals, I knew not whence. Overpowered by an intense
+      sentiment of horror, unaccountable yet unendurable, I threw on my
+      clothes with haste (for I felt that I should sleep no more during
+      the night), and endeavored to arouse myself from the pitiable
+      condition into which I had fallen, by pacing rapidly to and fro
+      through the apartment.
+
+      I had taken but few turns in this manner, when a light step on an
+      adjoining staircase arrested my attention. I presently recognised
+      it as that of Usher. In an instant afterward he rapped, with a
+      gentle touch, at my door, and entered, bearing a lamp. His
+      countenance was, as usual, cadaverously wan—but, moreover, there
+      was a species of mad hilarity in his eyes—an evidently restrained
+      _hysteria_ in his whole demeanor. His air appalled me—but
+      anything was preferable to the solitude which I had so long
+      endured, and I even welcomed his presence as a relief.
+
+      “And you have not seen it?” he said abruptly, after having stared
+      about him for some moments in silence—“you have not then seen
+      it?—but, stay! you shall.” Thus speaking, and having carefully
+      shaded his lamp, he hurried to one of the casements, and threw it
+      freely open to the storm.
+
+      The impetuous fury of the entering gust nearly lifted us from our
+      feet. It was, indeed, a tempestuous yet sternly beautiful night,
+      and one wildly singular in its terror and its beauty. A whirlwind
+      had apparently collected its force in our vicinity; for there
+      were frequent and violent alterations in the direction of the
+      wind; and the exceeding density of the clouds (which hung so low
+      as to press upon the turrets of the house) did not prevent our
+      perceiving the life-like velocity with which they flew careering
+      from all points against each other, without passing away into the
+      distance. I say that even their exceeding density did not prevent
+      our perceiving this—yet we had no glimpse of the moon or
+      stars—nor was there any flashing forth of the lightning. But the
+      under surfaces of the huge masses of agitated vapor, as well as
+      all terrestrial objects immediately around us, were glowing in
+      the unnatural light of a faintly luminous and distinctly visible
+      gaseous exhalation which hung about and enshrouded the mansion.
+
+      “You must not—you shall not behold this!” said I, shudderingly,
+      to Usher, as I led him, with a gentle violence, from the window
+      to a seat. “These appearances, which bewilder you, are merely
+      electrical phenomena not uncommon—or it may be that they have
+      their ghastly origin in the rank miasma of the tarn. Let us close
+      this casement;—the air is chilling and dangerous to your frame.
+      Here is one of your favorite romances. I will read, and you shall
+      listen;—and so we will pass away this terrible night together.”
+
+      The antique volume which I had taken up was the “Mad Trist” of
+      Sir Launcelot Canning; but I had called it a favorite of Usher’s
+      more in sad jest than in earnest; for, in truth, there is little
+      in its uncouth and unimaginative prolixity which could have had
+      interest for the lofty and spiritual ideality of my friend. It
+      was, however, the only book immediately at hand; and I indulged a
+      vague hope that the excitement which now agitated the
+      hypochondriac, might find relief (for the history of mental
+      disorder is full of similar anomalies) even in the extremeness of
+      the folly which I should read. Could I have judged, indeed, by
+      the wild overstrained air of vivacity with which he harkened, or
+      apparently harkened, to the words of the tale, I might well have
+      congratulated myself upon the success of my design.
+
+      I had arrived at that well-known portion of the story where
+      Ethelred, the hero of the Trist, having sought in vain for
+      peaceable admission into the dwelling of the hermit, proceeds to
+      make good an entrance by force. Here, it will be remembered, the
+      words of the narrative run thus:
+
+      “And Ethelred, who was by nature of a doughty heart, and who was
+      now mighty withal, on account of the powerfulness of the wine
+      which he had drunken, waited no longer to hold parley with the
+      hermit, who, in sooth, was of an obstinate and maliceful turn,
+      but, feeling the rain upon his shoulders, and fearing the rising
+      of the tempest, uplifted his mace outright, and, with blows, made
+      quickly room in the plankings of the door for his gauntleted
+      hand; and now pulling therewith sturdily, he so cracked, and
+      ripped, and tore all asunder, that the noise of the dry and
+      hollow-sounding wood alarummed and reverberated throughout the
+      forest.”
+
+      At the termination of this sentence I started, and for a moment,
+      paused; for it appeared to me (although I at once concluded that
+      my excited fancy had deceived me)—it appeared to me that, from
+      some very remote portion of the mansion, there came,
+      indistinctly, to my ears, what might have been, in its exact
+      similarity of character, the echo (but a stifled and dull one
+      certainly) of the very cracking and ripping sound which Sir
+      Launcelot had so particularly described. It was, beyond doubt,
+      the coincidence alone which had arrested my attention; for, amid
+      the rattling of the sashes of the casements, and the ordinary
+      commingled noises of the still increasing storm, the sound, in
+      itself, had nothing, surely, which should have interested or
+      disturbed me. I continued the story:
+
+      “But the good champion Ethelred, now entering within the door,
+      was sore enraged and amazed to perceive no signal of the
+      maliceful hermit; but, in the stead thereof, a dragon of a scaly
+      and prodigious demeanor, and of a fiery tongue, which sate in
+      guard before a palace of gold, with a floor of silver; and upon
+      the wall there hung a shield of shining brass with this legend
+      enwritten—
+
+     Who entereth herein, a conqueror hath bin;
+     Who slayeth the dragon, the shield he shall win;
+
+      And Ethelred uplifted his mace, and struck upon the head of the
+      dragon, which fell before him, and gave up his pesty breath, with
+      a shriek so horrid and harsh, and withal so piercing, that
+      Ethelred had fain to close his ears with his hands against the
+      dreadful noise of it, the like whereof was never before heard.”
+
+      Here again I paused abruptly, and now with a feeling of wild
+      amazement—for there could be no doubt whatever that, in this
+      instance, I did actually hear (although from what direction it
+      proceeded I found it impossible to say) a low and apparently
+      distant, but harsh, protracted, and most unusual screaming or
+      grating sound—the exact counterpart of what my fancy had already
+      conjured up for the dragon’s unnatural shriek as described by the
+      romancer.
+
+      Oppressed, as I certainly was, upon the occurrence of this second
+      and most extraordinary coincidence, by a thousand conflicting
+      sensations, in which wonder and extreme terror were predominant,
+      I still retained sufficient presence of mind to avoid exciting,
+      by any observation, the sensitive nervousness of my companion. I
+      was by no means certain that he had noticed the sounds in
+      question; although, assuredly, a strange alteration had, during
+      the last few minutes, taken place in his demeanor. From a
+      position fronting my own, he had gradually brought round his
+      chair, so as to sit with his face to the door of the chamber; and
+      thus I could but partially perceive his features, although I saw
+      that his lips trembled as if he were murmuring inaudibly. His
+      head had dropped upon his breast—yet I knew that he was not
+      asleep, from the wide and rigid opening of the eye as I caught a
+      glance of it in profile. The motion of his body, too, was at
+      variance with this idea—for he rocked from side to side with a
+      gentle yet constant and uniform sway. Having rapidly taken notice
+      of all this, I resumed the narrative of Sir Launcelot, which thus
+      proceeded:
+
+      “And now, the champion, having escaped from the terrible fury of
+      the dragon, bethinking himself of the brazen shield, and of the
+      breaking up of the enchantment which was upon it, removed the
+      carcass from out of the way before him, and approached valorously
+      over the silver pavement of the castle to where the shield was
+      upon the wall; which in sooth tarried not for his full coming,
+      but fell down at his feet upon the silver floor, with a mighty
+      great and terrible ringing sound.”
+
+      No sooner had these syllables passed my lips, than—as if a shield
+      of brass had indeed, at the moment, fallen heavily upon a floor
+      of silver—I became aware of a distinct, hollow, metallic, and
+      clangorous, yet apparently muffled reverberation. Completely
+      unnerved, I leaped to my feet; but the measured rocking movement
+      of Usher was undisturbed. I rushed to the chair in which he sat.
+      His eyes were bent fixedly before him, and throughout his whole
+      countenance there reigned a stony rigidity. But, as I placed my
+      hand upon his shoulder, there came a strong shudder over his
+      whole person; a sickly smile quivered about his lips; and I saw
+      that he spoke in a low, hurried, and gibbering murmur, as if
+      unconscious of my presence. Bending closely over him, I at length
+      drank in the hideous import of his words.
+
+      “Not hear it?—yes, I hear it, and _have_ heard it.
+      Long—long—long—many minutes, many hours, many days, have I heard
+      it—yet I dared not—oh, pity me, miserable wretch that I am!—I
+      dared not—I _dared_ not speak! _We have put her living in the
+      tomb!_ Said I not that my senses were acute? I _now_ tell you
+      that I heard her first feeble movements in the hollow coffin. I
+      heard them—many, many days ago—yet I dared not—_I dared not
+      speak!_ And now—to-night—Ethelred—ha! ha!—the breaking of the
+      hermit’s door, and the death-cry of the dragon, and the clangor
+      of the shield!—say, rather, the rending of her coffin, and the
+      grating of the iron hinges of her prison, and her struggles
+      within the coppered archway of the vault! Oh whither shall I fly?
+      Will she not be here anon? Is she not hurrying to upbraid me for
+      my haste? Have I not heard her footstep on the stair? Do I not
+      distinguish that heavy and horrible beating of her heart?
+      Madman!”—here he sprang furiously to his feet, and shrieked out
+      his syllables, as if in the effort he were giving up his
+      soul—“_Madman! I tell you that she now stands without the door!_”
+
+      As if in the superhuman energy of his utterance there had been
+      found the potency of a spell—the huge antique pannels to which
+      the speaker pointed, threw slowly back, upon the instant, their
+      ponderous and ebony jaws. It was the work of the rushing gust—but
+      then without those doors there _did_ stand the lofty and
+      enshrouded figure of the lady Madeline of Usher. There was blood
+      upon her white robes, and the evidence of some bitter struggle
+      upon every portion of her emaciated frame. For a moment she
+      remained trembling and reeling to and fro upon the
+      threshold—then, with a low moaning cry, fell heavily inward upon
+      the person of her brother, and in her violent and now final
+      death-agonies, bore him to the floor a corpse, and a victim to
+      the terrors he had anticipated.
+
+      From that chamber, and from that mansion, I fled aghast. The
+      storm was still abroad in all its wrath as I found myself
+      crossing the old causeway. Suddenly there shot along the path a
+      wild light, and I turned to see whence a gleam so unusual could
+      have issued; for the vast house and its shadows were alone behind
+      me. The radiance was that of the full, setting, and blood-red
+      moon, which now shone vividly through that once
+      barely-discernible fissure, of which I have before spoken as
+      extending from the roof of the building, in a zigzag direction,
+      to the base. While I gazed, this fissure rapidly widened—there
+      came a fierce breath of the whirlwind—the entire orb of the
+      satellite burst at once upon my sight—my brain reeled as I saw
+      the mighty walls rushing asunder—there was a long tumultuous
+      shouting sound like the voice of a thousand waters—and the deep
+      and dank tarn at my feet closed sullenly and silently over the
+      fragments of the “_House of Usher_.”
+
+
+
+
+SILENCE—A FABLE
+
+
+     “The mountain pinnacles slumber; valleys, crags and caves _are
+     silent_.”
+
+      “Listen to me,” said the Demon as he placed his hand upon my
+      head. “The region of which I speak is a dreary region in Libya,
+      by the borders of the river Zaire. And there is no quiet there,
+      nor silence.
+
+      “The waters of the river have a saffron and sickly hue; and they
+      flow not onwards to the sea, but palpitate forever and forever
+      beneath the red eye of the sun with a tumultuous and convulsive
+      motion. For many miles on either side of the river’s oozy bed is
+      a pale desert of gigantic water-lilies. They sigh one unto the
+      other in that solitude, and stretch towards the heaven their long
+      and ghastly necks, and nod to and fro their everlasting heads.
+      And there is an indistinct murmur which cometh out from among
+      them like the rushing of subterrene water. And they sigh one unto
+      the other.
+
+      “But there is a boundary to their realm—the boundary of the dark,
+      horrible, lofty forest. There, like the waves about the Hebrides,
+      the low underwood is agitated continually. But there is no wind
+      throughout the heaven. And the tall primeval trees rock eternally
+      hither and thither with a crashing and mighty sound. And from
+      their high summits, one by one, drop everlasting dews. And at the
+      roots strange poisonous flowers lie writhing in perturbed
+      slumber. And overhead, with a rustling and loud noise, the gray
+      clouds rush westwardly forever, until they roll, a cataract, over
+      the fiery wall of the horizon. But there is no wind throughout
+      the heaven. And by the shores of the river Zaire there is neither
+      quiet nor silence.
+
+      “It was night, and the rain fell; and falling, it was rain, but,
+      having fallen, it was blood. And I stood in the morass among the
+      tall and the rain fell upon my head—and the lilies sighed one
+      unto the other in the solemnity of their desolation.
+
+      “And, all at once, the moon arose through the thin ghastly mist,
+      and was crimson in color. And mine eyes fell upon a huge gray
+      rock which stood by the shore of the river, and was lighted by
+      the light of the moon. And the rock was gray, and ghastly, and
+      tall,—and the rock was gray. Upon its front were characters
+      engraven in the stone; and I walked through the morass of
+      water-lilies, until I came close unto the shore, that I might
+      read the characters upon the stone. But I could not decypher
+      them. And I was going back into the morass, when the moon shone
+      with a fuller red, and I turned and looked again upon the rock,
+      and upon the characters, and the characters were DESOLATION.
+
+      “And I looked upwards, and there stood a man upon the summit of
+      the rock; and I hid myself among the water-lilies that I might
+      discover the actions of the man. And the man was tall and stately
+      in form, and was wrapped up from his shoulders to his feet in the
+      toga of old Rome. And the outlines of his figure were
+      indistinct—but his features were the features of a deity; for the
+      mantle of the night, and of the mist, and of the moon, and of the
+      dew, had left uncovered the features of his face. And his brow
+      was lofty with thought, and his eye wild with care; and, in the
+      few furrows upon his cheek I read the fables of sorrow, and
+      weariness, and disgust with mankind, and a longing after
+      solitude.
+
+      “And the man sat upon the rock, and leaned his head upon his
+      hand, and looked out upon the desolation. He looked down into the
+      low unquiet shrubbery, and up into the tall primeval trees, and
+      up higher at the rustling heaven, and into the crimson moon. And
+      I lay close within shelter of the lilies, and observed the
+      actions of the man. And the man trembled in the solitude;—but the
+      night waned, and he sat upon the rock.
+
+      “And the man turned his attention from the heaven, and looked out
+      upon the dreary river Zaire, and upon the yellow ghastly waters,
+      and upon the pale legions of the water-lilies. And the man
+      listened to the sighs of the water-lilies, and to the murmur that
+      came up from among them. And I lay close within my covert and
+      observed the actions of the man. And the man trembled in the
+      solitude;—but the night waned and he sat upon the rock.
+
+      “Then I went down into the recesses of the morass, and waded afar
+      in among the wilderness of the lilies, and called unto the
+      hippopotami which dwelt among the fens in the recesses of the
+      morass. And the hippopotami heard my call, and came, with the
+      behemoth, unto the foot of the rock, and roared loudly and
+      fearfully beneath the moon. And I lay close within my covert and
+      observed the actions of the man. And the man trembled in the
+      solitude;—but the night waned and he sat upon the rock.
+
+      “Then I cursed the elements with the curse of tumult; and a
+      frightful tempest gathered in the heaven where, before, there had
+      been no wind. And the heaven became livid with the violence of
+      the tempest—and the rain beat upon the head of the man—and the
+      floods of the river came down—and the river was tormented into
+      foam—and the water-lilies shrieked within their beds—and the
+      forest crumbled before the wind—and the thunder rolled—and the
+      lightning fell—and the rock rocked to its foundation. And I lay
+      close within my covert and observed the actions of the man. And
+      the man trembled in the solitude;—but the night waned and he sat
+      upon the rock.
+
+      “Then I grew angry and cursed, with the curse of silence, the
+      river, and the lilies, and the wind, and the forest, and the
+      heaven, and the thunder, and the sighs of the water-lilies. And
+      they became accursed, and were still. And the moon ceased to
+      totter up its pathway to heaven—and the thunder died away—and the
+      lightning did not flash—and the clouds hung motionless—and the
+      waters sunk to their level and remained—and the trees ceased to
+      rock—and the water-lilies sighed no more—and the murmur was heard
+      no longer from among them, nor any shadow of sound throughout the
+      vast illimitable desert. And I looked upon the characters of the
+      rock, and they were changed; and the characters were SILENCE.
+
+      “And mine eyes fell upon the countenance of the man, and his
+      countenance was wan with terror. And, hurriedly, he raised his
+      head from his hand, and stood forth upon the rock and listened.
+      But there was no voice throughout the vast illimitable desert,
+      and the characters upon the rock were SILENCE. And the man
+      shuddered, and turned his face away, and fled afar off, in haste,
+      so that I beheld him no more.”
+
+      Now there are fine tales in the volumes of the Magi—in the
+      iron-bound, melancholy volumes of the Magi. Therein, I say, are
+      glorious histories of the Heaven, and of the Earth, and of the
+      mighty sea—and of the Genii that over-ruled the sea, and the
+      earth, and the lofty heaven. There was much lore too in the
+      sayings which were said by the Sybils; and holy, holy things were
+      heard of old by the dim leaves that trembled around Dodona—but,
+      as Allah liveth, that fable which the Demon told me as he sat by
+      my side in the shadow of the tomb, I hold to be the most
+      wonderful of all! And as the Demon made an end of his story, he
+      fell back within the cavity of the tomb and laughed. And I could
+      not laugh with the Demon, and he cursed me because I could not
+      laugh. And the lynx which dwelleth forever in the tomb, came out
+      therefrom, and lay down at the feet of the Demon, and looked at
+      him steadily in the face.
+
+
+
+
+THE MASQUE OF THE RED DEATH.
+
+
+      The “Red Death” had long devastated the country. No pestilence
+      had ever been so fatal, or so hideous. Blood was its Avatar and
+      its seal—the redness and the horror of blood. There were sharp
+      pains, and sudden dizziness, and then profuse bleeding at the
+      pores, with dissolution. The scarlet stains upon the body and
+      especially upon the face of the victim, were the pest ban which
+      shut him out from the aid and from the sympathy of his
+      fellow-men. And the whole seizure, progress and termination of
+      the disease, were the incidents of half an hour.
+
+      But the Prince Prospero was happy and dauntless and sagacious.
+      When his dominions were half depopulated, he summoned to his
+      presence a thousand hale and light-hearted friends from among the
+      knights and dames of his court, and with these retired to the
+      deep seclusion of one of his castellated abbeys. This was an
+      extensive and magnificent structure, the creation of the prince’s
+      own eccentric yet august taste. A strong and lofty wall girdled
+      it in. This wall had gates of iron. The courtiers, having
+      entered, brought furnaces and massy hammers and welded the bolts.
+      They resolved to leave means neither of ingress or egress to the
+      sudden impulses of despair or of frenzy from within. The abbey
+      was amply provisioned. With such precautions the courtiers might
+      bid defiance to contagion. The external world could take care of
+      itself. In the meantime it was folly to grieve, or to think. The
+      prince had provided all the appliances of pleasure. There were
+      buffoons, there were improvisatori, there were ballet-dancers,
+      there were musicians, there was Beauty, there was wine. All these
+      and security were within. Without was the “Red Death.”
+
+      It was toward the close of the fifth or sixth month of his
+      seclusion, and while the pestilence raged most furiously abroad,
+      that the Prince Prospero entertained his thousand friends at a
+      masked ball of the most unusual magnificence.
+
+      It was a voluptuous scene, that masquerade. But first let me tell
+      of the rooms in which it was held. There were seven—an imperial
+      suite. In many palaces, however, such suites form a long and
+      straight vista, while the folding doors slide back nearly to the
+      walls on either hand, so that the view of the whole extent is
+      scarcely impeded. Here the case was very different; as might have
+      been expected from the duke’s love of the bizarre. The apartments
+      were so irregularly disposed that the vision embraced but little
+      more than one at a time. There was a sharp turn at every twenty
+      or thirty yards, and at each turn a novel effect. To the right
+      and left, in the middle of each wall, a tall and narrow Gothic
+      window looked out upon a closed corridor which pursued the
+      windings of the suite. These windows were of stained glass whose
+      color varied in accordance with the prevailing hue of the
+      decorations of the chamber into which it opened. That at the
+      eastern extremity was hung, for example, in blue—and vividly blue
+      were its windows. The second chamber was purple in its ornaments
+      and tapestries, and here the panes were purple. The third was
+      green throughout, and so were the casements. The fourth was
+      furnished and lighted with orange—the fifth with white—the sixth
+      with violet. The seventh apartment was closely shrouded in black
+      velvet tapestries that hung all over the ceiling and down the
+      walls, falling in heavy folds upon a carpet of the same material
+      and hue. But in this chamber only, the color of the windows
+      failed to correspond with the decorations. The panes here were
+      scarlet—a deep blood color. Now in no one of the seven apartments
+      was there any lamp or candelabrum, amid the profusion of golden
+      ornaments that lay scattered to and fro or depended from the
+      roof. There was no light of any kind emanating from lamp or
+      candle within the suite of chambers. But in the corridors that
+      followed the suite, there stood, opposite to each window, a heavy
+      tripod, bearing a brazier of fire that projected its rays through
+      the tinted glass and so glaringly illumined the room. And thus
+      were produced a multitude of gaudy and fantastic appearances. But
+      in the western or black chamber the effect of the fire-light that
+      streamed upon the dark hangings through the blood-tinted panes,
+      was ghastly in the extreme, and produced so wild a look upon the
+      countenances of those who entered, that there were few of the
+      company bold enough to set foot within its precincts at all.
+
+      It was in this apartment, also, that there stood against the
+      western wall, a gigantic clock of ebony. Its pendulum swung to
+      and fro with a dull, heavy, monotonous clang; and when the
+      minute-hand made the circuit of the face, and the hour was to be
+      stricken, there came from the brazen lungs of the clock a sound
+      which was clear and loud and deep and exceedingly musical, but of
+      so peculiar a note and emphasis that, at each lapse of an hour,
+      the musicians of the orchestra were constrained to pause,
+      momentarily, in their performance, to hearken to the sound; and
+      thus the waltzers perforce ceased their evolutions; and there was
+      a brief disconcert of the whole gay company; and, while the
+      chimes of the clock yet rang, it was observed that the giddiest
+      grew pale, and the more aged and sedate passed their hands over
+      their brows as if in confused reverie or meditation. But when the
+      echoes had fully ceased, a light laughter at once pervaded the
+      assembly; the musicians looked at each other and smiled as if at
+      their own nervousness and folly, and made whispering vows, each
+      to the other, that the next chiming of the clock should produce
+      in them no similar emotion; and then, after the lapse of sixty
+      minutes (which embrace three thousand and six hundred seconds of
+      the Time that flies), there came yet another chiming of the
+      clock, and then were the same disconcert and tremulousness and
+      meditation as before.
+
+      But, in spite of these things, it was a gay and magnificent
+      revel. The tastes of the duke were peculiar. He had a fine eye
+      for colors and effects. He disregarded the decora of mere
+      fashion. His plans were bold and fiery, and his conceptions
+      glowed with barbaric lustre. There are some who would have
+      thought him mad. His followers felt that he was not. It was
+      necessary to hear and see and touch him to be sure that he was
+      not.
+
+      He had directed, in great part, the moveable embellishments of
+      the seven chambers, upon occasion of this great fête; and it was
+      his own guiding taste which had given character to the
+      masqueraders. Be sure they were grotesque. There were much glare
+      and glitter and piquancy and phantasm—much of what has been since
+      seen in “Hernani.” There were arabesque figures with unsuited
+      limbs and appointments. There were delirious fancies such as the
+      madman fashions. There was much of the beautiful, much of the
+      wanton, much of the bizarre, something of the terrible, and not a
+      little of that which might have excited disgust. To and fro in
+      the seven chambers there stalked, in fact, a multitude of dreams.
+      And these—the dreams—writhed in and about, taking hue from the
+      rooms, and causing the wild music of the orchestra to seem as the
+      echo of their steps. And, anon, there strikes the ebony clock
+      which stands in the hall of the velvet. And then, for a moment,
+      all is still, and all is silent save the voice of the clock. The
+      dreams are stiff-frozen as they stand. But the echoes of the
+      chime die away—they have endured but an instant—and a light,
+      half-subdued laughter floats after them as they depart. And now
+      again the music swells, and the dreams live, and writhe to and
+      fro more merrily than ever, taking hue from the many-tinted
+      windows through which stream the rays from the tripods. But to
+      the chamber which lies most westwardly of the seven, there are
+      now none of the maskers who venture; for the night is waning
+      away; and there flows a ruddier light through the blood-colored
+      panes; and the blackness of the sable drapery appals; and to him
+      whose foot falls upon the sable carpet, there comes from the near
+      clock of ebony a muffled peal more solemnly emphatic than any
+      which reaches their ears who indulge in the more remote gaieties
+      of the other apartments.
+
+      But these other apartments were densely crowded, and in them beat
+      feverishly the heart of life. And the revel went whirlingly on,
+      until at length there commenced the sounding of midnight upon the
+      clock. And then the music ceased, as I have told; and the
+      evolutions of the waltzers were quieted; and there was an uneasy
+      cessation of all things as before. But now there were twelve
+      strokes to be sounded by the bell of the clock; and thus it
+      happened, perhaps, that more of thought crept, with more of time,
+      into the meditations of the thoughtful among those who revelled.
+      And thus, too, it happened, perhaps, that before the last echoes
+      of the last chime had utterly sunk into silence, there were many
+      individuals in the crowd who had found leisure to become aware of
+      the presence of a masked figure which had arrested the attention
+      of no single individual before. And the rumor of this new
+      presence having spread itself whisperingly around, there arose at
+      length from the whole company a buzz, or murmur, expressive of
+      disapprobation and surprise—then, finally, of terror, of horror,
+      and of disgust.
+
+      In an assembly of phantasms such as I have painted, it may well
+      be supposed that no ordinary appearance could have excited such
+      sensation. In truth the masquerade license of the night was
+      nearly unlimited; but the figure in question had out-Heroded
+      Herod, and gone beyond the bounds of even the prince’s indefinite
+      decorum. There are chords in the hearts of the most reckless
+      which cannot be touched without emotion. Even with the utterly
+      lost, to whom life and death are equally jests, there are matters
+      of which no jest can be made. The whole company, indeed, seemed
+      now deeply to feel that in the costume and bearing of the
+      stranger neither wit nor propriety existed. The figure was tall
+      and gaunt, and shrouded from head to foot in the habiliments of
+      the grave. The mask which concealed the visage was made so nearly
+      to resemble the countenance of a stiffened corpse that the
+      closest scrutiny must have had difficulty in detecting the cheat.
+      And yet all this might have been endured, if not approved, by the
+      mad revellers around. But the mummer had gone so far as to assume
+      the type of the Red Death. His vesture was dabbled in blood—and
+      his broad brow, with all the features of the face, was
+      besprinkled with the scarlet horror.
+
+      When the eyes of Prince Prospero fell upon this spectral image
+      (which with a slow and solemn movement, as if more fully to
+      sustain its role, stalked to and fro among the waltzers) he was
+      seen to be convulsed, in the first moment with a strong shudder
+      either of terror or distaste; but, in the next, his brow reddened
+      with rage.
+
+      “Who dares?” he demanded hoarsely of the courtiers who stood near
+      him—“who dares insult us with this blasphemous mockery? Seize him
+      and unmask him—that we may know whom we have to hang at sunrise,
+      from the battlements!”
+
+      It was in the eastern or blue chamber in which stood the Prince
+      Prospero as he uttered these words. They rang throughout the
+      seven rooms loudly and clearly—for the prince was a bold and
+      robust man, and the music had become hushed at the waving of his
+      hand.
+
+      It was in the blue room where stood the prince, with a group of
+      pale courtiers by his side. At first, as he spoke, there was a
+      slight rushing movement of this group in the direction of the
+      intruder, who at the moment was also near at hand, and now, with
+      deliberate and stately step, made closer approach to the speaker.
+      But from a certain nameless awe with which the mad assumptions of
+      the mummer had inspired the whole party, there were found none
+      who put forth hand to seize him; so that, unimpeded, he passed
+      within a yard of the prince’s person; and, while the vast
+      assembly, as if with one impulse, shrank from the centres of the
+      rooms to the walls, he made his way uninterruptedly, but with the
+      same solemn and measured step which had distinguished him from
+      the first, through the blue chamber to the purple—through the
+      purple to the green—through the green to the orange—through this
+      again to the white—and even thence to the violet, ere a decided
+      movement had been made to arrest him. It was then, however, that
+      the Prince Prospero, maddening with rage and the shame of his own
+      momentary cowardice, rushed hurriedly through the six chambers,
+      while none followed him on account of a deadly terror that had
+      seized upon all. He bore aloft a drawn dagger, and had
+      approached, in rapid impetuosity, to within three or four feet of
+      the retreating figure, when the latter, having attained the
+      extremity of the velvet apartment, turned suddenly and confronted
+      his pursuer. There was a sharp cry—and the dagger dropped
+      gleaming upon the sable carpet, upon which, instantly afterwards,
+      fell prostrate in death the Prince Prospero. Then, summoning the
+      wild courage of despair, a throng of the revellers at once threw
+      themselves into the black apartment, and, seizing the mummer,
+      whose tall figure stood erect and motionless within the shadow of
+      the ebony clock, gasped in unutterable horror at finding the
+      grave-cerements and corpse-like mask which they handled with so
+      violent a rudeness, untenanted by any tangible form.
+
+      And now was acknowledged the presence of the Red Death. He had
+      come like a thief in the night. And one by one dropped the
+      revellers in the blood-bedewed halls of their revel, and died
+      each in the despairing posture of his fall. And the life of the
+      ebony clock went out with that of the last of the gay. And the
+      flames of the tripods expired. And Darkness and Decay and the Red
+      Death held illimitable dominion over all.
+
+
+
+
+THE CASK OF AMONTILLADO.
+
+
+      The thousand injuries of Fortunato I had borne as I best could;
+      but when he ventured upon insult, I vowed revenge. You, who so
+      well know the nature of my soul, will not suppose, however, that
+      I gave utterance to a threat. _At length_ I would be avenged;
+      this was a point definitively settled—but the very definitiveness
+      with which it was resolved, precluded the idea of risk. I must
+      not only punish, but punish with impunity. A wrong is unredressed
+      when retribution overtakes its redresser. It is equally
+      unredressed when the avenger fails to make himself felt as such
+      to him who has done the wrong.
+
+      It must be understood, that neither by word nor deed had I given
+      Fortunato cause to doubt my good will. I continued, as was my
+      wont, to smile in his face, and he did not perceive that my smile
+      _now_ was at the thought of his immolation.
+
+      He had a weak point—this Fortunato—although in other regards he
+      was a man to be respected and even feared. He prided himself on
+      his connoisseurship in wine. Few Italians have the true virtuoso
+      spirit. For the most part their enthusiasm is adopted to suit the
+      time and opportunity—to practise imposture upon the British and
+      Austrian _millionaires_. In painting and gemmary, Fortunato, like
+      his countrymen, was a quack—but in the matter of old wines he was
+      sincere. In this respect I did not differ from him materially: I
+      was skilful in the Italian vintages myself, and bought largely
+      whenever I could.
+
+      It was about dusk, one evening during the supreme madness of the
+      carnival season, that I encountered my friend. He accosted me
+      with excessive warmth, for he had been drinking much. The man
+      wore motley. He had on a tight-fitting parti-striped dress, and
+      his head was surmounted by the conical cap and bells. I was so
+      pleased to see him, that I thought I should never have done
+      wringing his hand.
+
+      I said to him: “My dear Fortunato, you are luckily met. How
+      remarkably well you are looking to-day! But I have received a
+      pipe of what passes for Amontillado, and I have my doubts.”
+
+      “How?” said he. “Amontillado? A pipe? Impossible! And in the
+      middle of the carnival!”
+
+      “I have my doubts,” I replied; “and I was silly enough to pay the
+      full Amontillado price without consulting you in the matter. You
+      were not to be found, and I was fearful of losing a bargain.”
+
+      “Amontillado!”
+
+      “I have my doubts.”
+
+      “Amontillado!”
+
+      “And I must satisfy them.”
+
+      “Amontillado!”
+
+      “As you are engaged, I am on my way to Luchesi. If any one has a
+      critical turn, it is he. He will tell me—”
+
+      “Luchesi cannot tell Amontillado from Sherry.”
+
+      “And yet some fools will have it that his taste is a match for
+      your own.”
+
+      “Come, let us go.”
+
+      “Whither?”
+
+      “To your vaults.”
+
+      “My friend, no; I will not impose upon your good nature. I
+      perceive you have an engagement. Luchesi—”
+
+      “I have no engagement;—come.”
+
+      “My friend, no. It is not the engagement, but the severe cold
+      with which I perceive you are afflicted. The vaults are
+      insufferably damp. They are encrusted with nitre.”
+
+      “Let us go, nevertheless. The cold is merely nothing.
+      Amontillado! You have been imposed upon. And as for Luchesi, he
+      cannot distinguish Sherry from Amontillado.”
+
+      Thus speaking, Fortunato possessed himself of my arm. Putting on
+      a mask of black silk, and drawing a _roquelaire_ closely about my
+      person, I suffered him to hurry me to my palazzo.
+
+      There were no attendants at home; they had absconded to make
+      merry in honor of the time. I had told them that I should not
+      return until the morning, and had given them explicit orders not
+      to stir from the house. These orders were sufficient, I well
+      knew, to insure their immediate disappearance, one and all, as
+      soon as my back was turned.
+
+      I took from their sconces two flambeaux, and giving one to
+      Fortunato, bowed him through several suites of rooms to the
+      archway that led into the vaults. I passed down a long and
+      winding staircase, requesting him to be cautious as he followed.
+      We came at length to the foot of the descent, and stood together
+      on the damp ground of the catacombs of the Montresors.
+
+      The gait of my friend was unsteady, and the bells upon his cap
+      jingled as he strode.
+
+      “The pipe,” said he.
+
+      “It is farther on,” said I; “but observe the white web-work which
+      gleams from these cavern walls.”
+
+      He turned towards me, and looked into my eyes with two filmy orbs
+      that distilled the rheum of intoxication.
+
+      “Nitre?” he asked, at length.
+
+      “Nitre,” I replied. “How long have you had that cough?”
+
+      “Ugh! ugh! ugh!—ugh! ugh! ugh!—ugh! ugh! ugh!—ugh! ugh! ugh!—ugh!
+      ugh! ugh!”
+
+      My poor friend found it impossible to reply for many minutes.
+
+      “It is nothing,” he said, at last.
+
+      “Come,” I said, with decision, “we will go back; your health is
+      precious. You are rich, respected, admired, beloved; you are
+      happy, as once I was. You are a man to be missed. For me it is no
+      matter. We will go back; you will be ill, and I cannot be
+      responsible. Besides, there is Luchesi—”
+
+      “Enough,” he said; “the cough is a mere nothing; it will not kill
+      me. I shall not die of a cough.”
+
+      “True—true,” I replied; “and, indeed, I had no intention of
+      alarming you unnecessarily—but you should use all proper caution.
+      A draught of this Medoc will defend us from the damps.”
+
+      Here I knocked off the neck of a bottle which I drew from a long
+      row of its fellows that lay upon the mould.
+
+      “Drink,” I said, presenting him the wine.
+
+      He raised it to his lips with a leer. He paused and nodded to me
+      familiarly, while his bells jingled.
+
+      “I drink,” he said, “to the buried that repose around us.”
+
+      “And I to your long life.”
+
+      He again took my arm, and we proceeded.
+
+      “These vaults,” he said, “are extensive.”
+
+      “The Montresors,” I replied, “were a great and numerous family.”
+
+      “I forget your arms.”
+
+      “A huge human foot d’or, in a field azure; the foot crushes a
+      serpent rampant whose fangs are imbedded in the heel.”
+
+      “And the motto?”
+
+      “_Nemo me impune lacessit_.”
+
+      “Good!” he said.
+
+      The wine sparkled in his eyes and the bells jingled. My own fancy
+      grew warm with the Medoc. We had passed through walls of piled
+      bones, with casks and puncheons intermingling, into the inmost
+      recesses of the catacombs. I paused again, and this time I made
+      bold to seize Fortunato by an arm above the elbow.
+
+      “The nitre!” I said: “see, it increases. It hangs like moss upon
+      the vaults. We are below the river’s bed. The drops of moisture
+      trickle among the bones. Come, we will go back ere it is too
+      late. Your cough—”
+
+      “It is nothing,” he said; “let us go on. But first, another
+      draught of the Medoc.”
+
+      I broke and reached him a flagon of De Grâve. He emptied it at a
+      breath. His eyes flashed with a fierce light. He laughed and
+      threw the bottle upwards with a gesticulation I did not
+      understand.
+
+      I looked at him in surprise. He repeated the movement—a grotesque
+      one.
+
+      “You do not comprehend?” he said.
+
+      “Not I,” I replied.
+
+      “Then you are not of the brotherhood.”
+
+      “How?”
+
+      “You are not of the masons.”
+
+      “Yes, yes,” I said, “yes, yes.”
+
+      “You? Impossible! A mason?”
+
+      “A mason,” I replied.
+
+      “A sign,” he said.
+
+      “It is this,” I answered, producing a trowel from beneath the
+      folds of my _roquelaire_.
+
+      “You jest,” he exclaimed, recoiling a few paces. “But let us
+      proceed to the Amontillado.”
+
+      “Be it so,” I said, replacing the tool beneath the cloak, and
+      again offering him my arm. He leaned upon it heavily. We
+      continued our route in search of the Amontillado. We passed
+      through a range of low arches, descended, passed on, and
+      descending again, arrived at a deep crypt, in which the foulness
+      of the air caused our flambeaux rather to glow than flame.
+
+      At the most remote end of the crypt there appeared another less
+      spacious. Its walls had been lined with human remains, piled to
+      the vault overhead, in the fashion of the great catacombs of
+      Paris. Three sides of this interior crypt were still ornamented
+      in this manner. From the fourth the bones had been thrown down,
+      and lay promiscuously upon the earth, forming at one point a
+      mound of some size. Within the wall thus exposed by the
+      displacing of the bones, we perceived a still interior recess, in
+      depth about four feet, in width three, in height six or seven. It
+      seemed to have been constructed for no especial use in itself,
+      but formed merely the interval between two of the colossal
+      supports of the roof of the catacombs, and was backed by one of
+      their circumscribing walls of solid granite.
+
+      It was in vain that Fortunato, uplifting his dull torch,
+      endeavored to pry into the depths of the recess. Its termination
+      the feeble light did not enable us to see.
+
+      “Proceed,” I said; “herein is the Amontillado. As for Luchesi—”
+
+      “He is an ignoramus,” interrupted my friend, as he stepped
+      unsteadily forward, while I followed immediately at his heels. In
+      an instant he had reached the extremity of the niche, and finding
+      his progress arrested by the rock, stood stupidly bewildered. A
+      moment more and I had fettered him to the granite. In its surface
+      were two iron staples, distant from each other about two feet,
+      horizontally. From one of these depended a short chain, from the
+      other a padlock. Throwing the links about his waist, it was but
+      the work of a few seconds to secure it. He was too much astounded
+      to resist. Withdrawing the key I stepped back from the recess.
+
+      “Pass your hand,” I said, “over the wall; you cannot help feeling
+      the nitre. Indeed it is _very_ damp. Once more let me _implore_
+      you to return. No? Then I must positively leave you. But I must
+      first render you all the little attentions in my power.”
+
+      “The Amontillado!” ejaculated my friend, not yet recovered from
+      his astonishment.
+
+      “True,” I replied; “the Amontillado.”
+
+      As I said these words I busied myself among the pile of bones of
+      which I have before spoken. Throwing them aside, I soon uncovered
+      a quantity of building stone and mortar. With these materials and
+      with the aid of my trowel, I began vigorously to wall up the
+      entrance of the niche.
+
+      I had scarcely laid the first tier of my masonry when I
+      discovered that the intoxication of Fortunato had in a great
+      measure worn off. The earliest indication I had of this was a low
+      moaning cry from the depth of the recess. It was _not_ the cry of
+      a drunken man. There was then a long and obstinate silence. I
+      laid the second tier, and the third, and the fourth; and then I
+      heard the furious vibrations of the chain. The noise lasted for
+      several minutes, during which, that I might hearken to it with
+      the more satisfaction, I ceased my labors and sat down upon the
+      bones. When at last the clanking subsided, I resumed the trowel,
+      and finished without interruption the fifth, the sixth, and the
+      seventh tier. The wall was now nearly upon a level with my
+      breast. I again paused, and holding the flambeaux over the
+      mason-work, threw a few feeble rays upon the figure within.
+
+      A succession of loud and shrill screams, bursting suddenly from
+      the throat of the chained form, seemed to thrust me violently
+      back. For a brief moment I hesitated—I trembled. Unsheathing my
+      rapier, I began to grope with it about the recess; but the
+      thought of an instant reassured me. I placed my hand upon the
+      solid fabric of the catacombs, and felt satisfied. I reapproached
+      the wall. I replied to the yells of him who clamored. I
+      re-echoed—I aided—I surpassed them in volume and in strength. I
+      did this, and the clamorer grew still.
+
+      It was now midnight, and my task was drawing to a close. I had
+      completed the eighth, the ninth, and the tenth tier. I had
+      finished a portion of the last and the eleventh; there remained
+      but a single stone to be fitted and plastered in. I struggled
+      with its weight; I placed it partially in its destined position.
+      But now there came from out the niche a low laugh that erected
+      the hairs upon my head. It was succeeded by a sad voice, which I
+      had difficulty in recognising as that of the noble Fortunato. The
+      voice said—
+
+      “Ha! ha! ha!—he! he!—a very good joke indeed—an excellent jest.
+      We will have many a rich laugh about it at the palazzo—he! he!
+      he!—over our wine—he! he! he!”
+
+      “The Amontillado!” I said.
+
+      “He! he! he!—he! he! he!—yes, the Amontillado. But is it not
+      getting late? Will not they be awaiting us at the palazzo, the
+      Lady Fortunato and the rest? Let us be gone.”
+
+      “Yes,” I said, “let us be gone.”
+
+      “_For the love of God, Montressor!_”
+
+      “Yes,” I said, “for the love of God!”
+
+      But to these words I hearkened in vain for a reply. I grew
+      impatient. I called aloud—
+
+      “Fortunato!”
+
+      No answer. I called again—
+
+      “Fortunato!”
+
+      No answer still. I thrust a torch through the remaining aperture
+      and let it fall within. There came forth in return only a
+      jingling of the bells. My heart grew sick—on account of the
+      dampness of the catacombs. I hastened to make an end of my labor.
+      I forced the last stone into its position; I plastered it up.
+      Against the new masonry I re-erected the old rampart of bones.
+      For the half of a century no mortal has disturbed them. _In pace
+      requiescat!_
+
+
+
+
+THE IMP OF THE PERVERSE
+
+
+      In the consideration of the faculties and impulses—of the prima
+      mobilia of the human soul, the phrenologists have failed to make
+      room for a propensity which, although obviously existing as a
+      radical, primitive, irreducible sentiment, has been equally
+      overlooked by all the moralists who have preceded them. In the
+      pure arrogance of the reason, we have all overlooked it. We have
+      suffered its existence to escape our senses, solely through want
+      of belief—of faith;—whether it be faith in Revelation, or faith
+      in the Kabbala. The idea of it has never occurred to us, simply
+      because of its supererogation. We saw no need of the impulse—for
+      the propensity. We could not perceive its necessity. We could not
+      understand, that is to say, we could not have understood, had the
+      notion of this primum mobile ever obtruded itself;—we could not
+      have understood in what manner it might be made to further the
+      objects of humanity, either temporal or eternal. It cannot be
+      denied that phrenology and, in great measure, all
+      metaphysicianism have been concocted a priori. The intellectual
+      or logical man, rather than the understanding or observant man,
+      set himself to imagine designs—to dictate purposes to God. Having
+      thus fathomed, to his satisfaction, the intentions of Jehovah,
+      out of these intentions he built his innumerable systems of mind.
+      In the matter of phrenology, for example, we first determined,
+      naturally enough, that it was the design of the Deity that man
+      should eat. We then assigned to man an organ of alimentiveness,
+      and this organ is the scourge with which the Deity compels man,
+      will-I nill-I, into eating. Secondly, having settled it to be
+      God’s will that man should continue his species, we discovered an
+      organ of amativeness, forthwith. And so with combativeness, with
+      ideality, with causality, with constructiveness,—so, in short,
+      with every organ, whether representing a propensity, a moral
+      sentiment, or a faculty of the pure intellect. And in these
+      arrangements of the Principia of human action, the Spurzheimites,
+      whether right or wrong, in part, or upon the whole, have but
+      followed, in principle, the footsteps of their predecessors;
+      deducing and establishing every thing from the preconceived
+      destiny of man, and upon the ground of the objects of his
+      Creator.
+
+      It would have been wiser, it would have been safer, to classify
+      (if classify we must) upon the basis of what man usually or
+      occasionally did, and was always occasionally doing, rather than
+      upon the basis of what we took it for granted the Deity intended
+      him to do. If we cannot comprehend God in his visible works, how
+      then in his inconceivable thoughts, that call the works into
+      being? If we cannot understand him in his objective creatures,
+      how then in his substantive moods and phases of creation?
+
+      Induction, _a posteriori_, would have brought phrenology to
+      admit, as an innate and primitive principle of human action, a
+      paradoxical something, which we may call _perverseness_, for want
+      of a more characteristic term. In the sense I intend, it is, in
+      fact, a _mobile_ without motive, a motive not _motivirt_. Through
+      its promptings we act without comprehensible object; or, if this
+      shall be understood as a contradiction in terms, we may so far
+      modify the proposition as to say, that through its promptings we
+      act, for the reason that we should _not_. In theory, no reason
+      can be more unreasonable, but, in fact, there is none more
+      strong. With certain minds, under certain conditions, it becomes
+      absolutely irresistible. I am not more certain that I breathe,
+      than that the assurance of the wrong or error of any action is
+      often the one unconquerable _force_ which impels us, and alone
+      impels us to its prosecution. Nor will this overwhelming tendency
+      to do wrong for the wrong’s sake, admit of analysis, or
+      resolution into ulterior elements. It is a radical, a primitive
+      impulse—elementary. It will be said, I am aware, that when we
+      persist in acts because we feel we should not persist in them,
+      our conduct is but a modification of that which ordinarily
+      springs from the combativeness of phrenology. But a glance will
+      show the fallacy of this idea. The phrenological combativeness
+      has for its essence, the necessity of self-defence. It is our
+      safeguard against injury. Its principle regards our well-being;
+      and thus the desire to be well is excited simultaneously with its
+      development. It follows, that the desire to be well must be
+      excited simultaneously with any principle which shall be merely a
+      modification of combativeness, but in the case of that something
+      which I term perverseness, the desire to be well is not only not
+      aroused, but a strongly antagonistical sentiment exists.
+
+      An appeal to one’s own heart is, after all, the best reply to the
+      sophistry just noticed. No one who trustingly consults and
+      thoroughly questions his own soul, will be disposed to deny the
+      entire radicalness of the propensity in question. It is not more
+      incomprehensible than distinctive. There lives no man who at some
+      period has not been tormented, for example, by an earnest desire
+      to tantalize a listener by circumlocution. The speaker is aware
+      that he displeases; he has every intention to please, he is
+      usually curt, precise, and clear; the most laconic and luminous
+      language is struggling for utterance upon his tongue; it is only
+      with difficulty that he restrains himself from giving it flow; he
+      dreads and deprecates the anger of him whom he addresses; yet,
+      the thought strikes him, that by certain involutions and
+      parentheses this anger may be engendered. That single thought is
+      enough. The impulse increases to a wish, the wish to a desire,
+      the desire to an uncontrollable longing, and the longing (to the
+      deep regret and mortification of the speaker, and in defiance of
+      all consequences) is indulged.
+
+      We have a task before us which must be speedily performed. We
+      know that it will be ruinous to make delay. The most important
+      crisis of our life calls, trumpet-tongued, for immediate energy
+      and action. We glow, we are consumed with eagerness to commence
+      the work, with the anticipation of whose glorious result our
+      whole souls are on fire. It must, it shall be undertaken to-day,
+      and yet we put it off until to-morrow; and why? There is no
+      answer, except that we feel perverse, using the word with no
+      comprehension of the principle. To-morrow arrives, and with it a
+      more impatient anxiety to do our duty, but with this very
+      increase of anxiety arrives, also, a nameless, a positively
+      fearful, because unfathomable, craving for delay. This craving
+      gathers strength as the moments fly. The last hour for action is
+      at hand. We tremble with the violence of the conflict within
+      us,—of the definite with the indefinite—of the substance with the
+      shadow. But, if the contest have proceeded thus far, it is the
+      shadow which prevails,—we struggle in vain. The clock strikes,
+      and is the knell of our welfare. At the same time, it is the
+      chanticleer-note to the ghost that has so long overawed us. It
+      flies—it disappears—we are free. The old energy returns. We will
+      labor now. Alas, it is too late!
+
+      We stand upon the brink of a precipice. We peer into the abyss—we
+      grow sick and dizzy. Our first impulse is to shrink from the
+      danger. Unaccountably we remain. By slow degrees our sickness and
+      dizziness and horror become merged in a cloud of unnamable
+      feeling. By gradations, still more imperceptible, this cloud
+      assumes shape, as did the vapor from the bottle out of which
+      arose the genius in the Arabian Nights. But out of this our cloud
+      upon the precipice’s edge, there grows into palpability, a shape,
+      far more terrible than any genius or any demon of a tale, and yet
+      it is but a thought, although a fearful one, and one which chills
+      the very marrow of our bones with the fierceness of the delight
+      of its horror. It is merely the idea of what would be our
+      sensations during the sweeping precipitancy of a fall from such a
+      height. And this fall—this rushing annihilation—for the very
+      reason that it involves that one most ghastly and loathsome of
+      all the most ghastly and loathsome images of death and suffering
+      which have ever presented themselves to our imagination—for this
+      very cause do we now the most vividly desire it. And because our
+      reason violently deters us from the brink, therefore do we the
+      most impetuously approach it. There is no passion in nature so
+      demoniacally impatient, as that of him who, shuddering upon the
+      edge of a precipice, thus meditates a plunge. To indulge, for a
+      moment, in any attempt at thought, is to be inevitably lost; for
+      reflection but urges us to forbear, and therefore it is, I say,
+      that we cannot. If there be no friendly arm to check us, or if we
+      fail in a sudden effort to prostrate ourselves backward from the
+      abyss, we plunge, and are destroyed.
+
+      Examine these similar actions as we will, we shall find them
+      resulting solely from the spirit of the Perverse. We perpetrate
+      them because we feel that we should not. Beyond or behind this
+      there is no intelligible principle; and we might, indeed, deem
+      this perverseness a direct instigation of the Arch-Fiend, were it
+      not occasionally known to operate in furtherance of good.
+
+      I have said thus much, that in some measure I may answer your
+      question—that I may explain to you why I am here—that I may
+      assign to you something that shall have at least the faint aspect
+      of a cause for my wearing these fetters, and for my tenanting
+      this cell of the condemned. Had I not been thus prolix, you might
+      either have misunderstood me altogether, or, with the rabble,
+      have fancied me mad. As it is, you will easily perceive that I am
+      one of the many uncounted victims of the Imp of the Perverse.
+
+      It is impossible that any deed could have been wrought with a
+      more thorough deliberation. For weeks, for months, I pondered
+      upon the means of the murder. I rejected a thousand schemes,
+      because their accomplishment involved a _chance_ of detection. At
+      length, in reading some French memoirs, I found an account of a
+      nearly fatal illness that occurred to Madame Pilau, through the
+      agency of a candle accidentally poisoned. The idea struck my
+      fancy at once. I knew my victim’s habit of reading in bed. I
+      knew, too, that his apartment was narrow and ill-ventilated. But
+      I need not vex you with impertinent details. I need not describe
+      the easy artifices by which I substituted, in his bed-room
+      candle-stand, a wax-light of my own making for the one which I
+      there found. The next morning he was discovered dead in his bed,
+      and the coroner’s verdict was—“Death by the visitation of God.”
+
+      Having inherited his estate, all went well with me for years. The
+      idea of detection never once entered my brain. Of the remains of
+      the fatal taper I had myself carefully disposed. I had left no
+      shadow of a clew by which it would be possible to convict, or
+      even to suspect me of the crime. It is inconceivable how rich a
+      sentiment of satisfaction arose in my bosom as I reflected upon
+      my absolute security. For a very long period of time I was
+      accustomed to revel in this sentiment. It afforded me more real
+      delight than all the mere worldly advantages accruing from my
+      sin. But there arrived at length an epoch, from which the
+      pleasurable feeling grew, by scarcely perceptible gradations,
+      into a haunting and harassing thought. It harassed because it
+      haunted. I could scarcely get rid of it for an instant. It is
+      quite a common thing to be thus annoyed with the ringing in our
+      ears, or rather in our memories, of the burthen of some ordinary
+      song, or some unimpressive snatches from an opera. Nor will we be
+      the less tormented if the song in itself be good, or the opera
+      air meritorious. In this manner, at last, I would perpetually
+      catch myself pondering upon my security, and repeating, in a low
+      undertone, the phrase, “I am safe.”
+
+      One day, whilst sauntering along the streets, I arrested myself
+      in the act of murmuring, half aloud, these customary syllables.
+      In a fit of petulance, I remodelled them thus: “I am safe—I am
+      safe—yes—if I be not fool enough to make open confession!”
+
+      No sooner had I spoken these words, than I felt an icy chill
+      creep to my heart. I had had some experience in these fits of
+      perversity (whose nature I have been at some trouble to explain),
+      and I remembered well that in no instance I had successfully
+      resisted their attacks. And now my own casual self-suggestion
+      that I might possibly be fool enough to confess the murder of
+      which I had been guilty, confronted me, as if the very ghost of
+      him whom I had murdered—and beckoned me on to death.
+
+      At first, I made an effort to shake off this nightmare of the
+      soul. I walked vigorously—faster—still faster—at length I ran. I
+      felt a maddening desire to shriek aloud. Every succeeding wave of
+      thought overwhelmed me with new terror, for, alas! I well, too
+      well understood that to think, in my situation, was to be lost. I
+      still quickened my pace. I bounded like a madman through the
+      crowded thoroughfares. At length, the populace took the alarm,
+      and pursued me. I felt then the consummation of my fate. Could I
+      have torn out my tongue, I would have done it, but a rough voice
+      resounded in my ears—a rougher grasp seized me by the shoulder. I
+      turned—I gasped for breath. For a moment I experienced all the
+      pangs of suffocation; I became blind, and deaf, and giddy; and
+      then some invisible fiend, I thought, struck me with his broad
+      palm upon the back. The long imprisoned secret burst forth from
+      my soul.
+
+      They say that I spoke with a distinct enunciation, but with
+      marked emphasis and passionate hurry, as if in dread of
+      interruption before concluding the brief but pregnant sentences
+      that consigned me to the hangman and to hell.
+
+      Having related all that was necessary for the fullest judicial
+      conviction, I fell prostrate in a swoon.
+
+      But why shall I say more? To-day I wear these chains, and am
+      _here!_ To-morrow I shall be fetterless!—_but where?_
+
+
+
+
+THE ISLAND OF THE FAY
+
+
+Nullus enim locus sine genio est.—_Servius_.
+
+      “La musique,” says Marmontel, in those “Contes Moraux” (*1) which
+      in all our translations, we have insisted upon calling “Moral
+      Tales,” as if in mockery of their spirit—“la musique est le seul
+      des talents qui jouissent de lui-même; tous les autres veulent
+      des temoins.” He here confounds the pleasure derivable from sweet
+      sounds with the capacity for creating them. No more than any
+      other talent, is that for music susceptible of complete
+      enjoyment, where there is no second party to appreciate its
+      exercise. And it is only in common with other talents that it
+      produces effects which may be fully enjoyed in solitude. The idea
+      which the raconteur has either failed to entertain clearly, or
+      has sacrificed in its expression to his national love of point,
+      is, doubtless, the very tenable one that the higher order of
+      music is the most thoroughly estimated when we are exclusively
+      alone. The proposition, in this form, will be admitted at once by
+      those who love the lyre for its own sake, and for its spiritual
+      uses. But there is one pleasure still within the reach of fallen
+      mortality and perhaps only one—which owes even more than does
+      music to the accessory sentiment of seclusion. I mean the
+      happiness experienced in the contemplation of natural scenery. In
+      truth, the man who would behold aright the glory of God upon
+      earth must in solitude behold that glory. To me, at least, the
+      presence—not of human life only, but of life in any other form
+      than that of the green things which grow upon the soil and are
+      voiceless—is a stain upon the landscape—is at war with the genius
+      of the scene. I love, indeed, to regard the dark valleys, and the
+      gray rocks, and the waters that silently smile, and the forests
+      that sigh in uneasy slumbers, and the proud watchful mountains
+      that look down upon all,—I love to regard these as themselves but
+      the colossal members of one vast animate and sentient whole—a
+      whole whose form (that of the sphere) is the most perfect and
+      most inclusive of all; whose path is among associate planets;
+      whose meek handmaiden is the moon, whose mediate sovereign is the
+      sun; whose life is eternity, whose thought is that of a God;
+      whose enjoyment is knowledge; whose destinies are lost in
+      immensity, whose cognizance of ourselves is akin with our own
+      cognizance of the animalculae which infest the brain—a being
+      which we, in consequence, regard as purely inanimate and material
+      much in the same manner as these animalculae must thus regard us.
+
+      Our telescopes and our mathematical investigations assure us on
+      every hand—notwithstanding the cant of the more ignorant of the
+      priesthood—that space, and therefore that bulk, is an important
+      consideration in the eyes of the Almighty. The cycles in which
+      the stars move are those best adapted for the evolution, without
+      collision, of the greatest possible number of bodies. The forms
+      of those bodies are accurately such as, within a given surface,
+      to include the greatest possible amount of matter;—while the
+      surfaces themselves are so disposed as to accommodate a denser
+      population than could be accommodated on the same surfaces
+      otherwise arranged. Nor is it any argument against bulk being an
+      object with God, that space itself is infinite; for there may be
+      an infinity of matter to fill it. And since we see clearly that
+      the endowment of matter with vitality is a principle—indeed, as
+      far as our judgments extend, the leading principle in the
+      operations of Deity,—it is scarcely logical to imagine it
+      confined to the regions of the minute, where we daily trace it,
+      and not extending to those of the august. As we find cycle within
+      cycle without end,—yet all revolving around one far-distant
+      centre which is the God-head, may we not analogically suppose in
+      the same manner, life within life, the less within the greater,
+      and all within the Spirit Divine? In short, we are madly erring,
+      through self-esteem, in believing man, in either his temporal or
+      future destinies, to be of more moment in the universe than that
+      vast “clod of the valley” which he tills and contemns, and to
+      which he denies a soul for no more profound reason than that he
+      does not behold it in operation. (*2)
+
+      These fancies, and such as these, have always given to my
+      meditations among the mountains and the forests, by the rivers
+      and the ocean, a tinge of what the everyday world would not fail
+      to term fantastic. My wanderings amid such scenes have been many,
+      and far-searching, and often solitary; and the interest with
+      which I have strayed through many a dim, deep valley, or gazed
+      into the reflected Heaven of many a bright lake, has been an
+      interest greatly deepened by the thought that I have strayed and
+      gazed alone. What flippant Frenchman was it who said in allusion
+      to the well-known work of Zimmerman, that, “la solitude est une
+      belle chose; mais il faut quelqu’un pour vous dire que la
+      solitude est une belle chose?” The epigram cannot be gainsayed;
+      but the necessity is a thing that does not exist.
+
+      It was during one of my lonely journeyings, amid a far distant
+      region of mountain locked within mountain, and sad rivers and
+      melancholy tarn writhing or sleeping within all—that I chanced
+      upon a certain rivulet and island. I came upon them suddenly in
+      the leafy June, and threw myself upon the turf, beneath the
+      branches of an unknown odorous shrub, that I might doze as I
+      contemplated the scene. I felt that thus only should I look upon
+      it—such was the character of phantasm which it wore.
+
+      On all sides—save to the west, where the sun was about
+      sinking—arose the verdant walls of the forest. The little river
+      which turned sharply in its course, and was thus immediately lost
+      to sight, seemed to have no exit from its prison, but to be
+      absorbed by the deep green foliage of the trees to the east—while
+      in the opposite quarter (so it appeared to me as I lay at length
+      and glanced upward) there poured down noiselessly and
+      continuously into the valley, a rich golden and crimson waterfall
+      from the sunset fountains of the sky.
+
+      About midway in the short vista which my dreamy vision took in,
+      one small circular island, profusely verdured, reposed upon the
+      bosom of the stream.
+
+      So blended bank and shadow there
+      That each seemed pendulous in air—
+
+      so mirror-like was the glassy water, that it was scarcely
+      possible to say at what point upon the slope of the emerald turf
+      its crystal dominion began.
+
+      My position enabled me to include in a single view both the
+      eastern and western extremities of the islet; and I observed a
+      singularly-marked difference in their aspects. The latter was all
+      one radiant harem of garden beauties. It glowed and blushed
+      beneath the eyes of the slant sunlight, and fairly laughed with
+      flowers. The grass was short, springy, sweet-scented, and
+      asphodel-interspersed. The trees were lithe, mirthful,
+      erect—bright, slender, and graceful,—of Eastern figure and
+      foliage, with bark smooth, glossy, and parti-colored. There
+      seemed a deep sense of life and joy about all; and although no
+      airs blew from out the heavens, yet every thing had motion
+      through the gentle sweepings to and fro of innumerable
+      butterflies, that might have been mistaken for tulips with wings.
+      (*4)
+
+      The other or eastern end of the isle was whelmed in the blackest
+      shade. A sombre, yet beautiful and peaceful gloom here pervaded
+      all things. The trees were dark in color, and mournful in form
+      and attitude, wreathing themselves into sad, solemn, and spectral
+      shapes that conveyed ideas of mortal sorrow and untimely death.
+      The grass wore the deep tint of the cypress, and the heads of its
+      blades hung droopingly, and hither and thither among it were many
+      small unsightly hillocks, low and narrow, and not very long, that
+      had the aspect of graves, but were not; although over and all
+      about them the rue and the rosemary clambered. The shade of the
+      trees fell heavily upon the water, and seemed to bury itself
+      therein, impregnating the depths of the element with darkness. I
+      fancied that each shadow, as the sun descended lower and lower,
+      separated itself sullenly from the trunk that gave it birth, and
+      thus became absorbed by the stream; while other shadows issued
+      momently from the trees, taking the place of their predecessors
+      thus entombed.
+
+      This idea, having once seized upon my fancy, greatly excited it,
+      and I lost myself forthwith in revery. “If ever island were
+      enchanted,” said I to myself, “this is it. This is the haunt of
+      the few gentle Fays who remain from the wreck of the race. Are
+      these green tombs theirs?—or do they yield up their sweet lives
+      as mankind yield up their own? In dying, do they not rather waste
+      away mournfully, rendering unto God, little by little, their
+      existence, as these trees render up shadow after shadow,
+      exhausting their substance unto dissolution? What the wasting
+      tree is to the water that imbibes its shade, growing thus blacker
+      by what it preys upon, may not the life of the Fay be to the
+      death which engulfs it?”
+
+      As I thus mused, with half-shut eyes, while the sun sank rapidly
+      to rest, and eddying currents careered round and round the
+      island, bearing upon their bosom large, dazzling, white flakes of
+      the bark of the sycamore—flakes which, in their multiform
+      positions upon the water, a quick imagination might have
+      converted into anything it pleased—while I thus mused, it
+      appeared to me that the form of one of those very Fays about whom
+      I had been pondering made its way slowly into the darkness from
+      out the light at the western end of the island. She stood erect
+      in a singularly fragile canoe, and urged it with the mere phantom
+      of an oar. While within the influence of the lingering sunbeams,
+      her attitude seemed indicative of joy—but sorrow deformed it as
+      she passed within the shade. Slowly she glided along, and at
+      length rounded the islet and re-entered the region of light. “The
+      revolution which has just been made by the Fay,” continued I,
+      musingly, “is the cycle of the brief year of her life. She has
+      floated through her winter and through her summer. She is a year
+      nearer unto Death; for I did not fail to see that, as she came
+      into the shade, her shadow fell from her, and was swallowed up in
+      the dark water, making its blackness more black.”
+
+      And again the boat appeared and the Fay; but about the attitude
+      of the latter there was more of care and uncertainty and less of
+      elastic joy. She floated again from out the light and into the
+      gloom (which deepened momently) and again her shadow fell from
+      her into the ebony water, and became absorbed into its blackness.
+      And again and again she made the circuit of the island, (while
+      the sun rushed down to his slumbers), and at each issuing into
+      the light there was more sorrow about her person, while it grew
+      feebler and far fainter and more indistinct, and at each passage
+      into the gloom there fell from her a darker shade, which became
+      whelmed in a shadow more black. But at length when the sun had
+      utterly departed, the Fay, now the mere ghost of her former self,
+      went disconsolately with her boat into the region of the ebony
+      flood—and that she issued thence at all I cannot say, for
+      darkness fell over all things and I beheld her magical figure no
+      more.
+
+
+
+
+THE ASSIGNATION
+
+
+     Stay for me there! I will not fail.
+     To meet thee in that hollow vale.
+
+(_Exequy on the death of his wife, by Henry King, Bishop of
+Chichester_.)
+
+      Ill-fated and mysterious man!—bewildered in the brilliancy of
+      thine own imagination, and fallen in the flames of thine own
+      youth! Again in fancy I behold thee! Once more thy form hath
+      risen before me!—not—oh! not as thou art—in the cold valley and
+      shadow—but as thou _shouldst be_—squandering away a life of
+      magnificent meditation in that city of dim visions, thine own
+      Venice—which is a star-beloved Elysium of the sea, and the wide
+      windows of whose Palladian palaces look down with a deep and
+      bitter meaning upon the secrets of her silent waters. Yes! I
+      repeat it—as thou _shouldst be_. There are surely other worlds
+      than this—other thoughts than the thoughts of the multitude—other
+      speculations than the speculations of the sophist. Who then shall
+      call thy conduct into question? who blame thee for thy visionary
+      hours, or denounce those occupations as a wasting away of life,
+      which were but the overflowings of thine everlasting energies?
+
+      It was at Venice, beneath the covered archway there called the
+      _Ponte di Sospiri_, that I met for the third or fourth time the
+      person of whom I speak. It is with a confused recollection that I
+      bring to mind the circumstances of that meeting. Yet I
+      remember—ah! how should I forget?—the deep midnight, the Bridge
+      of Sighs, the beauty of woman, and the Genius of Romance that
+      stalked up and down the narrow canal.
+
+      It was a night of unusual gloom. The great clock of the Piazza
+      had sounded the fifth hour of the Italian evening. The square of
+      the Campanile lay silent and deserted, and the lights in the old
+      Ducal Palace were dying fast away. I was returning home from the
+      Piazetta, by way of the Grand Canal. But as my gondola arrived
+      opposite the mouth of the canal San Marco, a female voice from
+      its recesses broke suddenly upon the night, in one wild,
+      hysterical, and long continued shriek. Startled at the sound, I
+      sprang upon my feet: while the gondolier, letting slip his single
+      oar, lost it in the pitchy darkness beyond a chance of recovery,
+      and we were consequently left to the guidance of the current
+      which here sets from the greater into the smaller channel. Like
+      some huge and sable-feathered condor, we were slowly drifting
+      down towards the Bridge of Sighs, when a thousand flambeaux
+      flashing from the windows, and down the staircases of the Ducal
+      Palace, turned all at once that deep gloom into a livid and
+      preternatural day.
+
+      A child, slipping from the arms of its own mother, had fallen
+      from an upper window of the lofty structure into the deep and dim
+      canal. The quiet waters had closed placidly over their victim;
+      and, although my own gondola was the only one in sight, many a
+      stout swimmer, already in the stream, was seeking in vain upon
+      the surface, the treasure which was to be found, alas! only
+      within the abyss. Upon the broad black marble flagstones at the
+      entrance of the palace, and a few steps above the water, stood a
+      figure which none who then saw can have ever since forgotten. It
+      was the Marchesa Aphrodite—the adoration of all Venice—the gayest
+      of the gay—the most lovely where all were beautiful—but still the
+      young wife of the old and intriguing Mentoni, and the mother of
+      that fair child, her first and only one, who now, deep beneath
+      the murky water, was thinking in bitterness of heart upon her
+      sweet caresses, and exhausting its little life in struggles to
+      call upon her name.
+
+      She stood alone. Her small, bare, and silvery feet gleamed in the
+      black mirror of marble beneath her. Her hair, not as yet more
+      than half loosened for the night from its ball-room array,
+      clustered, amid a shower of diamonds, round and round her
+      classical head, in curls like those of the young hyacinth. A
+      snowy-white and gauze-like drapery seemed to be nearly the sole
+      covering to her delicate form; but the mid-summer and midnight
+      air was hot, sullen, and still, and no motion in the statue-like
+      form itself, stirred even the folds of that raiment of very vapor
+      which hung around it as the heavy marble hangs around the Niobe.
+      Yet—strange to say!—her large lustrous eyes were not turned
+      downwards upon that grave wherein her brightest hope lay
+      buried—but riveted in a widely different direction! The prison of
+      the Old Republic is, I think, the stateliest building in all
+      Venice—but how could that lady gaze so fixedly upon it, when
+      beneath her lay stifling her only child? Yon dark, gloomy niche,
+      too, yawns right opposite her chamber window—what, then, _could_
+      there be in its shadows—in its architecture—in its ivy-wreathed
+      and solemn cornices—that the Marchesa di Mentoni had not wondered
+      at a thousand times before? Nonsense!—Who does not remember that,
+      at such a time as this, the eye, like a shattered mirror,
+      multiplies the images of its sorrow, and sees in innumerable
+      far-off places, the woe which is close at hand?
+
+      Many steps above the Marchesa, and within the arch of the
+      water-gate, stood, in full dress, the Satyr-like figure of
+      Mentoni himself. He was occasionally occupied in thrumming a
+      guitar, and seemed _ennuye_ to the very death, as at intervals he
+      gave directions for the recovery of his child. Stupefied and
+      aghast, I had myself no power to move from the upright position I
+      had assumed upon first hearing the shriek, and must have
+      presented to the eyes of the agitated group a spectral and
+      ominous appearance, as with pale countenance and rigid limbs, I
+      floated down among them in that funereal gondola.
+
+      All efforts proved in vain. Many of the most energetic in the
+      search were relaxing their exertions, and yielding to a gloomy
+      sorrow. There seemed but little hope for the child; (how much
+      less than for the mother!) but now, from the interior of that
+      dark niche which has been already mentioned as forming a part of
+      the Old Republican prison, and as fronting the lattice of the
+      Marchesa, a figure muffled in a cloak, stepped out within reach
+      of the light, and, pausing a moment upon the verge of the giddy
+      descent, plunged headlong into the canal. As, in an instant
+      afterwards, he stood with the still living and breathing child
+      within his grasp, upon the marble flagstones by the side of the
+      Marchesa, his cloak, heavy with the drenching water, became
+      unfastened, and, falling in folds about his feet, discovered to
+      the wonder-stricken spectators the graceful person of a very
+      young man, with the sound of whose name the greater part of
+      Europe was then ringing.
+
+      No word spoke the deliverer. But the Marchesa! She will now
+      receive her child—she will press it to her heart—she will cling
+      to its little form, and smother it with her caresses. Alas!
+      _another’s_ arms have taken it from the stranger—_another’s_ arms
+      have taken it away, and borne it afar off, unnoticed, into the
+      palace! And the Marchesa! Her lip—her beautiful lip trembles;
+      tears are gathering in her eyes—those eyes which, like Pliny’s
+      acanthus, are “soft and almost liquid.” Yes! tears are gathering
+      in those eyes—and see! the entire woman thrills throughout the
+      soul, and the statue has started into life! The pallor of the
+      marble countenance, the swelling of the marble bosom, the very
+      purity of the marble feet, we behold suddenly flushed over with a
+      tide of ungovernable crimson; and a slight shudder quivers about
+      her delicate frame, as a gentle air at Napoli about the rich
+      silver lilies in the grass.
+
+      Why _should_ that lady blush! To this demand there is no
+      answer—except that, having left, in the eager haste and terror of
+      a mother’s heart, the privacy of her own _boudoir_, she has
+      neglected to enthral her tiny feet in their slippers, and utterly
+      forgotten to throw over her Venetian shoulders that drapery which
+      is their due. What other possible reason could there have been
+      for her so blushing?—for the glance of those wild appealing
+      eyes?—for the unusual tumult of that throbbing bosom?—for the
+      convulsive pressure of that trembling hand?—that hand which fell,
+      as Mentoni turned into the palace, accidentally, upon the hand of
+      the stranger. What reason could there have been for the low—the
+      singularly low tone of those unmeaning words which the lady
+      uttered hurriedly in bidding him adieu? “Thou hast conquered,”
+      she said, or the murmurs of the water deceived me; “thou hast
+      conquered—one hour after sunrise—we shall meet—so let it be!”
+
+      The tumult had subsided, the lights had died away within the
+      palace, and the stranger, whom I now recognized, stood alone upon
+      the flags. He shook with inconceivable agitation, and his eye
+      glanced around in search of a gondola. I could not do less than
+      offer him the service of my own; and he accepted the civility.
+      Having obtained an oar at the water-gate, we proceeded together
+      to his residence, while he rapidly recovered his self-possession,
+      and spoke of our former slight acquaintance in terms of great
+      apparent cordiality.
+
+      There are some subjects upon which I take pleasure in being
+      minute. The person of the stranger—let me call him by this title,
+      who to all the world was still a stranger—the person of the
+      stranger is one of these subjects. In height he might have been
+      below rather than above the medium size: although there were
+      moments of intense passion when his frame actually _expanded_ and
+      belied the assertion. The light, almost slender symmetry of his
+      figure, promised more of that ready activity which he evinced at
+      the Bridge of Sighs, than of that Herculean strength which he has
+      been known to wield without an effort, upon occasions of more
+      dangerous emergency. With the mouth and chin of a deity—singular,
+      wild, full, liquid eyes, whose shadows varied from pure hazel to
+      intense and brilliant jet—and a profusion of curling, black hair,
+      from which a forehead of unusual breadth gleamed forth at
+      intervals all light and ivory—his were features than which I have
+      seen none more classically regular, except, perhaps, the marble
+      ones of the Emperor Commodus. Yet his countenance was,
+      nevertheless, one of those which all men have seen at some period
+      of their lives, and have never afterwards seen again. It had no
+      peculiar, it had no settled predominant expression to be fastened
+      upon the memory; a countenance seen and instantly forgotten, but
+      forgotten with a vague and never-ceasing desire of recalling it
+      to mind. Not that the spirit of each rapid passion failed, at any
+      time, to throw its own distinct image upon the mirror of that
+      face—but that the mirror, mirror-like, retained no vestige of the
+      passion, when the passion had departed.
+
+      Upon leaving him on the night of our adventure, he solicited me,
+      in what I thought an urgent manner, to call upon him _very_ early
+      the next morning. Shortly after sunrise, I found myself
+      accordingly at his Palazzo, one of those huge structures of
+      gloomy, yet fantastic pomp, which tower above the waters of the
+      Grand Canal in the vicinity of the Rialto. I was shown up a broad
+      winding staircase of mosaics, into an apartment whose
+      unparalleled splendor burst through the opening door with an
+      actual glare, making me blind and dizzy with luxuriousness.
+
+      I knew my acquaintance to be wealthy. Report had spoken of his
+      possessions in terms which I had even ventured to call terms of
+      ridiculous exaggeration. But as I gazed about me, I could not
+      bring myself to believe that the wealth of any subject in Europe
+      could have supplied the princely magnificence which burned and
+      blazed around.
+
+      Although, as I say, the sun had arisen, yet the room was still
+      brilliantly lighted up. I judge from this circumstance, as well
+      as from an air of exhaustion in the countenance of my friend,
+      that he had not retired to bed during the whole of the preceding
+      night. In the architecture and embellishments of the chamber, the
+      evident design had been to dazzle and astound. Little attention
+      had been paid to the _decora_ of what is technically called
+      _keeping_, or to the proprieties of nationality. The eye wandered
+      from object to object, and rested upon none—neither the
+      _grotesques_ of the Greek painters, nor the sculptures of the
+      best Italian days, nor the huge carvings of untutored Egypt. Rich
+      draperies in every part of the room trembled to the vibration of
+      low, melancholy music, whose origin was not to be discovered. The
+      senses were oppressed by mingled and conflicting perfumes,
+      reeking up from strange convolute censers, together with
+      multitudinous flaring and flickering tongues of emerald and
+      violet fire. The rays of the newly risen sun poured in upon the
+      whole, through windows, formed each of a single pane of
+      crimson-tinted glass. Glancing to and fro, in a thousand
+      reflections, from curtains which rolled from their cornices like
+      cataracts of molten silver, the beams of natural glory mingled at
+      length fitfully with the artificial light, and lay weltering in
+      subdued masses upon a carpet of rich, liquid-looking cloth of
+      Chili gold.
+
+      “Ha! ha! ha!—ha! ha! ha!”—laughed the proprietor, motioning me to
+      a seat as I entered the room, and throwing himself back at
+      full-length upon an ottoman. “I see,” said he, perceiving that I
+      could not immediately reconcile myself to the _bienseance_ of so
+      singular a welcome—“I see you are astonished at my apartment—at
+      my statues—my pictures—my originality of conception in
+      architecture and upholstery! absolutely drunk, eh, with my
+      magnificence? But pardon me, my dear sir, (here his tone of voice
+      dropped to the very spirit of cordiality,) pardon me for my
+      uncharitable laughter. You appeared so _utterly_ astonished.
+      Besides, some things are so completely ludicrous, that a man
+      _must_ laugh or die. To die laughing, must be the most glorious
+      of all glorious deaths! Sir Thomas More—a very fine man was Sir
+      Thomas More—Sir Thomas More died laughing, you remember. Also in
+      the _Absurdities_ of Ravisius Textor, there is a long list of
+      characters who came to the same magnificent end. Do you know,
+      however,” continued he musingly, “that at Sparta (which is now
+      Palæochori,) at Sparta, I say, to the west of the citadel, among
+      a chaos of scarcely visible ruins, is a kind of _socle_, upon
+      which are still legible the letters ΛΑΞΜ. They are undoubtedly
+      part of ΓΕΛΑΞΜΑ. Now, at Sparta were a thousand temples and
+      shrines to a thousand different divinities. How exceedingly
+      strange that the altar of Laughter should have survived all the
+      others! But in the present instance,” he resumed, with a singular
+      alteration of voice and manner, “I have no right to be merry at
+      your expense. You might well have been amazed. Europe cannot
+      produce anything so fine as this, my little regal cabinet. My
+      other apartments are by no means of the same order—mere _ultras_
+      of fashionable insipidity. This is better than fashion—is it not?
+      Yet this has but to be seen to become the rage—that is, with
+      those who could afford it at the cost of their entire patrimony.
+      I have guarded, however, against any such profanation. With one
+      exception, you are the only human being besides myself and my
+      _valet_, who has been admitted within the mysteries of these
+      imperial precincts, since they have been bedizened as you see!”
+
+      I bowed in acknowledgment—for the overpowering sense of splendor
+      and perfume, and music, together with the unexpected eccentricity
+      of his address and manner, prevented me from expressing, in
+      words, my appreciation of what I might have construed into a
+      compliment.
+
+      “Here,” he resumed, arising and leaning on my arm as he sauntered
+      around the apartment, “here are paintings from the Greeks to
+      Cimabue, and from Cimabue to the present hour. Many are chosen,
+      as you see, with little deference to the opinions of Virtu. They
+      are all, however, fitting tapestry for a chamber such as this.
+      Here, too, are some _chefs d’oeuvre_ of the unknown great; and
+      here, unfinished designs by men, celebrated in their day, whose
+      very names the perspicacity of the academies has left to silence
+      and to me. What think you,” said he, turning abruptly as he
+      spoke—“what think you of this Madonna della Pieta?”
+
+      “It is Guido’s own!” I said, with all the enthusiasm of my
+      nature, for I had been poring intently over its surpassing
+      loveliness. “It is Guido’s own!—how _could_ you have obtained
+      it?—she is undoubtedly in painting what the Venus is in
+      sculpture.”
+
+      “Ha!” said he thoughtfully, “the Venus—the beautiful Venus?—the
+      Venus of the Medici?—she of the diminutive head and the gilded
+      hair? Part of the left arm (here his voice dropped so as to be
+      heard with difficulty,) and all the right, are restorations; and
+      in the coquetry of that right arm lies, I think, the quintessence
+      of all affectation. Give _me_ the Canova! The Apollo, too, is a
+      copy—there can be no doubt of it—blind fool that I am, who cannot
+      behold the boasted inspiration of the Apollo! I cannot help—pity
+      me!—I cannot help preferring the Antinous. Was it not Socrates
+      who said that the statuary found his statue in the block of
+      marble? Then Michael Angelo was by no means original in his
+      couplet—
+
+     ‘Non ha l’ottimo artista alcun concetto
+     Che un marmo solo in se non circunscriva.’”
+
+      It has been, or should be remarked, that, in the manner of the
+      true gentleman, we are always aware of a difference from the
+      bearing of the vulgar, without being at once precisely able to
+      determine in what such difference consists. Allowing the remark
+      to have applied in its full force to the outward demeanor of my
+      acquaintance, I felt it, on that eventful morning, still more
+      fully applicable to his moral temperament and character. Nor can
+      I better define that peculiarity of spirit which seemed to place
+      him so essentially apart from all other human beings, than by
+      calling it a _habit_ of intense and continual thought, pervading
+      even his most trivial actions—intruding upon his moments of
+      dalliance—and interweaving itself with his very flashes of
+      merriment—like adders which writhe from out the eyes of the
+      grinning masks in the cornices around the temples of Persepolis.
+
+      I could not help, however, repeatedly observing, through the
+      mingled tone of levity and solemnity with which he rapidly
+      descanted upon matters of little importance, a certain air of
+      trepidation—a degree of nervous _unction_ in action and in
+      speech—an unquiet excitability of manner which appeared to me at
+      all times unaccountable, and upon some occasions even filled me
+      with alarm. Frequently, too, pausing in the middle of a sentence
+      whose commencement he had apparently forgotten, he seemed to be
+      listening in the deepest attention, as if either in momentary
+      expectation of a visitor, or to sounds which must have had
+      existence in his imagination alone.
+
+      It was during one of these reveries or pauses of apparent
+      abstraction, that, in turning over a page of the poet and scholar
+      Politian’s beautiful tragedy “The Orfeo,” (the first native
+      Italian tragedy,) which lay near me upon an ottoman, I discovered
+      a passage underlined in pencil. It was a passage towards the end
+      of the third act—a passage of the most heart-stirring
+      excitement—a passage which, although tainted with impurity, no
+      man shall read without a thrill of novel emotion—no woman without
+      a sigh. The whole page was blotted with fresh tears; and, upon
+      the opposite interleaf, were the following English lines, written
+      in a hand so very different from the peculiar characters of my
+      acquaintance, that I had some difficulty in recognising it as his
+      own:—
+
+Thou wast that all to me, love,
+    For which my soul did pine—
+A green isle in the sea, love,
+    A fountain and a shrine,
+All wreathed with fairy fruits and flowers;
+    And all the flowers were mine.
+
+Ah, dream too bright to last!
+    Ah, starry Hope, that didst arise
+But to be overcast!
+    A voice from out the Future cries,
+“Onward!”—but o’er the Past
+    (Dim gulf!) my spirit hovering lies,
+Mute—motionless—aghast!
+
+For alas!  alas!  with me
+    The light of life is o’er.
+“No more—no more—no more,”
+    (Such language holds the solemn sea
+To the sands upon the shore,)
+    Shall bloom the thunder-blasted tree,
+Or the stricken eagle soar!
+
+Now all my hours are trances;
+    And all my nightly dreams
+Are where the dark eye glances,
+    And where thy footstep gleams,
+In what ethereal dances,
+    By what Italian streams.
+
+Alas!  for that accursed time
+    They bore thee o’er the billow,
+From Love to titled age and crime,
+    And an unholy pillow!—
+From me, and from our misty clime,
+    Where weeps the silver willow!
+
+      That these lines were written in English—a language with which I
+      had not believed their author acquainted—afforded me little
+      matter for surprise. I was too well aware of the extent of his
+      acquirements, and of the singular pleasure he took in concealing
+      them from observation, to be astonished at any similar discovery;
+      but the place of date, I must confess, occasioned me no little
+      amazement. It had been originally written _London_, and
+      afterwards carefully overscored—not, however, so effectually as
+      to conceal the word from a scrutinizing eye. I say, this
+      occasioned me no little amazement; for I well remember that, in a
+      former conversation with a friend, I particularly inquired if he
+      had at any time met in London the Marchesa di Mentoni, (who for
+      some years previous to her marriage had resided in that city,)
+      when his answer, if I mistake not, gave me to understand that he
+      had never visited the metropolis of Great Britain. I might as
+      well here mention, that I have more than once heard, (without, of
+      course, giving credit to a report involving so many
+      improbabilities,) that the person of whom I speak, was not only
+      by birth, but in education, an _Englishman_.
+
+“There is one painting,” said he, without being aware of my notice of
+the tragedy—“there is still one painting which you have not seen.” And
+throwing aside a drapery, he discovered a full-length portrait of the
+Marchesa Aphrodite.
+
+Human art could have done no more in the delineation of her superhuman
+beauty. The same ethereal figure which stood before me the preceding
+night upon the steps of the Ducal Palace, stood before me once again.
+But in the expression of the countenance, which was beaming all over
+with smiles, there still lurked (incomprehensible anomaly!) that fitful
+stain of melancholy which will ever be found inseparable from the
+perfection of the beautiful. Her right arm lay folded over her bosom.
+With her left she pointed downward to a curiously fashioned vase. One
+small, fairy foot, alone visible, barely touched the earth; and,
+scarcely discernible in the brilliant atmosphere which seemed to
+encircle and enshrine her loveliness, floated a pair of the most
+delicately imagined wings. My glance fell from the painting to the
+figure of my friend, and the vigorous words of Chapman’s _Bussy
+D’Ambois_, quivered instinctively upon my lips:
+
+    “He is up
+There like a Roman statue!  He will stand
+Till Death hath made him marble!”
+
+      “Come,” he said at length, turning towards a table of richly
+      enamelled and massive silver, upon which were a few goblets
+      fantastically stained, together with two large Etruscan vases,
+      fashioned in the same extraordinary model as that in the
+      foreground of the portrait, and filled with what I supposed to be
+      Johannisberger. “Come,” he said, abruptly, “let us drink! It is
+      early—but let us drink. It is _indeed_ early,” he continued,
+      musingly, as a cherub with a heavy golden hammer made the
+      apartment ring with the first hour after sunrise: “It is _indeed_
+      early—but what matters it? let us drink! Let us pour out an
+      offering to yon solemn sun which these gaudy lamps and censers
+      are so eager to subdue!” And, having made me pledge him in a
+      bumper, he swallowed in rapid succession several goblets of the
+      wine.
+
+      “To dream,” he continued, resuming the tone of his desultory
+      conversation, as he held up to the rich light of a censer one of
+      the magnificent vases—“to dream has been the business of my life.
+      I have therefore framed for myself, as you see, a bower of
+      dreams. In the heart of Venice could I have erected a better? You
+      behold around you, it is true, a medley of architectural
+      embellishments. The chastity of Ionia is offended by antediluvian
+      devices, and the sphynxes of Egypt are outstretched upon carpets
+      of gold. Yet the effect is incongruous to the timid alone.
+      Proprieties of place, and especially of time, are the bugbears
+      which terrify mankind from the contemplation of the magnificent.
+      Once I was myself a decorist; but that sublimation of folly has
+      palled upon my soul. All this is now the fitter for my purpose.
+      Like these arabesque censers, my spirit is writhing in fire, and
+      the delirium of this scene is fashioning me for the wilder
+      visions of that land of real dreams whither I am now rapidly
+      departing.” He here paused abruptly, bent his head to his bosom,
+      and seemed to listen to a sound which I could not hear. At
+      length, erecting his frame, he looked upwards, and ejaculated the
+      lines of the Bishop of Chichester:
+
+     _“Stay for me there!  I will not fail_
+     _To meet thee in that hollow vale.”_
+
+      In the next instant, confessing the power of the wine, he threw
+      himself at full-length upon an ottoman.
+
+      A quick step was now heard upon the staircase, and a loud knock
+      at the door rapidly succeeded. I was hastening to anticipate a
+      second disturbance, when a page of Mentoni’s household burst into
+      the room, and faltered out, in a voice choking with emotion, the
+      incoherent words, “My mistress!—my mistress!—Poisoned!—poisoned!
+      Oh, beautiful—oh, beautiful Aphrodite!”
+
+      Bewildered, I flew to the ottoman, and endeavored to arouse the
+      sleeper to a sense of the startling intelligence. But his limbs
+      were rigid—his lips were livid—his lately beaming eyes were
+      riveted in _death_. I staggered back towards the table—my hand
+      fell upon a cracked and blackened goblet—and a consciousness of
+      the entire and terrible truth flashed suddenly over my soul.
+
+
+
+
+THE PIT AND THE PENDULUM
+
+
+     Impia tortorum longos hic turba furores
+     Sanguinis innocui, non satiata, aluit.
+     Sospite nunc patria, fracto nunc funeris antro,
+     Mors ubi dira fuit vita salusque patent.
+
+[_Quatrain composed for the gates of a market to be erected upon the
+site of the Jacobin Club House at Paris_.]
+
+      I was sick—sick unto death with that long agony; and when they at
+      length unbound me, and I was permitted to sit, I felt that my
+      senses were leaving me. The sentence—the dread sentence of
+      death—was the last of distinct accentuation which reached my
+      ears. After that, the sound of the inquisitorial voices seemed
+      merged in one dreamy indeterminate hum. It conveyed to my soul
+      the idea of _revolution_—perhaps from its association in fancy
+      with the burr of a mill wheel. This only for a brief period, for
+      presently I heard no more. Yet, for a while, I saw—but with how
+      terrible an exaggeration! I saw the lips of the black-robed
+      judges. They appeared to me white—whiter than the sheet upon
+      which I trace these words—and thin even to grotesqueness; thin
+      with the intensity of their expression of firmness—of immoveable
+      resolution—of stern contempt of human torture. I saw that the
+      decrees of what to me was Fate, were still issuing from those
+      lips. I saw them writhe with a deadly locution. I saw them
+      fashion the syllables of my name; and I shuddered because no
+      sound succeeded. I saw, too, for a few moments of delirious
+      horror, the soft and nearly imperceptible waving of the sable
+      draperies which enwrapped the walls of the apartment. And then my
+      vision fell upon the seven tall candles upon the table. At first
+      they wore the aspect of charity, and seemed white and slender
+      angels who would save me; but then, all at once, there came a
+      most deadly nausea over my spirit, and I felt every fibre in my
+      frame thrill as if I had touched the wire of a galvanic battery,
+      while the angel forms became meaningless spectres, with heads of
+      flame, and I saw that from them there would be no help. And then
+      there stole into my fancy, like a rich musical note, the thought
+      of what sweet rest there must be in the grave. The thought came
+      gently and stealthily, and it seemed long before it attained full
+      appreciation; but just as my spirit came at length properly to
+      feel and entertain it, the figures of the judges vanished, as if
+      magically, from before me; the tall candles sank into
+      nothingness; their flames went out utterly; the blackness of
+      darkness supervened; all sensations appeared swallowed up in a
+      mad rushing descent as of the soul into Hades. Then silence, and
+      stillness, night were the universe.
+
+      I had swooned; but still will not say that all of consciousness
+      was lost. What of it there remained I will not attempt to define,
+      or even to describe; yet all was not lost. In the deepest
+      slumber—no! In delirium—no! In a swoon—no! In death—no! even in
+      the grave all is not lost. Else there is no immortality for man.
+      Arousing from the most profound of slumbers, we break the
+      gossamer web of some dream. Yet in a second afterward, (so frail
+      may that web have been) we remember not that we have dreamed. In
+      the return to life from the swoon there are two stages; first,
+      that of the sense of mental or spiritual; secondly, that of the
+      sense of physical, existence. It seems probable that if, upon
+      reaching the second stage, we could recall the impressions of the
+      first, we should find these impressions eloquent in memories of
+      the gulf beyond. And that gulf is—what? How at least shall we
+      distinguish its shadows from those of the tomb? But if the
+      impressions of what I have termed the first stage are not, at
+      will, recalled, yet, after long interval, do they not come
+      unbidden, while we marvel whence they come? He who has never
+      swooned, is not he who finds strange palaces and wildly familiar
+      faces in coals that glow; is not he who beholds floating in
+      mid-air the sad visions that the many may not view; is not he who
+      ponders over the perfume of some novel flower; is not he whose
+      brain grows bewildered with the meaning of some musical cadence
+      which has never before arrested his attention.
+
+      Amid frequent and thoughtful endeavors to remember; amid earnest
+      struggles to regather some token of the state of seeming
+      nothingness into which my soul had lapsed, there have been
+      moments when I have dreamed of success; there have been brief,
+      very brief periods when I have conjured up remembrances which the
+      lucid reason of a later epoch assures me could have had reference
+      only to that condition of seeming unconsciousness. These shadows
+      of memory tell, indistinctly, of tall figures that lifted and
+      bore me in silence down—down—still down—till a hideous dizziness
+      oppressed me at the mere idea of the interminableness of the
+      descent. They tell also of a vague horror at my heart, on account
+      of that heart’s unnatural stillness. Then comes a sense of sudden
+      motionlessness throughout all things; as if those who bore me (a
+      ghastly train!) had outrun, in their descent, the limits of the
+      limitless, and paused from the wearisomeness of their toil. After
+      this I call to mind flatness and dampness; and then all is
+      madness—the madness of a memory which busies itself among
+      forbidden things.
+
+      Very suddenly there came back to my soul motion and sound—the
+      tumultuous motion of the heart, and, in my ears, the sound of its
+      beating. Then a pause in which all is blank. Then again sound,
+      and motion, and touch—a tingling sensation pervading my frame.
+      Then the mere consciousness of existence, without thought—a
+      condition which lasted long. Then, very suddenly, thought, and
+      shuddering terror, and earnest endeavor to comprehend my true
+      state. Then a strong desire to lapse into insensibility. Then a
+      rushing revival of soul and a successful effort to move. And now
+      a full memory of the trial, of the judges, of the sable
+      draperies, of the sentence, of the sickness, of the swoon. Then
+      entire forgetfulness of all that followed; of all that a later
+      day and much earnestness of endeavor have enabled me vaguely to
+      recall.
+
+      So far, I had not opened my eyes. I felt that I lay upon my back,
+      unbound. I reached out my hand, and it fell heavily upon
+      something damp and hard. There I suffered it to remain for many
+      minutes, while I strove to imagine where and what I could be. I
+      longed, yet dared not to employ my vision. I dreaded the first
+      glance at objects around me. It was not that I feared to look
+      upon things horrible, but that I grew aghast lest there should be
+      nothing to see. At length, with a wild desperation at heart, I
+      quickly unclosed my eyes. My worst thoughts, then, were
+      confirmed. The blackness of eternal night encompassed me. I
+      struggled for breath. The intensity of the darkness seemed to
+      oppress and stifle me. The atmosphere was intolerably close. I
+      still lay quietly, and made effort to exercise my reason. I
+      brought to mind the inquisitorial proceedings, and attempted from
+      that point to deduce my real condition. The sentence had passed;
+      and it appeared to me that a very long interval of time had since
+      elapsed. Yet not for a moment did I suppose myself actually dead.
+      Such a supposition, notwithstanding what we read in fiction, is
+      altogether inconsistent with real existence;—but where and in
+      what state was I? The condemned to death, I knew, perished
+      usually at the autos-da-fe, and one of these had been held on the
+      very night of the day of my trial. Had I been remanded to my
+      dungeon, to await the next sacrifice, which would not take place
+      for many months? This I at once saw could not be. Victims had
+      been in immediate demand. Moreover, my dungeon, as well as all
+      the condemned cells at Toledo, had stone floors, and light was
+      not altogether excluded.
+
+      A fearful idea now suddenly drove the blood in torrents upon my
+      heart, and for a brief period, I once more relapsed into
+      insensibility. Upon recovering, I at once started to my feet,
+      trembling convulsively in every fibre. I thrust my arms wildly
+      above and around me in all directions. I felt nothing; yet
+      dreaded to move a step, lest I should be impeded by the walls of
+      a tomb. Perspiration burst from every pore, and stood in cold big
+      beads upon my forehead. The agony of suspense grew at length
+      intolerable, and I cautiously moved forward, with my arms
+      extended, and my eyes straining from their sockets, in the hope
+      of catching some faint ray of light. I proceeded for many paces;
+      but still all was blackness and vacancy. I breathed more freely.
+      It seemed evident that mine was not, at least, the most hideous
+      of fates.
+
+      And now, as I still continued to step cautiously onward, there
+      came thronging upon my recollection a thousand vague rumors of
+      the horrors of Toledo. Of the dungeons there had been strange
+      things narrated—fables I had always deemed them—but yet strange,
+      and too ghastly to repeat, save in a whisper. Was I left to
+      perish of starvation in this subterranean world of darkness; or
+      what fate, perhaps even more fearful, awaited me? That the result
+      would be death, and a death of more than customary bitterness, I
+      knew too well the character of my judges to doubt. The mode and
+      the hour were all that occupied or distracted me.
+
+      My outstretched hands at length encountered some solid
+      obstruction. It was a wall, seemingly of stone masonry—very
+      smooth, slimy, and cold. I followed it up; stepping with all the
+      careful distrust with which certain antique narratives had
+      inspired me. This process, however, afforded me no means of
+      ascertaining the dimensions of my dungeon; as I might make its
+      circuit, and return to the point whence I set out, without being
+      aware of the fact; so perfectly uniform seemed the wall. I
+      therefore sought the knife which had been in my pocket, when led
+      into the inquisitorial chamber; but it was gone; my clothes had
+      been exchanged for a wrapper of coarse serge. I had thought of
+      forcing the blade in some minute crevice of the masonry, so as to
+      identify my point of departure. The difficulty, nevertheless, was
+      but trivial; although, in the disorder of my fancy, it seemed at
+      first insuperable. I tore a part of the hem from the robe and
+      placed the fragment at full length, and at right angles to the
+      wall. In groping my way around the prison, I could not fail to
+      encounter this rag upon completing the circuit. So, at least I
+      thought: but I had not counted upon the extent of the dungeon, or
+      upon my own weakness. The ground was moist and slippery. I
+      staggered onward for some time, when I stumbled and fell. My
+      excessive fatigue induced me to remain prostrate; and sleep soon
+      overtook me as I lay.
+
+      Upon awaking, and stretching forth an arm, I found beside me a
+      loaf and a pitcher with water. I was too much exhausted to
+      reflect upon this circumstance, but ate and drank with avidity.
+      Shortly afterward, I resumed my tour around the prison, and with
+      much toil came at last upon the fragment of the serge. Up to the
+      period when I fell I had counted fifty-two paces, and upon
+      resuming my walk, I had counted forty-eight more—when I arrived
+      at the rag. There were in all, then, a hundred paces; and,
+      admitting two paces to the yard, I presumed the dungeon to be
+      fifty yards in circuit. I had met, however, with many angles in
+      the wall, and thus I could form no guess at the shape of the
+      vault, for vault I could not help supposing it to be.
+
+      I had little object—certainly no hope—in these researches; but a
+      vague curiosity prompted me to continue them. Quitting the wall,
+      I resolved to cross the area of the enclosure. At first I
+      proceeded with extreme caution, for the floor, although seemingly
+      of solid material, was treacherous with slime. At length,
+      however, I took courage, and did not hesitate to step firmly;
+      endeavoring to cross in as direct a line as possible. I had
+      advanced some ten or twelve paces in this manner, when the
+      remnant of the torn hem of my robe became entangled between my
+      legs. I stepped on it, and fell violently on my face.
+
+      In the confusion attending my fall, I did not immediately
+      apprehend a somewhat startling circumstance, which yet, in a few
+      seconds afterward, and while I still lay prostrate, arrested my
+      attention. It was this: my chin rested upon the floor of the
+      prison, but my lips and the upper portion of my head, although
+      seemingly at a less elevation than the chin, touched nothing. At
+      the same time my forehead seemed bathed in a clammy vapor, and
+      the peculiar smell of decayed fungus arose to my nostrils. I put
+      forward my arm, and shuddered to find that I had fallen at the
+      very brink of a circular pit, whose extent, of course, I had no
+      means of ascertaining at the moment. Groping about the masonry
+      just below the margin, I succeeded in dislodging a small
+      fragment, and let it fall into the abyss. For many seconds I
+      hearkened to its reverberations as it dashed against the sides of
+      the chasm in its descent; at length there was a sullen plunge
+      into water, succeeded by loud echoes. At the same moment there
+      came a sound resembling the quick opening, and as rapid closing
+      of a door overhead, while a faint gleam of light flashed suddenly
+      through the gloom, and as suddenly faded away.
+
+      I saw clearly the doom which had been prepared for me, and
+      congratulated myself upon the timely accident by which I had
+      escaped. Another step before my fall, and the world had seen me
+      no more. And the death just avoided, was of that very character
+      which I had regarded as fabulous and frivolous in the tales
+      respecting the Inquisition. To the victims of its tyranny, there
+      was the choice of death with its direst physical agonies, or
+      death with its most hideous moral horrors. I had been reserved
+      for the latter. By long suffering my nerves had been unstrung,
+      until I trembled at the sound of my own voice, and had become in
+      every respect a fitting subject for the species of torture which
+      awaited me.
+
+      Shaking in every limb, I groped my way back to the wall—resolving
+      there to perish rather than risk the terrors of the wells, of
+      which my imagination now pictured many in various positions about
+      the dungeon. In other conditions of mind I might have had courage
+      to end my misery at once by a plunge into one of these abysses;
+      but now I was the veriest of cowards. Neither could I forget what
+      I had read of these pits—that the sudden extinction of life
+      formed no part of their most horrible plan.
+
+      Agitation of spirit kept me awake for many long hours, but at
+      length I again slumbered. Upon arousing, I found by my side, as
+      before, a loaf and a pitcher of water. A burning thirst consumed
+      me, and I emptied the vessel at a draught. It must have been
+      drugged—for scarcely had I drunk, before I became irresistibly
+      drowsy. A deep sleep fell upon me—a sleep like that of death. How
+      long it lasted of course, I know not; but when, once again, I
+      unclosed my eyes, the objects around me were visible. By a wild
+      sulphurous lustre, the origin of which I could not at first
+      determine, I was enabled to see the extent and aspect of the
+      prison.
+
+      In its size I had been greatly mistaken. The whole circuit of its
+      walls did not exceed twenty-five yards. For some minutes this
+      fact occasioned me a world of vain trouble; vain indeed! for what
+      could be of less importance, under the terrible circumstances
+      which environed me, then the mere dimensions of my dungeon? But
+      my soul took a wild interest in trifles, and I busied myself in
+      endeavors to account for the error I had committed in my
+      measurement. The truth at length flashed upon me. In my first
+      attempt at exploration I had counted fifty-two paces, up to the
+      period when I fell; I must then have been within a pace or two of
+      the fragment of serge; in fact, I had nearly performed the
+      circuit of the vault. I then slept—and, upon awaking, I must have
+      returned upon my steps—thus supposing the circuit nearly double
+      what it actually was. My confusion of mind prevented me from
+      observing that I began my tour with the wall to the left, and
+      ended it with the wall to the right.
+
+      I had been deceived, too, in respect to the shape of the
+      enclosure. In feeling my way I had found many angles, and thus
+      deduced an idea of great irregularity; so potent is the effect of
+      total darkness upon one arousing from lethargy or sleep! The
+      angles were simply those of a few slight depressions, or niches,
+      at odd intervals. The general shape of the prison was square.
+      What I had taken for masonry seemed now to be iron, or some other
+      metal, in huge plates, whose sutures or joints occasioned the
+      depression. The entire surface of this metallic enclosure was
+      rudely daubed in all the hideous and repulsive devices to which
+      the charnel superstition of the monks has given rise. The figures
+      of fiends in aspects of menace, with skeleton forms, and other
+      more really fearful images, overspread and disfigured the walls.
+      I observed that the outlines of these monstrosities were
+      sufficiently distinct, but that the colors seemed faded and
+      blurred, as if from the effects of a damp atmosphere. I now
+      noticed the floor, too, which was of stone. In the centre yawned
+      the circular pit from whose jaws I had escaped; but it was the
+      only one in the dungeon.
+
+      All this I saw indistinctly and by much effort—for my personal
+      condition had been greatly changed during slumber. I now lay upon
+      my back, and at full length, on a species of low framework of
+      wood. To this I was securely bound by a long strap resembling a
+      surcingle. It passed in many convolutions about my limbs and
+      body, leaving at liberty only my head, and my left arm to such
+      extent that I could, by dint of much exertion, supply myself with
+      food from an earthen dish which lay by my side on the floor. I
+      saw, to my horror, that the pitcher had been removed. I say to my
+      horror—for I was consumed with intolerable thirst. This thirst it
+      appeared to be the design of my persecutors to stimulate—for the
+      food in the dish was meat pungently seasoned.
+
+      Looking upward, I surveyed the ceiling of my prison. It was some
+      thirty or forty feet overhead, and constructed much as the side
+      walls. In one of its panels a very singular figure riveted my
+      whole attention. It was the painted figure of Time as he is
+      commonly represented, save that, in lieu of a scythe, he held
+      what, at a casual glance, I supposed to be the pictured image of
+      a huge pendulum such as we see on antique clocks. There was
+      something, however, in the appearance of this machine which
+      caused me to regard it more attentively. While I gazed directly
+      upward at it (for its position was immediately over my own) I
+      fancied that I saw it in motion. In an instant afterward the
+      fancy was confirmed. Its sweep was brief, and of course slow. I
+      watched it for some minutes, somewhat in fear, but more in
+      wonder. Wearied at length with observing its dull movement, I
+      turned my eyes upon the other objects in the cell.
+
+      A slight noise attracted my notice, and, looking to the floor, I
+      saw several enormous rats traversing it. They had issued from the
+      well, which lay just within view to my right. Even then, while I
+      gazed, they came up in troops, hurriedly, with ravenous eyes,
+      allured by the scent of the meat. From this it required much
+      effort and attention to scare them away.
+
+      It might have been half an hour, perhaps even an hour, (for I
+      could take but imperfect note of time) before I again cast my
+      eyes upward. What I then saw confounded and amazed me. The sweep
+      of the pendulum had increased in extent by nearly a yard. As a
+      natural consequence, its velocity was also much greater. But what
+      mainly disturbed me was the idea that had perceptibly descended.
+      I now observed—with what horror it is needless to say—that its
+      nether extremity was formed of a crescent of glittering steel,
+      about a foot in length from horn to horn; the horns upward, and
+      the under edge evidently as keen as that of a razor. Like a razor
+      also, it seemed massy and heavy, tapering from the edge into a
+      solid and broad structure above. It was appended to a weighty rod
+      of brass, and the whole hissed as it swung through the air.
+
+      I could no longer doubt the doom prepared for me by monkish
+      ingenuity in torture. My cognizance of the pit had become known
+      to the inquisitorial agents—_the pit_, whose horrors had been
+      destined for so bold a recusant as myself—the pit, typical of
+      hell, and regarded by rumor as the Ultima Thule of all their
+      punishments. The plunge into this pit I had avoided by the merest
+      of accidents, I knew that surprise, or entrapment into torment,
+      formed an important portion of all the grotesquerie of these
+      dungeon deaths. Having failed to fall, it was no part of the
+      demon plan to hurl me into the abyss; and thus (there being no
+      alternative) a different and a milder destruction awaited me.
+      Milder! I half smiled in my agony as I thought of such
+      application of such a term.
+
+      What boots it to tell of the long, long hours of horror more than
+      mortal, during which I counted the rushing vibrations of the
+      steel! Inch by inch—line by line—with a descent only appreciable
+      at intervals that seemed ages—down and still down it came! Days
+      passed—it might have been that many days passed—ere it swept so
+      closely over me as to fan me with its acrid breath. The odor of
+      the sharp steel forced itself into my nostrils. I prayed—I
+      wearied heaven with my prayer for its more speedy descent. I grew
+      frantically mad, and struggled to force myself upward against the
+      sweep of the fearful scimitar. And then I fell suddenly calm, and
+      lay smiling at the glittering death, as a child at some rare
+      bauble.
+
+      There was another interval of utter insensibility; it was brief;
+      for, upon again lapsing into life there had been no perceptible
+      descent in the pendulum. But it might have been long; for I knew
+      there were demons who took note of my swoon, and who could have
+      arrested the vibration at pleasure. Upon my recovery, too, I felt
+      very—oh! inexpressibly—sick and weak, as if through long
+      inanition. Even amid the agonies of that period, the human nature
+      craved food. With painful effort I outstretched my left arm as
+      far as my bonds permitted, and took possession of the small
+      remnant which had been spared me by the rats. As I put a portion
+      of it within my lips, there rushed to my mind a half formed
+      thought of joy—of hope. Yet what business had _I_ with hope? It
+      was, as I say, a half formed thought—man has many such, which are
+      never completed. I felt that it was of joy—of hope; but felt also
+      that it had perished in its formation. In vain I struggled to
+      perfect—to regain it. Long suffering had nearly annihilated all
+      my ordinary powers of mind. I was an imbecile—an idiot.
+
+      The vibration of the pendulum was at right angles to my length. I
+      saw that the crescent was designed to cross the region of the
+      heart. It would fray the serge of my robe—it would return and
+      repeat its operations—again—and again. Notwithstanding its
+      terrifically wide sweep (some thirty feet or more) and the
+      hissing vigor of its descent, sufficient to sunder these very
+      walls of iron, still the fraying of my robe would be all that,
+      for several minutes, it would accomplish. And at this thought I
+      paused. I dared not go farther than this reflection. I dwelt upon
+      it with a pertinacity of attention—as if, in so dwelling, I could
+      arrest here the descent of the steel. I forced myself to ponder
+      upon the sound of the crescent as it should pass across the
+      garment—upon the peculiar thrilling sensation which the friction
+      of cloth produces on the nerves. I pondered upon all this
+      frivolity until my teeth were on edge.
+
+      Down—steadily down it crept. I took a frenzied pleasure in
+      contrasting its downward with its lateral velocity. To the
+      right—to the left—far and wide—with the shriek of a damned
+      spirit! to my heart with the stealthy pace of the tiger! I
+      alternately laughed and howled as the one or the other idea grew
+      predominant.
+
+      Down—certainly, relentlessly down! It vibrated within three
+      inches of my bosom! I struggled violently, furiously, to free my
+      left arm. This was free only from the elbow to the hand. I could
+      reach the latter, from the platter beside me, to my mouth, with
+      great effort, but no farther. Could I have broken the fastenings
+      above the elbow, I would have seized and attempted to arrest the
+      pendulum. I might as well have attempted to arrest an avalanche!
+
+      Down—still unceasingly—still inevitably down! I gasped and
+      struggled at each vibration. I shrunk convulsively at its every
+      sweep. My eyes followed its outward or upward whirls with the
+      eagerness of the most unmeaning despair; they closed themselves
+      spasmodically at the descent, although death would have been a
+      relief, oh, how unspeakable! Still I quivered in every nerve to
+      think how slight a sinking of the machinery would precipitate
+      that keen, glistening axe upon my bosom. It was hope that
+      prompted the nerve to quiver—the frame to shrink. It was hope—the
+      hope that triumphs on the rack—that whispers to the
+      death-condemned even in the dungeons of the Inquisition.
+
+      I saw that some ten or twelve vibrations would bring the steel in
+      actual contact with my robe, and with this observation there
+      suddenly came over my spirit all the keen, collected calmness of
+      despair. For the first time during many hours—or perhaps days—I
+      thought. It now occurred to me that the bandage, or surcingle,
+      which enveloped me, was unique. I was tied by no separate cord.
+      The first stroke of the razorlike crescent athwart any portion of
+      the band, would so detach it that it might be unwound from my
+      person by means of my left hand. But how fearful, in that case,
+      the proximity of the steel! The result of the slightest struggle
+      how deadly! Was it likely, moreover, that the minions of the
+      torturer had not foreseen and provided for this possibility? Was
+      it probable that the bandage crossed my bosom in the track of the
+      pendulum? Dreading to find my faint, and, as it seemed, my last
+      hope frustrated, I so far elevated my head as to obtain a
+      distinct view of my breast. The surcingle enveloped my limbs and
+      body close in all directions—save in the path of the destroying
+      crescent.
+
+      Scarcely had I dropped my head back into its original position,
+      when there flashed upon my mind what I cannot better describe
+      than as the unformed half of that idea of deliverance to which I
+      have previously alluded, and of which a moiety only floated
+      indeterminately through my brain when I raised food to my burning
+      lips. The whole thought was now present—feeble, scarcely sane,
+      scarcely definite,—but still entire. I proceeded at once, with
+      the nervous energy of despair, to attempt its execution.
+
+      For many hours the immediate vicinity of the low framework upon
+      which I lay had been literally swarming with rats. They were
+      wild, bold, ravenous—their red eyes glaring upon me as if they
+      waited but for motionlessness on my part to make me their prey.
+      “To what food,” I thought, “have they been accustomed in the
+      well?”
+
+      They had devoured, in spite of all my efforts to prevent them,
+      all but a small remnant of the contents of the dish. I had fallen
+      into an habitual see-saw, or wave of the hand about the platter;
+      and, at length, the unconscious uniformity of the movement
+      deprived it of effect. In their voracity the vermin frequently
+      fastened their sharp fangs in my fingers. With the particles of
+      the oily and spicy viand which now remained, I thoroughly rubbed
+      the bandage wherever I could reach it; then, raising my hand from
+      the floor, I lay breathlessly still.
+
+      At first the ravenous animals were startled and terrified at the
+      change—at the cessation of movement. They shrank alarmedly back;
+      many sought the well. But this was only for a moment. I had not
+      counted in vain upon their voracity. Observing that I remained
+      without motion, one or two of the boldest leaped upon the
+      frame-work, and smelt at the surcingle. This seemed the signal
+      for a general rush. Forth from the well they hurried in fresh
+      troops. They clung to the wood—they overran it, and leaped in
+      hundreds upon my person. The measured movement of the pendulum
+      disturbed them not at all. Avoiding its strokes they busied
+      themselves with the anointed bandage. They pressed—they swarmed
+      upon me in ever accumulating heaps. They writhed upon my throat;
+      their cold lips sought my own; I was half stifled by their
+      thronging pressure; disgust, for which the world has no name,
+      swelled my bosom, and chilled, with a heavy clamminess, my heart.
+      Yet one minute, and I felt that the struggle would be over.
+      Plainly I perceived the loosening of the bandage. I knew that in
+      more than one place it must be already severed. With a more than
+      human resolution I lay still.
+
+      Nor had I erred in my calculations—nor had I endured in vain. I
+      at length felt that I was free. The surcingle hung in ribands
+      from my body. But the stroke of the pendulum already pressed upon
+      my bosom. It had divided the serge of the robe. It had cut
+      through the linen beneath. Twice again it swung, and a sharp
+      sense of pain shot through every nerve. But the moment of escape
+      had arrived. At a wave of my hand my deliverers hurried
+      tumultuously away. With a steady movement—cautious, sidelong,
+      shrinking, and slow—I slid from the embrace of the bandage and
+      beyond the reach of the scimitar. For the moment, at least, I was
+      free.
+
+      Free!—and in the grasp of the Inquisition! I had scarcely stepped
+      from my wooden bed of horror upon the stone floor of the prison,
+      when the motion of the hellish machine ceased and I beheld it
+      drawn up, by some invisible force, through the ceiling. This was
+      a lesson which I took desperately to heart. My every motion was
+      undoubtedly watched. Free!—I had but escaped death in one form of
+      agony, to be delivered unto worse than death in some other. With
+      that thought I rolled my eves nervously around on the barriers of
+      iron that hemmed me in. Something unusual—some change which, at
+      first, I could not appreciate distinctly—it was obvious, had
+      taken place in the apartment. For many minutes of a dreamy and
+      trembling abstraction, I busied myself in vain, unconnected
+      conjecture. During this period, I became aware, for the first
+      time, of the origin of the sulphurous light which illumined the
+      cell. It proceeded from a fissure, about half an inch in width,
+      extending entirely around the prison at the base of the walls,
+      which thus appeared, and were, completely separated from the
+      floor. I endeavored, but of course in vain, to look through the
+      aperture.
+
+      As I arose from the attempt, the mystery of the alteration in the
+      chamber broke at once upon my understanding. I have observed
+      that, although the outlines of the figures upon the walls were
+      sufficiently distinct, yet the colors seemed blurred and
+      indefinite. These colors had now assumed, and were momentarily
+      assuming, a startling and most intense brilliancy, that gave to
+      the spectral and fiendish portraitures an aspect that might have
+      thrilled even firmer nerves than my own. Demon eyes, of a wild
+      and ghastly vivacity, glared upon me in a thousand directions,
+      where none had been visible before, and gleamed with the lurid
+      lustre of a fire that I could not force my imagination to regard
+      as unreal.
+
+      _Unreal!_—Even while I breathed there came to my nostrils the
+      breath of the vapour of heated iron! A suffocating odour pervaded
+      the prison! A deeper glow settled each moment in the eyes that
+      glared at my agonies! A richer tint of crimson diffused itself
+      over the pictured horrors of blood. I panted! I gasped for
+      breath! There could be no doubt of the design of my
+      tormentors—oh! most unrelenting! oh! most demoniac of men! I
+      shrank from the glowing metal to the centre of the cell. Amid the
+      thought of the fiery destruction that impended, the idea of the
+      coolness of the well came over my soul like balm. I rushed to its
+      deadly brink. I threw my straining vision below. The glare from
+      the enkindled roof illumined its inmost recesses. Yet, for a wild
+      moment, did my spirit refuse to comprehend the meaning of what I
+      saw. At length it forced—it wrestled its way into my soul—it
+      burned itself in upon my shuddering reason. Oh! for a voice to
+      speak!—oh! horror!—oh! any horror but this! With a shriek, I
+      rushed from the margin, and buried my face in my hands—weeping
+      bitterly.
+
+      The heat rapidly increased, and once again I looked up,
+      shuddering as with a fit of the ague. There had been a second
+      change in the cell—and now the change was obviously in the form.
+      As before, it was in vain that I, at first, endeavoured to
+      appreciate or understand what was taking place. But not long was
+      I left in doubt. The Inquisitorial vengeance had been hurried by
+      my two-fold escape, and there was to be no more dallying with the
+      King of Terrors. The room had been square. I saw that two of its
+      iron angles were now acute—two, consequently, obtuse. The fearful
+      difference quickly increased with a low rumbling or moaning
+      sound. In an instant the apartment had shifted its form into that
+      of a lozenge. But the alteration stopped not here—I neither hoped
+      nor desired it to stop. I could have clasped the red walls to my
+      bosom as a garment of eternal peace. “Death,” I said, “any death
+      but that of the pit!” Fool! might I have not known that into the
+      pit it was the object of the burning iron to urge me? Could I
+      resist its glow? or, if even that, could I withstand its
+      pressure? And now, flatter and flatter grew the lozenge, with a
+      rapidity that left me no time for contemplation. Its centre, and
+      of course, its greatest width, came just over the yawning gulf. I
+      shrank back—but the closing walls pressed me resistlessly onward.
+      At length for my seared and writhing body there was no longer an
+      inch of foothold on the firm floor of the prison. I struggled no
+      more, but the agony of my soul found vent in one loud, long, and
+      final scream of despair. I felt that I tottered upon the brink—I
+      averted my eyes—
+
+      There was a discordant hum of human voices! There was a loud
+      blast as of many trumpets! There was a harsh grating as of a
+      thousand thunders! The fiery walls rushed back! An outstretched
+      arm caught my own as I fell, fainting, into the abyss. It was
+      that of General Lasalle. The French army had entered Toledo. The
+      Inquisition was in the hands of its enemies.
+
+
+
+
+THE PREMATURE BURIAL
+
+
+      There are certain themes of which the interest is all-absorbing,
+      but which are too entirely horrible for the purposes of
+      legitimate fiction. These the mere romanticist must eschew, if he
+      do not wish to offend or to disgust. They are with propriety
+      handled only when the severity and majesty of Truth sanctify and
+      sustain them. We thrill, for example, with the most intense of
+      “pleasurable pain” over the accounts of the Passage of the
+      Beresina, of the Earthquake at Lisbon, of the Plague at London,
+      of the Massacre of St. Bartholomew, or of the stifling of the
+      hundred and twenty-three prisoners in the Black Hole at Calcutta.
+      But in these accounts it is the fact——it is the reality——it is
+      the history which excites. As inventions, we should regard them
+      with simple abhorrence.
+
+      I have mentioned some few of the more prominent and august
+      calamities on record; but in these it is the extent, not less
+      than the character of the calamity, which so vividly impresses
+      the fancy. I need not remind the reader that, from the long and
+      weird catalogue of human miseries, I might have selected many
+      individual instances more replete with essential suffering than
+      any of these vast generalities of disaster. The true
+      wretchedness, indeed—the ultimate woe——is particular, not
+      diffuse. That the ghastly extremes of agony are endured by man
+      the unit, and never by man the mass——for this let us thank a
+      merciful God!
+
+      To be buried while alive is, beyond question, the most terrific
+      of these extremes which has ever fallen to the lot of mere
+      mortality. That it has frequently, very frequently, so fallen
+      will scarcely be denied by those who think. The boundaries which
+      divide Life from Death are at best shadowy and vague. Who shall
+      say where the one ends, and where the other begins? We know that
+      there are diseases in which occur total cessations of all the
+      apparent functions of vitality, and yet in which these cessations
+      are merely suspensions, properly so called. They are only
+      temporary pauses in the incomprehensible mechanism. A certain
+      period elapses, and some unseen mysterious principle again sets
+      in motion the magic pinions and the wizard wheels. The silver
+      cord was not for ever loosed, nor the golden bowl irreparably
+      broken. But where, meantime, was the soul?
+
+      Apart, however, from the inevitable conclusion, _a priori_ that
+      such causes must produce such effects——that the well-known
+      occurrence of such cases of suspended animation must naturally
+      give rise, now and then, to premature interments—apart from this
+      consideration, we have the direct testimony of medical and
+      ordinary experience to prove that a vast number of such
+      interments have actually taken place. I might refer at once, if
+      necessary, to a hundred well-authenticated instances. One of very
+      remarkable character, and of which the circumstances may be fresh
+      in the memory of some of my readers, occurred, not very long ago,
+      in the neighboring city of Baltimore, where it occasioned a
+      painful, intense, and widely-extended excitement. The wife of one
+      of the most respectable citizens—a lawyer of eminence and a
+      member of Congress—was seized with a sudden and unaccountable
+      illness, which completely baffled the skill of her physicians.
+      After much suffering she died, or was supposed to die. No one
+      suspected, indeed, or had reason to suspect, that she was not
+      actually dead. She presented all the ordinary appearances of
+      death. The face assumed the usual pinched and sunken outline. The
+      lips were of the usual marble pallor. The eyes were lustreless.
+      There was no warmth. Pulsation had ceased. For three days the
+      body was preserved unburied, during which it had acquired a stony
+      rigidity. The funeral, in short, was hastened, on account of the
+      rapid advance of what was supposed to be decomposition.
+
+      The lady was deposited in her family vault, which, for three
+      subsequent years, was undisturbed. At the expiration of this term
+      it was opened for the reception of a sarcophagus; but, alas! how
+      fearful a shock awaited the husband, who, personally, threw open
+      the door! As its portals swung outwardly back, some
+      white-apparelled object fell rattling within his arms. It was the
+      skeleton of his wife in her yet unmoulded shroud.
+
+      A careful investigation rendered it evident that she had revived
+      within two days after her entombment; that her struggles within
+      the coffin had caused it to fall from a ledge, or shelf to the
+      floor, where it was so broken as to permit her escape. A lamp
+      which had been accidentally left, full of oil, within the tomb,
+      was found empty; it might have been exhausted, however, by
+      evaporation. On the uttermost of the steps which led down into
+      the dread chamber was a large fragment of the coffin, with which,
+      it seemed, that she had endeavored to arrest attention by
+      striking the iron door. While thus occupied, she probably
+      swooned, or possibly died, through sheer terror; and, in failing,
+      her shroud became entangled in some iron-work which projected
+      interiorly. Thus she remained, and thus she rotted, erect.
+
+      In the year 1810, a case of living inhumation happened in France,
+      attended with circumstances which go far to warrant the assertion
+      that truth is, indeed, stranger than fiction. The heroine of the
+      story was a Mademoiselle Victorine Lafourcade, a young girl of
+      illustrious family, of wealth, and of great personal beauty.
+      Among her numerous suitors was Julien Bossuet, a poor
+      _litterateur_, or journalist of Paris. His talents and general
+      amiability had recommended him to the notice of the heiress, by
+      whom he seems to have been truly beloved; but her pride of birth
+      decided her, finally, to reject him, and to wed a Monsieur
+      Renelle, a banker and a diplomatist of some eminence. After
+      marriage, however, this gentleman neglected, and, perhaps, even
+      more positively ill-treated her. Having passed with him some
+      wretched years, she died—at least her condition so closely
+      resembled death as to deceive every one who saw her. She was
+      buried——not in a vault, but in an ordinary grave in the village
+      of her nativity. Filled with despair, and still inflamed by the
+      memory of a profound attachment, the lover journeys from the
+      capital to the remote province in which the village lies, with
+      the romantic purpose of disinterring the corpse, and possessing
+      himself of its luxuriant tresses. He reaches the grave. At
+      midnight he unearths the coffin, opens it, and is in the act of
+      detaching the hair, when he is arrested by the unclosing of the
+      beloved eyes. In fact, the lady had been buried alive. Vitality
+      had not altogether departed, and she was aroused by the caresses
+      of her lover from the lethargy which had been mistaken for death.
+      He bore her frantically to his lodgings in the village. He
+      employed certain powerful restoratives suggested by no little
+      medical learning. In fine, she revived. She recognized her
+      preserver. She remained with him until, by slow degrees, she
+      fully recovered her original health. Her woman’s heart was not
+      adamant, and this last lesson of love sufficed to soften it. She
+      bestowed it upon Bossuet. She returned no more to her husband,
+      but, concealing from him her resurrection, fled with her lover to
+      America. Twenty years afterward, the two returned to France, in
+      the persuasion that time had so greatly altered the lady’s
+      appearance that her friends would be unable to recognize her.
+      They were mistaken, however, for, at the first meeting, Monsieur
+      Renelle did actually recognize and make claim to his wife. This
+      claim she resisted, and a judicial tribunal sustained her in her
+      resistance, deciding that the peculiar circumstances, with the
+      long lapse of years, had extinguished, not only equitably, but
+      legally, the authority of the husband.
+
+      The “Chirurgical Journal” of Leipsic, a periodical of high
+      authority and merit, which some American bookseller would do well
+      to translate and republish, records in a late number a very
+      distressing event of the character in question.
+
+      An officer of artillery, a man of gigantic stature and of robust
+      health, being thrown from an unmanageable horse, received a very
+      severe contusion upon the head, which rendered him insensible at
+      once; the skull was slightly fractured, but no immediate danger
+      was apprehended. Trepanning was accomplished successfully. He was
+      bled, and many other of the ordinary means of relief were
+      adopted. Gradually, however, he fell into a more and more
+      hopeless state of stupor, and, finally, it was thought that he
+      died.
+
+      The weather was warm, and he was buried with indecent haste in
+      one of the public cemeteries. His funeral took place on Thursday.
+      On the Sunday following, the grounds of the cemetery were, as
+      usual, much thronged with visitors, and about noon an intense
+      excitement was created by the declaration of a peasant that,
+      while sitting upon the grave of the officer, he had distinctly
+      felt a commotion of the earth, as if occasioned by some one
+      struggling beneath. At first little attention was paid to the
+      man’s asseveration; but his evident terror, and the dogged
+      obstinacy with which he persisted in his story, had at length
+      their natural effect upon the crowd. Spades were hurriedly
+      procured, and the grave, which was shamefully shallow, was in a
+      few minutes so far thrown open that the head of its occupant
+      appeared. He was then seemingly dead; but he sat nearly erect
+      within his coffin, the lid of which, in his furious struggles, he
+      had partially uplifted.
+
+      He was forthwith conveyed to the nearest hospital, and there
+      pronounced to be still living, although in an asphytic condition.
+      After some hours he revived, recognized individuals of his
+      acquaintance, and, in broken sentences spoke of his agonies in
+      the grave.
+
+      From what he related, it was clear that he must have been
+      conscious of life for more than an hour, while inhumed, before
+      lapsing into insensibility. The grave was carelessly and loosely
+      filled with an exceedingly porous soil; and thus some air was
+      necessarily admitted. He heard the footsteps of the crowd
+      overhead, and endeavored to make himself heard in turn. It was
+      the tumult within the grounds of the cemetery, he said, which
+      appeared to awaken him from a deep sleep, but no sooner was he
+      awake than he became fully aware of the awful horrors of his
+      position.
+
+      This patient, it is recorded, was doing well and seemed to be in
+      a fair way of ultimate recovery, but fell a victim to the
+      quackeries of medical experiment. The galvanic battery was
+      applied, and he suddenly expired in one of those ecstatic
+      paroxysms which, occasionally, it superinduces.
+
+      The mention of the galvanic battery, nevertheless, recalls to my
+      memory a well known and very extraordinary case in point, where
+      its action proved the means of restoring to animation a young
+      attorney of London, who had been interred for two days. This
+      occurred in 1831, and created, at the time, a very profound
+      sensation wherever it was made the subject of converse.
+
+      The patient, Mr. Edward Stapleton, had died, apparently of typhus
+      fever, accompanied with some anomalous symptoms which had excited
+      the curiosity of his medical attendants. Upon his seeming
+      decease, his friends were requested to sanction a post-mortem
+      examination, but declined to permit it. As often happens, when
+      such refusals are made, the practitioners resolved to disinter
+      the body and dissect it at leisure, in private. Arrangements were
+      easily effected with some of the numerous corps of
+      body-snatchers, with which London abounds; and, upon the third
+      night after the funeral, the supposed corpse was unearthed from a
+      grave eight feet deep, and deposited in the opening chamber of
+      one of the private hospitals.
+
+      An incision of some extent had been actually made in the abdomen,
+      when the fresh and undecayed appearance of the subject suggested
+      an application of the battery. One experiment succeeded another,
+      and the customary effects supervened, with nothing to
+      characterize them in any respect, except, upon one or two
+      occasions, a more than ordinary degree of life-likeness in the
+      convulsive action.
+
+      It grew late. The day was about to dawn; and it was thought
+      expedient, at length, to proceed at once to the dissection. A
+      student, however, was especially desirous of testing a theory of
+      his own, and insisted upon applying the battery to one of the
+      pectoral muscles. A rough gash was made, and a wire hastily
+      brought in contact, when the patient, with a hurried but quite
+      unconvulsive movement, arose from the table, stepped into the
+      middle of the floor, gazed about him uneasily for a few seconds,
+      and then—spoke. What he said was unintelligible, but words were
+      uttered; the syllabification was distinct. Having spoken, he fell
+      heavily to the floor.
+
+      For some moments all were paralyzed with awe—but the urgency of
+      the case soon restored them their presence of mind. It was seen
+      that Mr. Stapleton was alive, although in a swoon. Upon
+      exhibition of ether he revived and was rapidly restored to
+      health, and to the society of his friends—from whom, however, all
+      knowledge of his resuscitation was withheld, until a relapse was
+      no longer to be apprehended. Their wonder—their rapturous
+      astonishment—may be conceived.
+
+      The most thrilling peculiarity of this incident, nevertheless, is
+      involved in what Mr. S. himself asserts. He declares that at no
+      period was he altogether insensible—that, dully and confusedly,
+      he was aware of everything which happened to him, from the moment
+      in which he was pronounced dead by his physicians, to that in
+      which he fell swooning to the floor of the hospital. “I am
+      alive,” were the uncomprehended words which, upon recognizing the
+      locality of the dissecting-room, he had endeavored, in his
+      extremity, to utter.
+
+      It were an easy matter to multiply such histories as these—but I
+      forbear—for, indeed, we have no need of such to establish the
+      fact that premature interments occur. When we reflect how very
+      rarely, from the nature of the case, we have it in our power to
+      detect them, we must admit that they may frequently occur without
+      our cognizance. Scarcely, in truth, is a graveyard ever
+      encroached upon, for any purpose, to any great extent, that
+      skeletons are not found in postures which suggest the most
+      fearful of suspicions.
+
+      Fearful indeed the suspicion—but more fearful the doom! It may be
+      asserted, without hesitation, that no event is so terribly well
+      adapted to inspire the supremeness of bodily and of mental
+      distress, as is burial before death. The unendurable oppression
+      of the lungs—the stifling fumes from the damp earth—the clinging
+      to the death garments—the rigid embrace of the narrow house—the
+      blackness of the absolute Night—the silence like a sea that
+      overwhelms—the unseen but palpable presence of the Conqueror
+      Worm—these things, with the thoughts of the air and grass above,
+      with memory of dear friends who would fly to save us if but
+      informed of our fate, and with consciousness that of this fate
+      they can never be informed—that our hopeless portion is that of
+      the really dead—these considerations, I say, carry into the
+      heart, which still palpitates, a degree of appalling and
+      intolerable horror from which the most daring imagination must
+      recoil. We know of nothing so agonizing upon Earth—we can dream
+      of nothing half so hideous in the realms of the nethermost Hell.
+      And thus all narratives upon this topic have an interest
+      profound; an interest, nevertheless, which, through the sacred
+      awe of the topic itself, very properly and very peculiarly
+      depends upon our conviction of the truth of the matter narrated.
+      What I have now to tell is of my own actual knowledge—of my own
+      positive and personal experience.
+
+      For several years I had been subject to attacks of the singular
+      disorder which physicians have agreed to term catalepsy, in
+      default of a more definitive title. Although both the immediate
+      and the predisposing causes, and even the actual diagnosis, of
+      this disease are still mysterious, its obvious and apparent
+      character is sufficiently well understood. Its variations seem to
+      be chiefly of degree. Sometimes the patient lies, for a day only,
+      or even for a shorter period, in a species of exaggerated
+      lethargy. He is senseless and externally motionless; but the
+      pulsation of the heart is still faintly perceptible; some traces
+      of warmth remain; a slight color lingers within the centre of the
+      cheek; and, upon application of a mirror to the lips, we can
+      detect a torpid, unequal, and vacillating action of the lungs.
+      Then again the duration of the trance is for weeks—even for
+      months; while the closest scrutiny, and the most rigorous medical
+      tests, fail to establish any material distinction between the
+      state of the sufferer and what we conceive of absolute death.
+      Very usually he is saved from premature interment solely by the
+      knowledge of his friends that he has been previously subject to
+      catalepsy, by the consequent suspicion excited, and, above all,
+      by the non-appearance of decay. The advances of the malady are,
+      luckily, gradual. The first manifestations, although marked, are
+      unequivocal. The fits grow successively more and more
+      distinctive, and endure each for a longer term than the
+      preceding. In this lies the principal security from inhumation.
+      The unfortunate whose first attack should be of the extreme
+      character which is occasionally seen, would almost inevitably be
+      consigned alive to the tomb.
+
+      My own case differed in no important particular from those
+      mentioned in medical books. Sometimes, without any apparent
+      cause, I sank, little by little, into a condition of
+      semi-syncope, or half swoon; and, in this condition, without
+      pain, without ability to stir, or, strictly speaking, to think,
+      but with a dull lethargic consciousness of life and of the
+      presence of those who surrounded my bed, I remained, until the
+      crisis of the disease restored me, suddenly, to perfect
+      sensation. At other times I was quickly and impetuously smitten.
+      I grew sick, and numb, and chilly, and dizzy, and so fell
+      prostrate at once. Then, for weeks, all was void, and black, and
+      silent, and Nothing became the universe. Total annihilation could
+      be no more. From these latter attacks I awoke, however, with a
+      gradation slow in proportion to the suddenness of the seizure.
+      Just as the day dawns to the friendless and houseless beggar who
+      roams the streets throughout the long desolate winter night—just
+      so tardily—just so wearily—just so cheerily came back the light
+      of the Soul to me.
+
+      Apart from the tendency to trance, however, my general health
+      appeared to be good; nor could I perceive that it was at all
+      affected by the one prevalent malady—unless, indeed, an
+      idiosyncrasy in my ordinary sleep may be looked upon as
+      superinduced. Upon awaking from slumber, I could never gain, at
+      once, thorough possession of my senses, and always remained, for
+      many minutes, in much bewilderment and perplexity—the mental
+      faculties in general, but the memory in especial, being in a
+      condition of absolute abeyance.
+
+      In all that I endured there was no physical suffering but of
+      moral distress an infinitude. My fancy grew charnel, I talked “of
+      worms, of tombs, and epitaphs.” I was lost in reveries of death,
+      and the idea of premature burial held continual possession of my
+      brain. The ghastly Danger to which I was subjected haunted me day
+      and night. In the former, the torture of meditation was
+      excessive—in the latter, supreme. When the grim Darkness
+      overspread the Earth, then, with every horror of thought, I
+      shook—shook as the quivering plumes upon the hearse. When Nature
+      could endure wakefulness no longer, it was with a struggle that I
+      consented to sleep—for I shuddered to reflect that, upon awaking,
+      I might find myself the tenant of a grave. And when, finally, I
+      sank into slumber, it was only to rush at once into a world of
+      phantasms, above which, with vast, sable, overshadowing wing,
+      hovered, predominant, the one sepulchral Idea.
+
+      From the innumerable images of gloom which thus oppressed me in
+      dreams, I select for record but a solitary vision. Methought I
+      was immersed in a cataleptic trance of more than usual duration
+      and profundity. Suddenly there came an icy hand upon my forehead,
+      and an impatient, gibbering voice whispered the word “Arise!”
+      within my ear.
+
+      I sat erect. The darkness was total. I could not see the figure
+      of him who had aroused me. I could call to mind neither the
+      period at which I had fallen into the trance, nor the locality in
+      which I then lay. While I remained motionless, and busied in
+      endeavors to collect my thought, the cold hand grasped me
+      fiercely by the wrist, shaking it petulantly, while the gibbering
+      voice said again:
+
+      “Arise! did I not bid thee arise?”
+
+      “And who,” I demanded, “art thou?”
+
+      “I have no name in the regions which I inhabit,” replied the
+      voice, mournfully; “I was mortal, but am fiend. I was merciless,
+      but am pitiful. Thou dost feel that I shudder. My teeth chatter
+      as I speak, yet it is not with the chilliness of the night—of the
+      night without end. But this hideousness is insufferable. How
+      canst thou tranquilly sleep? I cannot rest for the cry of these
+      great agonies. These sights are more than I can bear. Get thee
+      up! Come with me into the outer Night, and let me unfold to thee
+      the graves. Is not this a spectacle of woe?—Behold!”
+
+      I looked; and the unseen figure, which still grasped me by the
+      wrist, had caused to be thrown open the graves of all mankind;
+      and from each issued the faint phosphoric radiance of decay; so
+      that I could see into the innermost recesses, and there view the
+      shrouded bodies in their sad and solemn slumbers with the worm.
+      But alas! the real sleepers were fewer, by many millions, than
+      those who slumbered not at all; and there was a feeble
+      struggling; and there was a general sad unrest; and from out the
+      depths of the countless pits there came a melancholy rustling
+      from the garments of the buried. And of those who seemed
+      tranquilly to repose, I saw that a vast number had changed, in a
+      greater or less degree, the rigid and uneasy position in which
+      they had originally been entombed. And the voice again said to me
+      as I gazed:
+
+      “Is it not—oh! is it _not_ a pitiful sight?” But, before I could
+      find words to reply, the figure had ceased to grasp my wrist, the
+      phosphoric lights expired, and the graves were closed with a
+      sudden violence, while from out them arose a tumult of despairing
+      cries, saying again: “Is it not—O, God, is it _not_ a very
+      pitiful sight?”
+
+      Phantasies such as these, presenting themselves at night,
+      extended their terrific influence far into my waking hours. My
+      nerves became thoroughly unstrung, and I fell a prey to perpetual
+      horror. I hesitated to ride, or to walk, or to indulge in any
+      exercise that would carry me from home. In fact, I no longer
+      dared trust myself out of the immediate presence of those who
+      were aware of my proneness to catalepsy, lest, falling into one
+      of my usual fits, I should be buried before my real condition
+      could be ascertained. I doubted the care, the fidelity of my
+      dearest friends. I dreaded that, in some trance of more than
+      customary duration, they might be prevailed upon to regard me as
+      irrecoverable. I even went so far as to fear that, as I
+      occasioned much trouble, they might be glad to consider any very
+      protracted attack as sufficient excuse for getting rid of me
+      altogether. It was in vain they endeavored to reassure me by the
+      most solemn promises. I exacted the most sacred oaths, that under
+      no circumstances they would bury me until decomposition had so
+      materially advanced as to render farther preservation impossible.
+      And, even then, my mortal terrors would listen to no reason—would
+      accept no consolation. I entered into a series of elaborate
+      precautions. Among other things, I had the family vault so
+      remodelled as to admit of being readily opened from within. The
+      slightest pressure upon a long lever that extended far into the
+      tomb would cause the iron portal to fly back. There were
+      arrangements also for the free admission of air and light, and
+      convenient receptacles for food and water, within immediate reach
+      of the coffin intended for my reception. This coffin was warmly
+      and softly padded, and was provided with a lid, fashioned upon
+      the principle of the vault-door, with the addition of springs so
+      contrived that the feeblest movement of the body would be
+      sufficient to set it at liberty. Besides all this, there was
+      suspended from the roof of the tomb, a large bell, the rope of
+      which, it was designed, should extend through a hole in the
+      coffin, and so be fastened to one of the hands of the corpse.
+      But, alas? what avails the vigilance against the Destiny of man?
+      Not even these well-contrived securities sufficed to save from
+      the uttermost agonies of living inhumation, a wretch to these
+      agonies foredoomed!
+
+      There arrived an epoch—as often before there had arrived—in which
+      I found myself emerging from total unconsciousness into the first
+      feeble and indefinite sense of existence. Slowly—with a tortoise
+      gradation—approached the faint gray dawn of the psychal day. A
+      torpid uneasiness. An apathetic endurance of dull pain. No
+      care—no hope—no effort. Then, after a long interval, a ringing in
+      the ears; then, after a lapse still longer, a prickling or
+      tingling sensation in the extremities; then a seemingly eternal
+      period of pleasurable quiescence, during which the awakening
+      feelings are struggling into thought; then a brief re-sinking
+      into non-entity; then a sudden recovery. At length the slight
+      quivering of an eyelid, and immediately thereupon, an electric
+      shock of a terror, deadly and indefinite, which sends the blood
+      in torrents from the temples to the heart. And now the first
+      positive effort to think. And now the first endeavor to remember.
+      And now a partial and evanescent success. And now the memory has
+      so far regained its dominion, that, in some measure, I am
+      cognizant of my state. I feel that I am not awaking from ordinary
+      sleep. I recollect that I have been subject to catalepsy. And
+      now, at last, as if by the rush of an ocean, my shuddering spirit
+      is overwhelmed by the one grim Danger—by the one spectral and
+      ever-prevalent idea.
+
+      For some minutes after this fancy possessed me, I remained
+      without motion. And why? I could not summon courage to move. I
+      dared not make the effort which was to satisfy me of my fate—and
+      yet there was something at my heart which whispered me it was
+      sure. Despair—such as no other species of wretchedness ever calls
+      into being—despair alone urged me, after long irresolution, to
+      uplift the heavy lids of my eyes. I uplifted them. It was
+      dark—all dark. I knew that the fit was over. I knew that the
+      crisis of my disorder had long passed. I knew that I had now
+      fully recovered the use of my visual faculties—and yet it was
+      dark—all dark—the intense and utter raylessness of the Night that
+      endureth for evermore.
+
+      I endeavored to shriek; and my lips and my parched tongue moved
+      convulsively together in the attempt—but no voice issued from the
+      cavernous lungs, which oppressed as if by the weight of some
+      incumbent mountain, gasped and palpitated, with the heart, at
+      every elaborate and struggling inspiration.
+
+      The movement of the jaws, in this effort to cry aloud, showed me
+      that they were bound up, as is usual with the dead. I felt, too,
+      that I lay upon some hard substance; and by something similar my
+      sides were, also, closely compressed. So far, I had not ventured
+      to stir any of my limbs—but now I violently threw up my arms,
+      which had been lying at length, with the wrists crossed. They
+      struck a solid wooden substance, which extended above my person
+      at an elevation of not more than six inches from my face. I could
+      no longer doubt that I reposed within a coffin at last.
+
+      And now, amid all my infinite miseries, came sweetly the cherub
+      Hope—for I thought of my precautions. I writhed, and made
+      spasmodic exertions to force open the lid: it would not move. I
+      felt my wrists for the bell-rope: it was not to be found. And now
+      the Comforter fled for ever, and a still sterner Despair reigned
+      triumphant; for I could not help perceiving the absence of the
+      paddings which I had so carefully prepared—and then, too, there
+      came suddenly to my nostrils the strong peculiar odor of moist
+      earth. The conclusion was irresistible. I was not within the
+      vault. I had fallen into a trance while absent from home—while
+      among strangers—when, or how, I could not remember—and it was
+      they who had buried me as a dog—nailed up in some common
+      coffin—and thrust deep, deep, and for ever, into some ordinary
+      and nameless grave.
+
+      As this awful conviction forced itself, thus, into the innermost
+      chambers of my soul, I once again struggled to cry aloud. And in
+      this second endeavor I succeeded. A long, wild, and continuous
+      shriek, or yell of agony, resounded through the realms of the
+      subterranean Night.
+
+      “Hillo! hillo, there!” said a gruff voice, in reply.
+
+      “What the devil’s the matter now!” said a second.
+
+      “Get out o’ that!” said a third.
+
+      “What do you mean by yowling in that ere kind of style, like a
+      cattymount?” said a fourth; and hereupon I was seized and shaken
+      without ceremony, for several minutes, by a junto of very
+      rough-looking individuals. They did not arouse me from my
+      slumber—for I was wide awake when I screamed—but they restored me
+      to the full possession of my memory.
+
+      This adventure occurred near Richmond, in Virginia. Accompanied
+      by a friend, I had proceeded, upon a gunning expedition, some
+      miles down the banks of the James River. Night approached, and we
+      were overtaken by a storm. The cabin of a small sloop lying at
+      anchor in the stream, and laden with garden mould, afforded us
+      the only available shelter. We made the best of it, and passed
+      the night on board. I slept in one of the only two berths in the
+      vessel—and the berths of a sloop of sixty or twenty tons need
+      scarcely be described. That which I occupied had no bedding of
+      any kind. Its extreme width was eighteen inches. The distance of
+      its bottom from the deck overhead was precisely the same. I found
+      it a matter of exceeding difficulty to squeeze myself in.
+      Nevertheless, I slept soundly, and the whole of my vision—for it
+      was no dream, and no nightmare—arose naturally from the
+      circumstances of my position—from my ordinary bias of thought—and
+      from the difficulty, to which I have alluded, of collecting my
+      senses, and especially of regaining my memory, for a long time
+      after awaking from slumber. The men who shook me were the crew of
+      the sloop, and some laborers engaged to unload it. From the load
+      itself came the earthly smell. The bandage about the jaws was a
+      silk handkerchief in which I had bound up my head, in default of
+      my customary nightcap.
+
+      The tortures endured, however, were indubitably quite equal for
+      the time, to those of actual sepulture. They were fearfully—they
+      were inconceivably hideous; but out of Evil proceeded Good; for
+      their very excess wrought in my spirit an inevitable revulsion.
+      My soul acquired tone—acquired temper. I went abroad. I took
+      vigorous exercise. I breathed the free air of Heaven. I thought
+      upon other subjects than Death. I discarded my medical books.
+      “Buchan” I burned. I read no “Night Thoughts”—no fustian about
+      churchyards—no bugaboo tales—such as this. In short, I became a
+      new man, and lived a man’s life. From that memorable night, I
+      dismissed forever my charnel apprehensions, and with them
+      vanished the cataleptic disorder, of which, perhaps, they had
+      been less the consequence than the cause.
+
+      There are moments when, even to the sober eye of Reason, the
+      world of our sad Humanity may assume the semblance of a Hell—but
+      the imagination of man is no Carathis, to explore with impunity
+      its every cavern. Alas! the grim legion of sepulchral terrors
+      cannot be regarded as altogether fanciful—but, like the Demons in
+      whose company Afrasiab made his voyage down the Oxus, they must
+      sleep, or they will devour us—they must be suffered to slumber,
+      or we perish.
+
+
+
+
+THE DOMAIN OF ARNHEIM
+
+
+The garden like a lady fair was cut,
+    That lay as if she slumbered in delight,
+And to the open skies her eyes did shut.
+    The azure fields of Heaven were ’sembled right
+    In a large round, set with the flowers of light.
+The flowers de luce, and the round sparks of dew
+That hung upon their azure leaves did shew
+Like twinkling stars that sparkle in the evening blue.
+                    —_Giles Fletcher_.
+
+      From his cradle to his grave a gale of prosperity bore my friend
+      Ellison along. Nor do I use the word prosperity in its mere
+      worldly sense. I mean it as synonymous with happiness. The person
+      of whom I speak seemed born for the purpose of foreshadowing the
+      doctrines of Turgot, Price, Priestley, and Condorcet—of
+      exemplifying by individual instance what has been deemed the
+      chimera of the perfectionists. In the brief existence of Ellison
+      I fancy that I have seen refuted the dogma, that in man’s very
+      nature lies some hidden principle, the antagonist of bliss. An
+      anxious examination of his career has given me to understand that
+      in general, from the violation of a few simple laws of humanity
+      arises the wretchedness of mankind—that as a species we have in
+      our possession the as yet unwrought elements of content—and that,
+      even now, in the present darkness and madness of all thought on
+      the great question of the social condition, it is not impossible
+      that man, the individual, under certain unusual and highly
+      fortuitous conditions, may be happy.
+
+      With opinions such as these my young friend, too, was fully
+      imbued, and thus it is worthy of observation that the
+      uninterrupted enjoyment which distinguished his life was, in
+      great measure, the result of preconcert. It is indeed evident
+      that with less of the instinctive philosophy which, now and then,
+      stands so well in the stead of experience, Mr. Ellison would have
+      found himself precipitated, by the very extraordinary success of
+      his life, into the common vortex of unhappiness which yawns for
+      those of pre-eminent endowments. But it is by no means my object
+      to pen an essay on happiness. The ideas of my friend may be
+      summed up in a few words. He admitted but four elementary
+      principles, or more strictly, conditions of bliss. That which he
+      considered chief was (strange to say!) the simple and purely
+      physical one of free exercise in the open air. “The health,” he
+      said, “attainable by other means is scarcely worth the name.” He
+      instanced the ecstasies of the fox-hunter, and pointed to the
+      tillers of the earth, the only people who, as a class, can be
+      fairly considered happier than others. His second condition was
+      the love of woman. His third, and most difficult of realization,
+      was the contempt of ambition. His fourth was an object of
+      unceasing pursuit; and he held that, other things being equal,
+      the extent of attainable happiness was in proportion to the
+      spirituality of this object.
+
+      Ellison was remarkable in the continuous profusion of good gifts
+      lavished upon him by fortune. In personal grace and beauty he
+      exceeded all men. His intellect was of that order to which the
+      acquisition of knowledge is less a labor than an intuition and a
+      necessity. His family was one of the most illustrious of the
+      empire. His bride was the loveliest and most devoted of women.
+      His possessions had been always ample; but on the attainment of
+      his majority, it was discovered that one of those extraordinary
+      freaks of fate had been played in his behalf which startle the
+      whole social world amid which they occur, and seldom fail
+      radically to alter the moral constitution of those who are their
+      objects.
+
+      It appears that about a hundred years before Mr. Ellison’s coming
+      of age, there had died, in a remote province, one Mr. Seabright
+      Ellison. This gentleman had amassed a princely fortune, and,
+      having no immediate connections, conceived the whim of suffering
+      his wealth to accumulate for a century after his decease.
+      Minutely and sagaciously directing the various modes of
+      investment, he bequeathed the aggregate amount to the nearest of
+      blood, bearing the name of Ellison, who should be alive at the
+      end of the hundred years. Many attempts had been made to set
+      aside this singular bequest; their ex post facto character
+      rendered them abortive; but the attention of a jealous government
+      was aroused, and a legislative act finally obtained, forbidding
+      all similar accumulations. This act, however, did not prevent
+      young Ellison from entering into possession, on his twenty-first
+      birthday, as the heir of his ancestor Seabright, of a fortune of
+      four hundred and fifty millions of dollars. (*1)
+
+      When it had become known that such was the enormous wealth
+      inherited, there were, of course, many speculations as to the
+      mode of its disposal. The magnitude and the immediate
+      availability of the sum bewildered all who thought on the topic.
+      The possessor of any appreciable amount of money might have been
+      imagined to perform any one of a thousand things. With riches
+      merely surpassing those of any citizen, it would have been easy
+      to suppose him engaging to supreme excess in the fashionable
+      extravagances of his time—or busying himself with political
+      intrigue—or aiming at ministerial power—or purchasing increase of
+      nobility—or collecting large museums of virtu—or playing the
+      munificent patron of letters, of science, of art—or endowing, and
+      bestowing his name upon extensive institutions of charity. But
+      for the inconceivable wealth in the actual possession of the
+      heir, these objects and all ordinary objects were felt to afford
+      too limited a field. Recourse was had to figures, and these but
+      sufficed to confound. It was seen that, even at three per cent.,
+      the annual income of the inheritance amounted to no less than
+      thirteen millions and five hundred thousand dollars; which was
+      one million and one hundred and twenty-five thousand per month;
+      or thirty-six thousand nine hundred and eighty-six per day; or
+      one thousand five hundred and forty-one per hour; or six and
+      twenty dollars for every minute that flew. Thus the usual track
+      of supposition was thoroughly broken up. Men knew not what to
+      imagine. There were some who even conceived that Mr. Ellison
+      would divest himself of at least one-half of his fortune, as of
+      utterly superfluous opulence—enriching whole troops of his
+      relatives by division of his superabundance. To the nearest of
+      these he did, in fact, abandon the very unusual wealth which was
+      his own before the inheritance.
+
+      I was not surprised, however, to perceive that he had long made
+      up his mind on a point which had occasioned so much discussion to
+      his friends. Nor was I greatly astonished at the nature of his
+      decision. In regard to individual charities he had satisfied his
+      conscience. In the possibility of any improvement, properly so
+      called, being effected by man himself in the general condition of
+      man, he had (I am sorry to confess it) little faith. Upon the
+      whole, whether happily or unhappily, he was thrown back, in very
+      great measure, upon self.
+
+      In the widest and noblest sense he was a poet. He comprehended,
+      moreover, the true character, the august aims, the supreme
+      majesty and dignity of the poetic sentiment. The fullest, if not
+      the sole proper satisfaction of this sentiment he instinctively
+      felt to lie in the creation of novel forms of beauty. Some
+      peculiarities, either in his early education, or in the nature of
+      his intellect, had tinged with what is termed materialism all his
+      ethical speculations; and it was this bias, perhaps, which led
+      him to believe that the most advantageous at least, if not the
+      sole legitimate field for the poetic exercise, lies in the
+      creation of novel moods of purely physical loveliness. Thus it
+      happened he became neither musician nor poet—if we use this
+      latter term in its every-day acceptation. Or it might have been
+      that he neglected to become either, merely in pursuance of his
+      idea that in contempt of ambition is to be found one of the
+      essential principles of happiness on earth. Is it not indeed,
+      possible that, while a high order of genius is necessarily
+      ambitious, the highest is above that which is termed ambition?
+      And may it not thus happen that many far greater than Milton have
+      contentedly remained “mute and inglorious?” I believe that the
+      world has never seen—and that, unless through some series of
+      accidents goading the noblest order of mind into distasteful
+      exertion, the world will never see—that full extent of triumphant
+      execution, in the richer domains of art, of which the human
+      nature is absolutely capable.
+
+      Ellison became neither musician nor poet; although no man lived
+      more profoundly enamored of music and poetry. Under other
+      circumstances than those which invested him, it is not impossible
+      that he would have become a painter. Sculpture, although in its
+      nature rigorously poetical was too limited in its extent and
+      consequences, to have occupied, at any time, much of his
+      attention. And I have now mentioned all the provinces in which
+      the common understanding of the poetic sentiment has declared it
+      capable of expatiating. But Ellison maintained that the richest,
+      the truest, and most natural, if not altogether the most
+      extensive province, had been unaccountably neglected. No
+      definition had spoken of the landscape-gardener as of the poet;
+      yet it seemed to my friend that the creation of the
+      landscape-garden offered to the proper Muse the most magnificent
+      of opportunities. Here, indeed, was the fairest field for the
+      display of imagination in the endless combining of forms of novel
+      beauty; the elements to enter into combination being, by a vast
+      superiority, the most glorious which the earth could afford. In
+      the multiform and multicolor of the flowers and the trees, he
+      recognised the most direct and energetic efforts of Nature at
+      physical loveliness. And in the direction or concentration of
+      this effort—or, more properly, in its adaptation to the eyes
+      which were to behold it on earth—he perceived that he should be
+      employing the best means—laboring to the greatest advantage—in
+      the fulfilment, not only of his own destiny as poet, but of the
+      august purposes for which the Deity had implanted the poetic
+      sentiment in man.
+
+      “Its adaptation to the eyes which were to behold it on earth.” In
+      his explanation of this phraseology, Mr. Ellison did much toward
+      solving what has always seemed to me an enigma:—I mean the fact
+      (which none but the ignorant dispute) that no such combination of
+      scenery exists in nature as the painter of genius may produce. No
+      such paradises are to be found in reality as have glowed on the
+      canvas of Claude. In the most enchanting of natural landscapes,
+      there will always be found a defect or an excess—many excesses
+      and defects. While the component parts may defy, individually,
+      the highest skill of the artist, the arrangement of these parts
+      will always be susceptible of improvement. In short, no position
+      can be attained on the wide surface of the natural earth, from
+      which an artistical eye, looking steadily, will not find matter
+      of offence in what is termed the “composition” of the landscape.
+      And yet how unintelligible is this! In all other matters we are
+      justly instructed to regard nature as supreme. With her details
+      we shrink from competition. Who shall presume to imitate the
+      colors of the tulip, or to improve the proportions of the lily of
+      the valley? The criticism which says, of sculpture or
+      portraiture, that here nature is to be exalted or idealized
+      rather than imitated, is in error. No pictorial or sculptural
+      combinations of points of human liveliness do more than approach
+      the living and breathing beauty. In landscape alone is the
+      principle of the critic true; and, having felt its truth here, it
+      is but the headlong spirit of generalization which has led him to
+      pronounce it true throughout all the domains of art. Having, I
+      say, felt its truth here; for the feeling is no affectation or
+      chimera. The mathematics afford no more absolute demonstrations
+      than the sentiments of his art yields the artist. He not only
+      believes, but positively knows, that such and such apparently
+      arbitrary arrangements of matter constitute and alone constitute
+      the true beauty. His reasons, however, have not yet been matured
+      into expression. It remains for a more profound analysis than the
+      world has yet seen, fully to investigate and express them.
+      Nevertheless he is confirmed in his instinctive opinions by the
+      voice of all his brethren. Let a “composition” be defective; let
+      an emendation be wrought in its mere arrangement of form; let
+      this emendation be submitted to every artist in the world; by
+      each will its necessity be admitted. And even far more than this;
+      in remedy of the defective composition, each insulated member of
+      the fraternity would have suggested the identical emendation.
+
+      I repeat that in landscape arrangements alone is the physical
+      nature susceptible of exaltation, and that, therefore, her
+      susceptibility of improvement at this one point, was a mystery I
+      had been unable to solve. My own thoughts on the subject had
+      rested in the idea that the primitive intention of nature would
+      have so arranged the earth’s surface as to have fulfilled at all
+      points man’s sense of perfection in the beautiful, the sublime,
+      or the picturesque; but that this primitive intention had been
+      frustrated by the known geological disturbances—disturbances of
+      form and color—grouping, in the correction or allaying of which
+      lies the soul of art. The force of this idea was much weakened,
+      however, by the necessity which it involved of considering the
+      disturbances abnormal and unadapted to any purpose. It was
+      Ellison who suggested that they were prognostic of death. He thus
+      explained:—Admit the earthly immortality of man to have been the
+      first intention. We have then the primitive arrangement of the
+      earth’s surface adapted to his blissful estate, as not existent
+      but designed. The disturbances were the preparations for his
+      subsequently conceived deathful condition.
+
+      “Now,” said my friend, “what we regard as exaltation of the
+      landscape may be really such, as respects only the moral or human
+      point of view. Each alteration of the natural scenery may
+      possibly effect a blemish in the picture, if we can suppose this
+      picture viewed at large—in mass—from some point distant from the
+      earth’s surface, although not beyond the limits of its
+      atmosphere. It is easily understood that what might improve a
+      closely scrutinized detail, may at the same time injure a general
+      or more distantly observed effect. There may be a class of
+      beings, human once, but now invisible to humanity, to whom, from
+      afar, our disorder may seem order—our unpicturesqueness
+      picturesque; in a word, the earth-angels, for whose scrutiny more
+      especially than our own, and for whose death-refined appreciation
+      of the beautiful, may have been set in array by God the wide
+      landscape-gardens of the hemispheres.”
+
+      In the course of discussion, my friend quoted some passages from
+      a writer on landscape-gardening who has been supposed to have
+      well treated his theme:
+
+      “There are properly but two styles of landscape-gardening, the
+      natural and the artificial. One seeks to recall the original
+      beauty of the country, by adapting its means to the surrounding
+      scenery, cultivating trees in harmony with the hills or plain of
+      the neighboring land; detecting and bringing into practice those
+      nice relations of size, proportion, and color which, hid from the
+      common observer, are revealed everywhere to the experienced
+      student of nature. The result of the natural style of gardening,
+      is seen rather in the absence of all defects and incongruities—in
+      the prevalence of a healthy harmony and order—than in the
+      creation of any special wonders or miracles. The artificial style
+      has as many varieties as there are different tastes to gratify.
+      It has a certain general relation to the various styles of
+      building. There are the stately avenues and retirements of
+      Versailles; Italian terraces; and a various mixed old English
+      style, which bears some relation to the domestic Gothic or
+      English Elizabethan architecture. Whatever may be said against
+      the abuses of the artificial landscape-gardening, a mixture of
+      pure art in a garden scene adds to it a great beauty. This is
+      partly pleasing to the eye, by the show of order and design, and
+      partly moral. A terrace, with an old moss-covered balustrade,
+      calls up at once to the eye the fair forms that have passed there
+      in other days. The slightest exhibition of art is an evidence of
+      care and human interest.”
+
+      “From what I have already observed,” said Ellison, “you will
+      understand that I reject the idea, here expressed, of recalling
+      the original beauty of the country. The original beauty is never
+      so great as that which may be introduced. Of course, every thing
+      depends on the selection of a spot with capabilities. What is
+      said about detecting and bringing into practice nice relations of
+      size, proportion, and color, is one of those mere vaguenesses of
+      speech which serve to veil inaccuracy of thought. The phrase
+      quoted may mean any thing, or nothing, and guides in no degree.
+      That the true result of the natural style of gardening is seen
+      rather in the absence of all defects and incongruities than in
+      the creation of any special wonders or miracles, is a proposition
+      better suited to the grovelling apprehension of the herd than to
+      the fervid dreams of the man of genius. The negative merit
+      suggested appertains to that hobbling criticism which, in
+      letters, would elevate Addison into apotheosis. In truth, while
+      that virtue which consists in the mere avoidance of vice appeals
+      directly to the understanding, and can thus be circumscribed in
+      rule, the loftier virtue, which flames in creation, can be
+      apprehended in its results alone. Rule applies but to the merits
+      of denial—to the excellencies which refrain. Beyond these, the
+      critical art can but suggest. We may be instructed to build a
+      “Cato,” but we are in vain told how to conceive a Parthenon or an
+      “Inferno.” The thing done, however; the wonder accomplished; and
+      the capacity for apprehension becomes universal. The sophists of
+      the negative school who, through inability to create, have
+      scoffed at creation, are now found the loudest in applause. What,
+      in its chrysalis condition of principle, affronted their demure
+      reason, never fails, in its maturity of accomplishment, to extort
+      admiration from their instinct of beauty.
+
+      “The author’s observations on the artificial style,” continued
+      Ellison, “are less objectionable. A mixture of pure art in a
+      garden scene adds to it a great beauty. This is just; as also is
+      the reference to the sense of human interest. The principle
+      expressed is incontrovertible—but there may be something beyond
+      it. There may be an object in keeping with the principle—an
+      object unattainable by the means ordinarily possessed by
+      individuals, yet which, if attained, would lend a charm to the
+      landscape-garden far surpassing that which a sense of merely
+      human interest could bestow. A poet, having very unusual
+      pecuniary resources, might, while retaining the necessary idea of
+      art or culture, or, as our author expresses it, of interest, so
+      imbue his designs at once with extent and novelty of beauty, as
+      to convey the sentiment of spiritual interference. It will be
+      seen that, in bringing about such result, he secures all the
+      advantages of interest or design, while relieving his work of the
+      harshness or technicality of the worldly art. In the most rugged
+      of wildernesses—in the most savage of the scenes of pure
+      nature—there is apparent the art of a creator; yet this art is
+      apparent to reflection only; in no respect has it the obvious
+      force of a feeling. Now let us suppose this sense of the Almighty
+      design to be one step depressed—to be brought into something like
+      harmony or consistency with the sense of human art—to form an
+      intermedium between the two:—let us imagine, for example, a
+      landscape whose combined vastness and definitiveness—whose united
+      beauty, magnificence, and strangeness, shall convey the idea of
+      care, or culture, or superintendence, on the part of beings
+      superior, yet akin to humanity—then the sentiment of interest is
+      preserved, while the art intervolved is made to assume the air of
+      an intermediate or secondary nature—a nature which is not God,
+      nor an emanation from God, but which still is nature in the sense
+      of the handiwork of the angels that hover between man and God.”
+
+      It was in devoting his enormous wealth to the embodiment of a
+      vision such as this—in the free exercise in the open air ensured
+      by the personal superintendence of his plans—in the unceasing
+      object which these plans afforded—in the high spirituality of the
+      object—in the contempt of ambition which it enabled him truly to
+      feel—in the perennial springs with which it gratified, without
+      possibility of satiating, that one master passion of his soul,
+      the thirst for beauty, above all, it was in the sympathy of a
+      woman, not unwomanly, whose loveliness and love enveloped his
+      existence in the purple atmosphere of Paradise, that Ellison
+      thought to find, and found, exemption from the ordinary cares of
+      humanity, with a far greater amount of positive happiness than
+      ever glowed in the rapt day-dreams of De Staël.
+
+      I despair of conveying to the reader any distinct conception of
+      the marvels which my friend did actually accomplish. I wish to
+      describe, but am disheartened by the difficulty of description,
+      and hesitate between detail and generality. Perhaps the better
+      course will be to unite the two in their extremes.
+
+      Mr. Ellison’s first step regarded, of course, the choice of a
+      locality, and scarcely had he commenced thinking on this point,
+      when the luxuriant nature of the Pacific Islands arrested his
+      attention. In fact, he had made up his mind for a voyage to the
+      South Seas, when a night’s reflection induced him to abandon the
+      idea. “Were I misanthropic,” he said, “such a locale would suit
+      me. The thoroughness of its insulation and seclusion, and the
+      difficulty of ingress and egress, would in such case be the charm
+      of charms; but as yet I am not Timon. I wish the composure but
+      not the depression of solitude. There must remain with me a
+      certain control over the extent and duration of my repose. There
+      will be frequent hours in which I shall need, too, the sympathy
+      of the poetic in what I have done. Let me seek, then, a spot not
+      far from a populous city—whose vicinity, also, will best enable
+      me to execute my plans.”
+
+      In search of a suitable place so situated, Ellison travelled for
+      several years, and I was permitted to accompany him. A thousand
+      spots with which I was enraptured he rejected without hesitation,
+      for reasons which satisfied me, in the end, that he was right. We
+      came at length to an elevated table-land of wonderful fertility
+      and beauty, affording a panoramic prospect very little less in
+      extent than that of Aetna, and, in Ellison’s opinion as well as
+      my own, surpassing the far-famed view from that mountain in all
+      the true elements of the picturesque.
+
+      “I am aware,” said the traveller, as he drew a sigh of deep
+      delight after gazing on this scene, entranced, for nearly an
+      hour, “I know that here, in my circumstances, nine-tenths of the
+      most fastidious of men would rest content. This panorama is
+      indeed glorious, and I should rejoice in it but for the excess of
+      its glory. The taste of all the architects I have ever known
+      leads them, for the sake of ‘prospect,’ to put up buildings on
+      hill-tops. The error is obvious. Grandeur in any of its moods,
+      but especially in that of extent, startles, excites—and then
+      fatigues, depresses. For the occasional scene nothing can be
+      better—for the constant view nothing worse. And, in the constant
+      view, the most objectionable phase of grandeur is that of extent;
+      the worst phase of extent, that of distance. It is at war with
+      the sentiment and with the sense of seclusion—the sentiment and
+      sense which we seek to humor in ‘retiring to the country.’ In
+      looking from the summit of a mountain we cannot help feeling
+      abroad in the world. The heart-sick avoid distant prospects as a
+      pestilence.”
+
+      It was not until toward the close of the fourth year of our
+      search that we found a locality with which Ellison professed
+      himself satisfied. It is, of course, needless to say where was
+      the locality. The late death of my friend, in causing his domain
+      to be thrown open to certain classes of visitors, has given to
+      Arnheim a species of secret and subdued if not solemn celebrity,
+      similar in kind, although infinitely superior in degree, to that
+      which so long distinguished Fonthill.
+
+      The usual approach to Arnheim was by the river. The visitor left
+      the city in the early morning. During the forenoon he passed
+      between shores of a tranquil and domestic beauty, on which grazed
+      innumerable sheep, their white fleeces spotting the vivid green
+      of rolling meadows. By degrees the idea of cultivation subsided
+      into that of merely pastoral care. This slowly became merged in a
+      sense of retirement—this again in a consciousness of solitude. As
+      the evening approached, the channel grew more narrow; the banks
+      more and more precipitous; and these latter were clothed in rich,
+      more profuse, and more sombre foliage. The water increased in
+      transparency. The stream took a thousand turns, so that at no
+      moment could its gleaming surface be seen for a greater distance
+      than a furlong. At every instant the vessel seemed imprisoned
+      within an enchanted circle, having insuperable and impenetrable
+      walls of foliage, a roof of ultramarine satin, and no floor—the
+      keel balancing itself with admirable nicety on that of a phantom
+      bark which, by some accident having been turned upside down,
+      floated in constant company with the substantial one, for the
+      purpose of sustaining it. The channel now became a gorge—although
+      the term is somewhat inapplicable, and I employ it merely because
+      the language has no word which better represents the most
+      striking—not the most distinctive—feature of the scene. The
+      character of gorge was maintained only in the height and
+      parallelism of the shores; it was lost altogether in their other
+      traits. The walls of the ravine (through which the clear water
+      still tranquilly flowed) arose to an elevation of a hundred and
+      occasionally of a hundred and fifty feet, and inclined so much
+      toward each other as, in a great measure, to shut out the light
+      of day; while the long plume-like moss which depended densely
+      from the intertwining shrubberies overhead, gave the whole chasm
+      an air of funereal gloom. The windings became more frequent and
+      intricate, and seemed often as if returning in upon themselves,
+      so that the voyager had long lost all idea of direction. He was,
+      moreover, enwrapt in an exquisite sense of the strange. The
+      thought of nature still remained, but her character seemed to
+      have undergone modification, there was a weird symmetry, a
+      thrilling uniformity, a wizard propriety in these her works. Not
+      a dead branch—not a withered leaf—not a stray pebble—not a patch
+      of the brown earth was anywhere visible. The crystal water welled
+      up against the clean granite, or the unblemished moss, with a
+      sharpness of outline that delighted while it bewildered the eye.
+
+      Having threaded the mazes of this channel for some hours, the
+      gloom deepening every moment, a sharp and unexpected turn of the
+      vessel brought it suddenly, as if dropped from heaven, into a
+      circular basin of very considerable extent when compared with the
+      width of the gorge. It was about two hundred yards in diameter,
+      and girt in at all points but one—that immediately fronting the
+      vessel as it entered—by hills equal in general height to the
+      walls of the chasm, although of a thoroughly different character.
+      Their sides sloped from the water’s edge at an angle of some
+      forty-five degrees, and they were clothed from base to summit—not
+      a perceptible point escaping—in a drapery of the most gorgeous
+      flower-blossoms; scarcely a green leaf being visible among the
+      sea of odorous and fluctuating color. This basin was of great
+      depth, but so transparent was the water that the bottom, which
+      seemed to consist of a thick mass of small round alabaster
+      pebbles, was distinctly visible by glimpses—that is to say,
+      whenever the eye could permit itself not to see, far down in the
+      inverted heaven, the duplicate blooming of the hills. On these
+      latter there were no trees, nor even shrubs of any size. The
+      impressions wrought on the observer were those of richness,
+      warmth, color, quietude, uniformity, softness, delicacy,
+      daintiness, voluptuousness, and a miraculous extremeness of
+      culture that suggested dreams of a new race of fairies,
+      laborious, tasteful, magnificent, and fastidious; but as the eye
+      traced upward the myriad-tinted slope, from its sharp junction
+      with the water to its vague termination amid the folds of
+      overhanging cloud, it became, indeed, difficult not to fancy a
+      panoramic cataract of rubies, sapphires, opals, and golden
+      onyxes, rolling silently out of the sky.
+
+      The visitor, shooting suddenly into this bay from out the gloom
+      of the ravine, is delighted but astounded by the full orb of the
+      declining sun, which he had supposed to be already far below the
+      horizon, but which now confronts him, and forms the sole
+      termination of an otherwise limitless vista seen through another
+      chasm-like rift in the hills.
+
+      But here the voyager quits the vessel which has borne him so far,
+      and descends into a light canoe of ivory, stained with arabesque
+      devices in vivid scarlet, both within and without. The poop and
+      beak of this boat arise high above the water, with sharp points,
+      so that the general form is that of an irregular crescent. It
+      lies on the surface of the bay with the proud grace of a swan. On
+      its ermined floor reposes a single feathery paddle of satin-wood;
+      but no oarsmen or attendant is to be seen. The guest is bidden to
+      be of good cheer—that the fates will take care of him. The larger
+      vessel disappears, and he is left alone in the canoe, which lies
+      apparently motionless in the middle of the lake. While he
+      considers what course to pursue, however, he becomes aware of a
+      gentle movement in the fairy bark. It slowly swings itself around
+      until its prow points toward the sun. It advances with a gentle
+      but gradually accelerated velocity, while the slight ripples it
+      creates seem to break about the ivory side in divinest
+      melody—seem to offer the only possible explanation of the
+      soothing yet melancholy music for whose unseen origin the
+      bewildered voyager looks around him in vain.
+
+      The canoe steadily proceeds, and the rocky gate of the vista is
+      approached, so that its depths can be more distinctly seen. To
+      the right arise a chain of lofty hills rudely and luxuriantly
+      wooded. It is observed, however, that the trait of exquisite
+      cleanness where the bank dips into the water, still prevails.
+      There is not one token of the usual river _débris_. To the left
+      the character of the scene is softer and more obviously
+      artificial. Here the bank slopes upward from the stream in a very
+      gentle ascent, forming a broad sward of grass of a texture
+      resembling nothing so much as velvet, and of a brilliancy of
+      green which would bear comparison with the tint of the purest
+      emerald. This plateau varies in width from ten to three hundred
+      yards; reaching from the river-bank to a wall, fifty feet high,
+      which extends, in an infinity of curves, but following the
+      general direction of the river, until lost in the distance to the
+      westward. This wall is of one continuous rock, and has been
+      formed by cutting perpendicularly the once rugged precipice of
+      the stream’s southern bank, but no trace of the labor has been
+      suffered to remain. The chiselled stone has the hue of ages, and
+      is profusely overhung and overspread with the ivy, the coral
+      honeysuckle, the eglantine, and the clematis. The uniformity of
+      the top and bottom lines of the wall is fully relieved by
+      occasional trees of gigantic height, growing singly or in small
+      groups, both along the plateau and in the domain behind the wall,
+      but in close proximity to it; so that frequent limbs (of the
+      black walnut especially) reach over and dip their pendent
+      extremities into the water. Farther back within the domain, the
+      vision is impeded by an impenetrable screen of foliage.
+
+      These things are observed during the canoe’s gradual approach to
+      what I have called the gate of the vista. On drawing nearer to
+      this, however, its chasm-like appearance vanishes; a new outlet
+      from the bay is discovered to the left—in which direction the
+      wall is also seen to sweep, still following the general course of
+      the stream. Down this new opening the eye cannot penetrate very
+      far; for the stream, accompanied by the wall, still bends to the
+      left, until both are swallowed up by the leaves.
+
+      The boat, nevertheless, glides magically into the winding
+      channel; and here the shore opposite the wall is found to
+      resemble that opposite the wall in the straight vista. Lofty
+      hills, rising occasionally into mountains, and covered with
+      vegetation in wild luxuriance, still shut in the scene.
+
+      Floating gently onward, but with a velocity slightly augmented,
+      the voyager, after many short turns, finds his progress
+      apparently barred by a gigantic gate or rather door of burnished
+      gold, elaborately carved and fretted, and reflecting the direct
+      rays of the now fast-sinking sun with an effulgence that seems to
+      wreath the whole surrounding forest in flames. This gate is
+      inserted in the lofty wall; which here appears to cross the river
+      at right angles. In a few moments, however, it is seen that the
+      main body of the water still sweeps in a gentle and extensive
+      curve to the left, the wall following it as before, while a
+      stream of considerable volume, diverging from the principal one,
+      makes its way, with a slight ripple, under the door, and is thus
+      hidden from sight. The canoe falls into the lesser channel and
+      approaches the gate. Its ponderous wings are slowly and musically
+      expanded. The boat glides between them, and commences a rapid
+      descent into a vast amphitheatre entirely begirt with purple
+      mountains, whose bases are laved by a gleaming river throughout
+      the full extent of their circuit. Meantime the whole Paradise of
+      Arnheim bursts upon the view. There is a gush of entrancing
+      melody; there is an oppressive sense of strange sweet odor;—there
+      is a dream-like intermingling to the eye of tall slender Eastern
+      trees—bosky shrubberies—flocks of golden and crimson
+      birds—lily-fringed lakes—meadows of violets, tulips, poppies,
+      hyacinths, and tuberoses—long intertangled lines of silver
+      streamlets—and, upspringing confusedly from amid all, a mass of
+      semi-Gothic, semi-Saracenic architecture sustaining itself by
+      miracle in mid-air, glittering in the red sunlight with a hundred
+      oriels, minarets, and pinnacles; and seeming the phantom
+      handiwork, conjointly, of the Sylphs, of the Fairies, of the
+      Genii and of the Gnomes.
+
+
+
+
+LANDOR’S COTTAGE
+
+
+A Pendant to “The Domain of Arnheim”
+
+      During A pedestrian trip last summer, through one or two of the
+      river counties of New York, I found myself, as the day declined,
+      somewhat embarrassed about the road I was pursuing. The land
+      undulated very remarkably; and my path, for the last hour, had
+      wound about and about so confusedly, in its effort to keep in the
+      valleys, that I no longer knew in what direction lay the sweet
+      village of B——, where I had determined to stop for the night. The
+      sun had scarcely shone—strictly speaking—during the day, which
+      nevertheless, had been unpleasantly warm. A smoky mist,
+      resembling that of the Indian summer, enveloped all things, and
+      of course, added to my uncertainty. Not that I cared much about
+      the matter. If I did not hit upon the village before sunset, or
+      even before dark, it was more than possible that a little Dutch
+      farmhouse, or something of that kind, would soon make its
+      appearance—although, in fact, the neighborhood (perhaps on
+      account of being more picturesque than fertile) was very sparsely
+      inhabited. At all events, with my knapsack for a pillow, and my
+      hound as a sentry, a bivouac in the open air was just the thing
+      which would have amused me. I sauntered on, therefore, quite at
+      ease—Ponto taking charge of my gun—until at length, just as I had
+      begun to consider whether the numerous little glades that led
+      hither and thither, were intended to be paths at all, I was
+      conducted by one of them into an unquestionable carriage track.
+      There could be no mistaking it. The traces of light wheels were
+      evident; and although the tall shrubberies and overgrown
+      undergrowth met overhead, there was no obstruction whatever
+      below, even to the passage of a Virginian mountain wagon—the most
+      aspiring vehicle, I take it, of its kind. The road, however,
+      except in being open through the wood—if wood be not too weighty
+      a name for such an assemblage of light trees—and except in the
+      particulars of evident wheel-tracks—bore no resemblance to any
+      road I had before seen. The tracks of which I speak were but
+      faintly perceptible—having been impressed upon the firm, yet
+      pleasantly moist surface of—what looked more like green Genoese
+      velvet than any thing else. It was grass, clearly—but grass such
+      as we seldom see out of England—so short, so thick, so even, and
+      so vivid in color. Not a single impediment lay in the
+      wheel-route—not even a chip or dead twig. The stones that once
+      obstructed the way had been carefully _placed_—not thrown—along
+      the sides of the lane, so as to define its boundaries at bottom
+      with a kind of half-precise, half-negligent, and wholly
+      picturesque definition. Clumps of wild flowers grew everywhere,
+      luxuriantly, in the interspaces.
+
+      What to make of all this, of course I knew not. Here was art
+      undoubtedly—that did not surprise me—all roads, in the ordinary
+      sense, are works of art; nor can I say that there was much to
+      wonder at in the mere excess of art manifested; all that seemed
+      to have been done, might have been done here—with such natural
+      “capabilities” (as they have it in the books on Landscape
+      Gardening)—with very little labor and expense. No; it was not the
+      amount but the character of the art which caused me to take a
+      seat on one of the blossomy stones and gaze up and down this
+      fairy-like avenue for half an hour or more in bewildered
+      admiration. One thing became more and more evident the longer I
+      gazed: an artist, and one with a most scrupulous eye for form,
+      had superintended all these arrangements. The greatest care had
+      been taken to preserve a due medium between the neat and graceful
+      on the one hand, and the pittoresque, in the true sense of the
+      Italian term, on the other. There were few straight, and no long
+      uninterrupted lines. The same effect of curvature or of color
+      appeared twice, usually, but not oftener, at any one point of
+      view. Everywhere was variety in uniformity. It was a piece of
+      “composition,” in which the most fastidiously critical taste
+      could scarcely have suggested an emendation.
+
+      I had turned to the right as I entered this road, and now,
+      arising, I continued in the same direction. The path was so
+      serpentine, that at no moment could I trace its course for more
+      than two or three paces in advance. Its character did not undergo
+      any material change.
+
+      Presently the murmur of water fell gently upon my ear—and in a
+      few moments afterward, as I turned with the road somewhat more
+      abruptly than hitherto, I became aware that a building of some
+      kind lay at the foot of a gentle declivity just before me. I
+      could see nothing distinctly on account of the mist which
+      occupied all the little valley below. A gentle breeze, however,
+      now arose, as the sun was about descending; and while I remained
+      standing on the brow of the slope, the fog gradually became
+      dissipated into wreaths, and so floated over the scene.
+
+      As it came fully into view—thus gradually as I describe it—piece
+      by piece, here a tree, there a glimpse of water, and here again
+      the summit of a chimney, I could scarcely help fancying that the
+      whole was one of the ingenious illusions sometimes exhibited
+      under the name of “vanishing pictures.”
+
+      By the time, however, that the fog had thoroughly disappeared,
+      the sun had made its way down behind the gentle hills, and
+      thence, as if with a slight chassez to the south, had come again
+      fully into sight, glaring with a purplish lustre through a chasm
+      that entered the valley from the west. Suddenly, therefore—and as
+      if by the hand of magic—this whole valley and every thing in it
+      became brilliantly visible.
+
+      The first _coup d’œil_, as the sun slid into the position
+      described, impressed me very much as I have been impressed, when
+      a boy, by the concluding scene of some well-arranged theatrical
+      spectacle or melodrama. Not even the monstrosity of color was
+      wanting; for the sunlight came out through the chasm, tinted all
+      orange and purple; while the vivid green of the grass in the
+      valley was reflected more or less upon all objects from the
+      curtain of vapor that still hung overhead, as if loth to take its
+      total departure from a scene so enchantingly beautiful.
+
+      The little vale into which I thus peered down from under the fog
+      canopy could not have been more than four hundred yards long;
+      while in breadth it varied from fifty to one hundred and fifty or
+      perhaps two hundred. It was most narrow at its northern
+      extremity, opening out as it tended southwardly, but with no very
+      precise regularity. The widest portion was within eighty yards of
+      the southern extreme. The slopes which encompassed the vale could
+      not fairly be called hills, unless at their northern face. Here a
+      precipitous ledge of granite arose to a height of some ninety
+      feet; and, as I have mentioned, the valley at this point was not
+      more than fifty feet wide; but as the visitor proceeded
+      southwardly from the cliff, he found on his right hand and on his
+      left, declivities at once less high, less precipitous, and less
+      rocky. All, in a word, sloped and softened to the south; and yet
+      the whole vale was engirdled by eminences, more or less high,
+      except at two points. One of these I have already spoken of. It
+      lay considerably to the north of west, and was where the setting
+      sun made its way, as I have before described, into the
+      amphitheatre, through a cleanly cut natural cleft in the granite
+      embankment; this fissure might have been ten yards wide at its
+      widest point, so far as the eye could trace it. It seemed to lead
+      up, up like a natural causeway, into the recesses of unexplored
+      mountains and forests. The other opening was directly at the
+      southern end of the vale. Here, generally, the slopes were
+      nothing more than gentle inclinations, extending from east to
+      west about one hundred and fifty yards. In the middle of this
+      extent was a depression, level with the ordinary floor of the
+      valley. As regards vegetation, as well as in respect to every
+      thing else, the scene softened and sloped to the south. To the
+      north—on the craggy precipice—a few paces from the verge—up
+      sprang the magnificent trunks of numerous hickories, black
+      walnuts, and chestnuts, interspersed with occasional oak; and the
+      strong lateral branches thrown out by the walnuts especially,
+      spread far over the edge of the cliff. Proceeding southwardly,
+      the explorer saw, at first, the same class of trees, but less and
+      less lofty and Salvatorish in character; then he saw the gentler
+      elm, succeeded by the sassafras and locust—these again by the
+      softer linden, red-bud, catalpa, and maple—these yet again by
+      still more graceful and more modest varieties. The whole face of
+      the southern declivity was covered with wild shrubbery alone—an
+      occasional silver willow or white poplar excepted. In the bottom
+      of the valley itself—(for it must be borne in mind that the
+      vegetation hitherto mentioned grew only on the cliffs or
+      hillsides)—were to be seen three insulated trees. One was an elm
+      of fine size and exquisite form: it stood guard over the southern
+      gate of the vale. Another was a hickory, much larger than the
+      elm, and altogether a much finer tree, although both were
+      exceedingly beautiful: it seemed to have taken charge of the
+      northwestern entrance, springing from a group of rocks in the
+      very jaws of the ravine, and throwing its graceful body, at an
+      angle of nearly forty-five degrees, far out into the sunshine of
+      the amphitheatre. About thirty yards east of this tree stood,
+      however, the pride of the valley, and beyond all question the
+      most magnificent tree I have ever seen, unless, perhaps, among
+      the cypresses of the Itchiatuckanee. It was a triple-stemmed
+      tulip-tree—the Liriodendron Tulipiferum—one of the natural order
+      of magnolias. Its three trunks separated from the parent at about
+      three feet from the soil, and diverging very slightly and
+      gradually, were not more than four feet apart at the point where
+      the largest stem shot out into foliage: this was at an elevation
+      of about eighty feet. The whole height of the principal division
+      was one hundred and twenty feet. Nothing can surpass in beauty
+      the form, or the glossy, vivid green of the leaves of the
+      tulip-tree. In the present instance they were fully eight inches
+      wide; but their glory was altogether eclipsed by the gorgeous
+      splendor of the profuse blossoms. Conceive, closely congregated,
+      a million of the largest and most resplendent tulips! Only thus
+      can the reader get any idea of the picture I would convey. And
+      then the stately grace of the clean, delicately-granulated
+      columnar stems, the largest four feet in diameter, at twenty from
+      the ground. The innumerable blossoms, mingling with those of
+      other trees scarcely less beautiful, although infinitely less
+      majestic, filled the valley with more than Arabian perfumes.
+
+      The general floor of the amphitheatre was grass of the same
+      character as that I had found in the road; if anything, more
+      deliciously soft, thick, velvety, and miraculously green. It was
+      hard to conceive how all this beauty had been attained.
+
+      I have spoken of two openings into the vale. From the one to the
+      northwest issued a rivulet, which came, gently murmuring and
+      slightly foaming, down the ravine, until it dashed against the
+      group of rocks out of which sprang the insulated hickory. Here,
+      after encircling the tree, it passed on a little to the north of
+      east, leaving the tulip tree some twenty feet to the south, and
+      making no decided alteration in its course until it came near the
+      midway between the eastern and western boundaries of the valley.
+      At this point, after a series of sweeps, it turned off at right
+      angles and pursued a generally southern direction meandering as
+      it went—until it became lost in a small lake of irregular figure
+      (although roughly oval), that lay gleaming near the lower
+      extremity of the vale. This lakelet was, perhaps, a hundred yards
+      in diameter at its widest part. No crystal could be clearer than
+      its waters. Its bottom, which could be distinctly seen, consisted
+      altogether, of pebbles brilliantly white. Its banks, of the
+      emerald grass already described, rounded, rather than sloped, off
+      into the clear heaven below; and so clear was this heaven, so
+      perfectly, at times, did it reflect all objects above it, that
+      where the true bank ended and where the mimic one commenced, it
+      was a point of no little difficulty to determine. The trout, and
+      some other varieties of fish, with which this pond seemed to be
+      almost inconveniently crowded, had all the appearance of
+      veritable flying-fish. It was almost impossible to believe that
+      they were not absolutely suspended in the air. A light birch
+      canoe that lay placidly on the water, was reflected in its
+      minutest fibres with a fidelity unsurpassed by the most
+      exquisitely polished mirror. A small island, fairly laughing with
+      flowers in full bloom, and affording little more space than just
+      enough for a picturesque little building, seemingly a
+      fowl-house—arose from the lake not far from its northern shore—to
+      which it was connected by means of an inconceivably light-looking
+      and yet very primitive bridge. It was formed of a single, broad
+      and thick plank of the tulip wood. This was forty feet long, and
+      spanned the interval between shore and shore with a slight but
+      very perceptible arch, preventing all oscillation. From the
+      southern extreme of the lake issued a continuation of the
+      rivulet, which, after meandering for, perhaps, thirty yards,
+      finally passed through the “depression” (already described) in
+      the middle of the southern declivity, and tumbling down a sheer
+      precipice of a hundred feet, made its devious and unnoticed way
+      to the Hudson.
+
+      The lake was deep—at some points thirty feet—but the rivulet
+      seldom exceeded three, while its greatest width was about eight.
+      Its bottom and banks were as those of the pond—if a defect could
+      have been attributed, in point of picturesqueness, it was that of
+      excessive neatness.
+
+      The expanse of the green turf was relieved, here and there, by an
+      occasional showy shrub, such as the hydrangea, or the common
+      snowball, or the aromatic seringa; or, more frequently, by a
+      clump of geraniums blossoming gorgeously in great varieties.
+      These latter grew in pots which were carefully buried in the
+      soil, so as to give the plants the appearance of being
+      indigenous. Besides all this, the lawn’s velvet was exquisitely
+      spotted with sheep—a considerable flock of which roamed about the
+      vale, in company with three tamed deer, and a vast number of
+      brilliantly-plumed ducks. A very large mastiff seemed to be in
+      vigilant attendance upon these animals, each and all.
+
+      Along the eastern and western cliffs—where, toward the upper
+      portion of the amphitheatre, the boundaries were more or less
+      precipitous—grew ivy in great profusion—so that only here and
+      there could even a glimpse of the naked rock be obtained. The
+      northern precipice, in like manner, was almost entirely clothed
+      by grape-vines of rare luxuriance; some springing from the soil
+      at the base of the cliff, and others from ledges on its face.
+
+      The slight elevation which formed the lower boundary of this
+      little domain, was crowned by a neat stone wall, of sufficient
+      height to prevent the escape of the deer. Nothing of the fence
+      kind was observable elsewhere; for nowhere else was an artificial
+      enclosure needed:—any stray sheep, for example, which should
+      attempt to make its way out of the vale by means of the ravine,
+      would find its progress arrested, after a few yards’ advance, by
+      the precipitous ledge of rock over which tumbled the cascade that
+      had arrested my attention as I first drew near the domain. In
+      short, the only ingress or egress was through a gate occupying a
+      rocky pass in the road, a few paces below the point at which I
+      stopped to reconnoitre the scene.
+
+      I have described the brook as meandering very irregularly through
+      the whole of its course. Its two general directions, as I have
+      said, were first from west to east, and then from north to south.
+      At the turn, the stream, sweeping backward, made an almost
+      circular loop, so as to form a peninsula which was very nearly an
+      island, and which included about the sixteenth of an acre. On
+      this peninsula stood a dwelling-house—and when I say that this
+      house, like the infernal terrace seen by Vathek, “etait d’une
+      architecture inconnue dans les annales de la terre,” I mean,
+      merely, that its tout ensemble struck me with the keenest sense
+      of combined novelty and propriety—in a word, of poetry—(for, than
+      in the words just employed, I could scarcely give, of poetry in
+      the abstract, a more rigorous definition)—and I do not mean that
+      merely outre was perceptible in any respect.
+
+      In fact nothing could well be more simple—more utterly
+      unpretending than this cottage. Its marvellous effect lay
+      altogether in its artistic arrangement as a picture. I could have
+      fancied, while I looked at it, that some eminent
+      landscape-painter had built it with his brush.
+
+      The point of view from which I first saw the valley, was not
+      altogether, although it was nearly, the best point from which to
+      survey the house. I will therefore describe it as I afterwards
+      saw it—from a position on the stone wall at the southern extreme
+      of the amphitheatre.
+
+      The main building was about twenty-four feet long and sixteen
+      broad—certainly not more. Its total height, from the ground to
+      the apex of the roof, could not have exceeded eighteen feet. To
+      the west end of this structure was attached one about a third
+      smaller in all its proportions:—the line of its front standing
+      back about two yards from that of the larger house, and the line
+      of its roof, of course, being considerably depressed below that
+      of the roof adjoining. At right angles to these buildings, and
+      from the rear of the main one—not exactly in the middle—extended
+      a third compartment, very small—being, in general, one-third less
+      than the western wing. The roofs of the two larger were very
+      steep—sweeping down from the ridge-beam with a long concave
+      curve, and extending at least four feet beyond the walls in
+      front, so as to form the roofs of two piazzas. These latter
+      roofs, of course, needed no support; but as they had the air of
+      needing it, slight and perfectly plain pillars were inserted at
+      the corners alone. The roof of the northern wing was merely an
+      extension of a portion of the main roof. Between the chief
+      building and western wing arose a very tall and rather slender
+      square chimney of hard Dutch bricks, alternately black and red:—a
+      slight cornice of projecting bricks at the top. Over the gables
+      the roofs also projected very much:—in the main building about
+      four feet to the east and two to the west. The principal door was
+      not exactly in the main division, being a little to the
+      east—while the two windows were to the west. These latter did not
+      extend to the floor, but were much longer and narrower than
+      usual—they had single shutters like doors—the panes were of
+      lozenge form, but quite large. The door itself had its upper half
+      of glass, also in lozenge panes—a movable shutter secured it at
+      night. The door to the west wing was in its gable, and quite
+      simple—a single window looked out to the south. There was no
+      external door to the north wing, and it also had only one window
+      to the east.
+
+      The blank wall of the eastern gable was relieved by stairs (with
+      a balustrade) running diagonally across it—the ascent being from
+      the south. Under cover of the widely projecting eave these steps
+      gave access to a door leading to the garret, or rather loft—for
+      it was lighted only by a single window to the north, and seemed
+      to have been intended as a store-room.
+
+      The piazzas of the main building and western wing had no floors,
+      as is usual; but at the doors and at each window, large, flat
+      irregular slabs of granite lay imbedded in the delicious turf,
+      affording comfortable footing in all weather. Excellent paths of
+      the same material—not nicely adapted, but with the velvety sod
+      filling frequent intervals between the stones, led hither and
+      thither from the house, to a crystal spring about five paces off,
+      to the road, or to one or two out-houses that lay to the north,
+      beyond the brook, and were thoroughly concealed by a few locusts
+      and catalpas.
+
+      Not more than six steps from the main door of the cottage stood
+      the dead trunk of a fantastic pear-tree, so clothed from head to
+      foot in the gorgeous bignonia blossoms that one required no
+      little scrutiny to determine what manner of sweet thing it could
+      be. From various arms of this tree hung cages of different kinds.
+      In one, a large wicker cylinder with a ring at top, revelled a
+      mocking bird; in another an oriole; in a third the impudent
+      bobolink—while three or four more delicate prisons were loudly
+      vocal with canaries.
+
+      The pillars of the piazza were enwreathed in jasmine and sweet
+      honeysuckle; while from the angle formed by the main structure
+      and its west wing, in front, sprang a grape-vine of unexampled
+      luxuriance. Scorning all restraint, it had clambered first to the
+      lower roof—then to the higher; and along the ridge of this latter
+      it continued to writhe on, throwing out tendrils to the right and
+      left, until at length it fairly attained the east gable, and fell
+      trailing over the stairs.
+
+      The whole house, with its wings, was constructed of the
+      old-fashioned Dutch shingles—broad, and with unrounded corners.
+      It is a peculiarity of this material to give houses built of it
+      the appearance of being wider at bottom than at top—after the
+      manner of Egyptian architecture; and in the present instance,
+      this exceedingly picturesque effect was aided by numerous pots of
+      gorgeous flowers that almost encompassed the base of the
+      buildings.
+
+      The shingles were painted a dull gray; and the happiness with
+      which this neutral tint melted into the vivid green of the tulip
+      tree leaves that partially overshadowed the cottage, can readily
+      be conceived by an artist.
+
+      From the position near the stone wall, as described, the
+      buildings were seen at great advantage—for the southeastern angle
+      was thrown forward—so that the eye took in at once the whole of
+      the two fronts, with the picturesque eastern gable, and at the
+      same time obtained just a sufficient glimpse of the northern
+      wing, with parts of a pretty roof to the spring-house, and nearly
+      half of a light bridge that spanned the brook in the near
+      vicinity of the main buildings.
+
+      I did not remain very long on the brow of the hill, although long
+      enough to make a thorough survey of the scene at my feet. It was
+      clear that I had wandered from the road to the village, and I had
+      thus good traveller’s excuse to open the gate before me, and
+      inquire my way, at all events; so, without more ado, I proceeded.
+
+      The road, after passing the gate, seemed to lie upon a natural
+      ledge, sloping gradually down along the face of the north-eastern
+      cliffs. It led me on to the foot of the northern precipice, and
+      thence over the bridge, round by the eastern gable to the front
+      door. In this progress, I took notice that no sight of the
+      out-houses could be obtained.
+
+      As I turned the corner of the gable, the mastiff bounded towards
+      me in stern silence, but with the eye and the whole air of a
+      tiger. I held him out my hand, however, in token of amity—and I
+      never yet knew the dog who was proof against such an appeal to
+      his courtesy. He not only shut his mouth and wagged his tail, but
+      absolutely offered me his paw—afterward extending his civilities
+      to Ponto.
+
+      As no bell was discernible, I rapped with my stick against the
+      door, which stood half open. Instantly a figure advanced to the
+      threshold—that of a young woman about twenty-eight years of
+      age—slender, or rather slight, and somewhat above the medium
+      height. As she approached, with a certain modest decision of step
+      altogether indescribable. I said to myself, “Surely here I have
+      found the perfection of natural, in contradistinction from
+      artificial grace.” The second impression which she made on me,
+      but by far the more vivid of the two, was that of enthusiasm. So
+      intense an expression of romance, perhaps I should call it, or of
+      unworldliness, as that which gleamed from her deep-set eyes, had
+      never so sunk into my heart of hearts before. I know not how it
+      is, but this peculiar expression of the eye, wreathing itself
+      occasionally into the lips, is the most powerful, if not
+      absolutely the sole spell, which rivets my interest in woman.
+      “Romance,” provided my readers fully comprehended what I would
+      here imply by the word—“romance” and “womanliness” seem to me
+      convertible terms: and, after all, what man truly loves in woman,
+      is simply her womanhood. The eyes of Annie (I heard some one from
+      the interior call her “Annie, darling!”) were “spiritual grey;”
+      her hair, a light chestnut: this is all I had time to observe of
+      her.
+
+      At her most courteous of invitations, I entered—passing first
+      into a tolerably wide vestibule. Having come mainly to observe, I
+      took notice that to my right as I stepped in, was a window, such
+      as those in front of the house; to the left, a door leading into
+      the principal room; while, opposite me, an open door enabled me
+      to see a small apartment, just the size of the vestibule,
+      arranged as a study, and having a large bow window looking out to
+      the north.
+
+      Passing into the parlor, I found myself with Mr. Landor—for this,
+      I afterwards found, was his name. He was civil, even cordial in
+      his manner, but just then, I was more intent on observing the
+      arrangements of the dwelling which had so much interested me,
+      than the personal appearance of the tenant.
+
+      The north wing, I now saw, was a bed-chamber, its door opened
+      into the parlor. West of this door was a single window, looking
+      toward the brook. At the west end of the parlor, were a
+      fireplace, and a door leading into the west wing—probably a
+      kitchen.
+
+      Nothing could be more rigorously simple than the furniture of the
+      parlor. On the floor was an ingrain carpet, of excellent
+      texture—a white ground, spotted with small circular green
+      figures. At the windows were curtains of snowy white jaconet
+      muslin: they were tolerably full, and hung decisively, perhaps
+      rather formally in sharp, parallel plaits to the floor—just to
+      the floor. The walls were prepared with a French paper of great
+      delicacy, a silver ground, with a faint green cord running
+      zig-zag throughout. Its expanse was relieved merely by three of
+      Julien’s exquisite lithographs a trois crayons, fastened to the
+      wall without frames. One of these drawings was a scene of
+      Oriental luxury, or rather voluptuousness; another was a
+      “carnival piece,” spirited beyond compare; the third was a Greek
+      female head—a face so divinely beautiful, and yet of an
+      expression so provokingly indeterminate, never before arrested my
+      attention.
+
+      The more substantial furniture consisted of a round table, a few
+      chairs (including a large rocking-chair), and a sofa, or rather
+      “settee;” its material was plain maple painted a creamy white,
+      slightly interstriped with green; the seat of cane. The chairs
+      and table were “to match,” but the forms of all had evidently
+      been designed by the same brain which planned “the grounds;” it
+      is impossible to conceive anything more graceful.
+
+      On the table were a few books; a large, square, crystal bottle of
+      some novel perfume; a plain ground glass _astral_ (not solar)
+      lamp with an Italian shade; and a large vase of
+      resplendently-blooming flowers. Flowers, indeed, of gorgeous
+      colours and delicate odour formed the sole mere decoration of the
+      apartment. The fire-place was nearly filled with a vase of
+      brilliant geranium. On a triangular shelf in each angle of the
+      room stood also a similar vase, varied only as to its lovely
+      contents. One or two smaller bouquets adorned the mantel, and
+      late violets clustered about the open windows.
+
+      It is not the purpose of this work to do more than give in
+      detail, a picture of Mr. Landor’s residence—as I found it. How he
+      made it what it was—and why—with some particulars of Mr. Landor
+      himself—may, possibly form the subject of another article.
+
+
+
+
+WILLIAM WILSON
+
+
+    What say of it? what say of CONSCIENCE grim,
+    That spectre in my path?
+                    —_Chamberlayne’s Pharronida._
+
+      Let me call myself, for the present, William Wilson. The fair
+      page now lying before me need not be sullied with my real
+      appellation. This has been already too much an object for the
+      scorn—for the horror—for the detestation of my race. To the
+      uttermost regions of the globe have not the indignant winds
+      bruited its unparalleled infamy? Oh, outcast of all outcasts most
+      abandoned!—to the earth art thou not forever dead? to its honors,
+      to its flowers, to its golden aspirations?—and a cloud, dense,
+      dismal, and limitless, does it not hang eternally between thy
+      hopes and heaven?
+
+      I would not, if I could, here or to-day, embody a record of my
+      later years of unspeakable misery, and unpardonable crime. This
+      epoch—these later years—took unto themselves a sudden elevation
+      in turpitude, whose origin alone it is my present purpose to
+      assign. Men usually grow base by degrees. From me, in an instant,
+      all virtue dropped bodily as a mantle. From comparatively trivial
+      wickedness I passed, with the stride of a giant, into more than
+      the enormities of an Elah-Gabalus. What chance—what one event
+      brought this evil thing to pass, bear with me while I relate.
+      Death approaches; and the shadow which foreruns him has thrown a
+      softening influence over my spirit. I long, in passing through
+      the dim valley, for the sympathy—I had nearly said for the
+      pity—of my fellow men. I would fain have them believe that I have
+      been, in some measure, the slave of circumstances beyond human
+      control. I would wish them to seek out for me, in the details I
+      am about to give, some little oasis of fatality amid a wilderness
+      of error. I would have them allow—what they cannot refrain from
+      allowing—that, although temptation may have erewhile existed as
+      great, man was never thus, at least, tempted before—certainly,
+      never thus fell. And is it therefore that he has never thus
+      suffered? Have I not indeed been living in a dream? And am I not
+      now dying a victim to the horror and the mystery of the wildest
+      of all sublunary visions?
+
+      I am the descendant of a race whose imaginative and easily
+      excitable temperament has at all times rendered them remarkable;
+      and, in my earliest infancy, I gave evidence of having fully
+      inherited the family character. As I advanced in years it was
+      more strongly developed; becoming, for many reasons, a cause of
+      serious disquietude to my friends, and of positive injury to
+      myself. I grew self-willed, addicted to the wildest caprices, and
+      a prey to the most ungovernable passions. Weak-minded, and beset
+      with constitutional infirmities akin to my own, my parents could
+      do but little to check the evil propensities which distinguished
+      me. Some feeble and ill-directed efforts resulted in complete
+      failure on their part, and, of course, in total triumph on mine.
+      Thenceforward my voice was a household law; and at an age when
+      few children have abandoned their leading-strings, I was left to
+      the guidance of my own will, and became, in all but name, the
+      master of my own actions.
+
+      My earliest recollections of a school-life, are connected with a
+      large, rambling, Elizabethan house, in a misty-looking village of
+      England, where were a vast number of gigantic and gnarled trees,
+      and where all the houses were excessively ancient. In truth, it
+      was a dream-like and spirit-soothing place, that venerable old
+      town. At this moment, in fancy, I feel the refreshing chilliness
+      of its deeply-shadowed avenues, inhale the fragrance of its
+      thousand shrubberies, and thrill anew with undefinable delight,
+      at the deep hollow note of the church-bell, breaking, each hour,
+      with sullen and sudden roar, upon the stillness of the dusky
+      atmosphere in which the fretted Gothic steeple lay imbedded and
+      asleep.
+
+      It gives me, perhaps, as much of pleasure as I can now in any
+      manner experience, to dwell upon minute recollections of the
+      school and its concerns. Steeped in misery as I am—misery, alas!
+      only too real—I shall be pardoned for seeking relief, however
+      slight and temporary, in the weakness of a few rambling details.
+      These, moreover, utterly trivial, and even ridiculous in
+      themselves, assume, to my fancy, adventitious importance, as
+      connected with a period and a locality when and where I recognise
+      the first ambiguous monitions of the destiny which afterwards so
+      fully overshadowed me. Let me then remember.
+
+      The house, I have said, was old and irregular. The grounds were
+      extensive, and a high and solid brick wall, topped with a bed of
+      mortar and broken glass, encompassed the whole. This prison-like
+      rampart formed the limit of our domain; beyond it we saw but
+      thrice a week—once every Saturday afternoon, when, attended by
+      two ushers, we were permitted to take brief walks in a body
+      through some of the neighbouring fields—and twice during Sunday,
+      when we were paraded in the same formal manner to the morning and
+      evening service in the one church of the village. Of this church
+      the principal of our school was pastor. With how deep a spirit of
+      wonder and perplexity was I wont to regard him from our remote
+      pew in the gallery, as, with step solemn and slow, he ascended
+      the pulpit! This reverend man, with countenance so demurely
+      benign, with robes so glossy and so clerically flowing, with wig
+      so minutely powdered, so rigid and so vast,—-could this be he
+      who, of late, with sour visage, and in snuffy habiliments,
+      administered, ferule in hand, the Draconian laws of the academy?
+      Oh, gigantic paradox, too utterly monstrous for solution!
+
+      At an angle of the ponderous wall frowned a more ponderous gate.
+      It was riveted and studded with iron bolts, and surmounted with
+      jagged iron spikes. What impressions of deep awe did it inspire!
+      It was never opened save for the three periodical egressions and
+      ingressions already mentioned; then, in every creak of its mighty
+      hinges, we found a plenitude of mystery—a world of matter for
+      solemn remark, or for more solemn meditation.
+
+      The extensive enclosure was irregular in form, having many
+      capacious recesses. Of these, three or four of the largest
+      constituted the play-ground. It was level, and covered with fine
+      hard gravel. I well remember it had no trees, nor benches, nor
+      anything similar within it. Of course it was in the rear of the
+      house. In front lay a small parterre, planted with box and other
+      shrubs, but through this sacred division we passed only upon rare
+      occasions indeed—such as a first advent to school or final
+      departure thence, or perhaps, when a parent or friend having
+      called for us, we joyfully took our way home for the Christmas or
+      Midsummer holidays.
+
+      But the house!—how quaint an old building was this!—to me how
+      veritably a palace of enchantment! There was really no end to its
+      windings—to its incomprehensible subdivisions. It was difficult,
+      at any given time, to say with certainty upon which of its two
+      stories one happened to be. From each room to every other there
+      were sure to be found three or four steps either in ascent or
+      descent. Then the lateral branches were
+      innumerable—inconceivable—and so returning in upon themselves,
+      that our most exact ideas in regard to the whole mansion were not
+      very far different from those with which we pondered upon
+      infinity. During the five years of my residence here, I was never
+      able to ascertain with precision, in what remote locality lay the
+      little sleeping apartment assigned to myself and some eighteen or
+      twenty other scholars.
+
+      The school-room was the largest in the house—I could not help
+      thinking, in the world. It was very long, narrow, and dismally
+      low, with pointed Gothic windows and a ceiling of oak. In a
+      remote and terror-inspiring angle was a square enclosure of eight
+      or ten feet, comprising the sanctum, “during hours,” of our
+      principal, the Reverend Dr. Bransby. It was a solid structure,
+      with massy door, sooner than open which in the absence of the
+      “Dominie,” we would all have willingly perished by the _peine
+      forte et dure_. In other angles were two other similar boxes, far
+      less reverenced, indeed, but still greatly matters of awe. One of
+      these was the pulpit of the “classical” usher, one of the
+      “English and mathematical.” Interspersed about the room, crossing
+      and recrossing in endless irregularity, were innumerable benches
+      and desks, black, ancient, and time-worn, piled desperately with
+      much-bethumbed books, and so beseamed with initial letters, names
+      at full length, grotesque figures, and other multiplied efforts
+      of the knife, as to have entirely lost what little of original
+      form might have been their portion in days long departed. A huge
+      bucket with water stood at one extremity of the room, and a clock
+      of stupendous dimensions at the other.
+
+      Encompassed by the massy walls of this venerable academy, I
+      passed, yet not in tedium or disgust, the years of the third
+      lustrum of my life. The teeming brain of childhood requires no
+      external world of incident to occupy or amuse it; and the
+      apparently dismal monotony of a school was replete with more
+      intense excitement than my riper youth has derived from luxury,
+      or my full manhood from crime. Yet I must believe that my first
+      mental development had in it much of the uncommon—even much of
+      the _outré_. Upon mankind at large the events of very early
+      existence rarely leave in mature age any definite impression. All
+      is gray shadow—a weak and irregular remembrance—an indistinct
+      regathering of feeble pleasures and phantasmagoric pains. With me
+      this is not so. In childhood I must have felt with the energy of
+      a man what I now find stamped upon memory in lines as vivid, as
+      deep, and as durable as the _exergues_ of the Carthaginian
+      medals.
+
+      Yet in fact—in the fact of the world’s view—how little was there
+      to remember! The morning’s awakening, the nightly summons to bed;
+      the connings, the recitations; the periodical half-holidays, and
+      perambulations; the play-ground, with its broils, its pastimes,
+      its intrigues;—these, by a mental sorcery long forgotten, were
+      made to involve a wilderness of sensation, a world of rich
+      incident, an universe of varied emotion, of excitement the most
+      passionate and spirit-stirring. “_Oh, le bon temps, que ce siècle
+      de fer!_”
+
+      In truth, the ardor, the enthusiasm, and the imperiousness of my
+      disposition, soon rendered me a marked character among my
+      schoolmates, and by slow, but natural gradations, gave me an
+      ascendancy over all not greatly older than myself;—over all with
+      a single exception. This exception was found in the person of a
+      scholar, who, although no relation, bore the same Christian and
+      surname as myself;—a circumstance, in fact, little remarkable;
+      for, notwithstanding a noble descent, mine was one of those
+      everyday appellations which seem, by prescriptive right, to have
+      been, time out of mind, the common property of the mob. In this
+      narrative I have therefore designated myself as William Wilson,—a
+      fictitious title not very dissimilar to the real. My namesake
+      alone, of those who in school phraseology constituted “our set,”
+      presumed to compete with me in the studies of the class—in the
+      sports and broils of the play-ground—to refuse implicit belief in
+      my assertions, and submission to my will—indeed, to interfere
+      with my arbitrary dictation in any respect whatsoever. If there
+      is on earth a supreme and unqualified despotism, it is the
+      despotism of a master-mind in boyhood over the less energetic
+      spirits of its companions.
+
+      Wilson’s rebellion was to me a source of the greatest
+      embarrassment; the more so as, in spite of the bravado with which
+      in public I made a point of treating him and his pretensions, I
+      secretly felt that I feared him, and could not help thinking the
+      equality which he maintained so easily with myself, a proof of
+      his true superiority; since not to be overcome cost me a
+      perpetual struggle. Yet this superiority—even this equality—was
+      in truth acknowledged by no one but myself; our associates, by
+      some unaccountable blindness, seemed not even to suspect it.
+      Indeed, his competition, his resistance, and especially his
+      impertinent and dogged interference with my purposes, were not
+      more pointed than private. He appeared to be destitute alike of
+      the ambition which urged, and of the passionate energy of mind
+      which enabled me to excel. In his rivalry he might have been
+      supposed actuated solely by a whimsical desire to thwart,
+      astonish, or mortify myself; although there were times when I
+      could not help observing, with a feeling made up of wonder,
+      abasement, and pique, that he mingled with his injuries, his
+      insults, or his contradictions, a certain most inappropriate, and
+      assuredly most unwelcome affectionateness of manner. I could only
+      conceive this singular behavior to arise from a consummate
+      self-conceit assuming the vulgar airs of patronage and
+      protection.
+
+      Perhaps it was this latter trait in Wilson’s conduct, conjoined
+      with our identity of name, and the mere accident of our having
+      entered the school upon the same day, which set afloat the notion
+      that we were brothers, among the senior classes in the academy.
+      These do not usually inquire with much strictness into the
+      affairs of their juniors. I have before said, or should have
+      said, that Wilson was not, in the most remote degree, connected
+      with my family. But assuredly if we had been brothers we must
+      have been twins; for, after leaving Dr. Bransby’s, I casually
+      learned that my namesake was born on the nineteenth of January,
+      1813—and this is a somewhat remarkable coincidence; for the day
+      is precisely that of my own nativity.
+
+      It may seem strange that in spite of the continual anxiety
+      occasioned me by the rivalry of Wilson, and his intolerable
+      spirit of contradiction, I could not bring myself to hate him
+      altogether. We had, to be sure, nearly every day a quarrel in
+      which, yielding me publicly the palm of victory, he, in some
+      manner, contrived to make me feel that it was he who had deserved
+      it; yet a sense of pride on my part, and a veritable dignity on
+      his own, kept us always upon what are called “speaking terms,”
+      while there were many points of strong congeniality in our
+      tempers, operating to awake me in a sentiment which our position
+      alone, perhaps, prevented from ripening into friendship. It is
+      difficult, indeed, to define, or even to describe, my real
+      feelings towards him. They formed a motley and heterogeneous
+      admixture;—some petulant animosity, which was not yet hatred,
+      some esteem, more respect, much fear, with a world of uneasy
+      curiosity. To the moralist it will be unnecessary to say, in
+      addition, that Wilson and myself were the most inseparable of
+      companions.
+
+      It was no doubt the anomalous state of affairs existing between
+      us, which turned all my attacks upon him, (and they were many,
+      either open or covert) into the channel of banter or practical
+      joke (giving pain while assuming the aspect of mere fun) rather
+      than into a more serious and determined hostility. But my
+      endeavours on this head were by no means uniformly successful,
+      even when my plans were the most wittily concocted; for my
+      namesake had much about him, in character, of that unassuming and
+      quiet austerity which, while enjoying the poignancy of its own
+      jokes, has no heel of Achilles in itself, and absolutely refuses
+      to be laughed at. I could find, indeed, but one vulnerable point,
+      and that, lying in a personal peculiarity, arising, perhaps, from
+      constitutional disease, would have been spared by any antagonist
+      less at his wit’s end than myself;—my rival had a weakness in the
+      faucal or guttural organs, which precluded him from raising his
+      voice at any time above a very low whisper. Of this defect I did
+      not fail to take what poor advantage lay in my power.
+
+      Wilson’s retaliations in kind were many; and there was one form
+      of his practical wit that disturbed me beyond measure. How his
+      sagacity first discovered at all that so petty a thing would vex
+      me, is a question I never could solve; but, having discovered, he
+      habitually practised the annoyance. I had always felt aversion to
+      my uncourtly patronymic, and its very common, if not plebeian
+      praenomen. The words were venom in my ears; and when, upon the
+      day of my arrival, a second William Wilson came also to the
+      academy, I felt angry with him for bearing the name, and doubly
+      disgusted with the name because a stranger bore it, who would be
+      the cause of its twofold repetition, who would be constantly in
+      my presence, and whose concerns, in the ordinary routine of the
+      school business, must inevitably, on account of the detestable
+      coincidence, be often confounded with my own.
+
+      The feeling of vexation thus engendered grew stronger with every
+      circumstance tending to show resemblance, moral or physical,
+      between my rival and myself. I had not then discovered the
+      remarkable fact that we were of the same age; but I saw that we
+      were of the same height, and I perceived that we were even
+      singularly alike in general contour of person and outline of
+      feature. I was galled, too, by the rumor touching a relationship,
+      which had grown current in the upper forms. In a word, nothing
+      could more seriously disturb me, (although I scrupulously
+      concealed such disturbance,) than any allusion to a similarity of
+      mind, person, or condition existing between us. But, in truth, I
+      had no reason to believe that (with the exception of the matter
+      of relationship, and in the case of Wilson himself,) this
+      similarity had ever been made a subject of comment, or even
+      observed at all by our schoolfellows. That he observed it in all
+      its bearings, and as fixedly as I, was apparent; but that he
+      could discover in such circumstances so fruitful a field of
+      annoyance, can only be attributed, as I said before, to his more
+      than ordinary penetration.
+
+      His cue, which was to perfect an imitation of myself, lay both in
+      words and in actions; and most admirably did he play his part. My
+      dress it was an easy matter to copy; my gait and general manner
+      were, without difficulty, appropriated; in spite of his
+      constitutional defect, even my voice did not escape him. My
+      louder tones were, of course, unattempted, but then the key—it
+      was identical; _and his singular whisper, it grew the very echo
+      of my own_.
+
+      How greatly this most exquisite portraiture harassed me, (for it
+      could not justly be termed a caricature,) I will not now venture
+      to describe. I had but one consolation—in the fact that the
+      imitation, apparently, was noticed by myself alone, and that I
+      had to endure only the knowing and strangely sarcastic smiles of
+      my namesake himself. Satisfied with having produced in my bosom
+      the intended effect, he seemed to chuckle in secret over the
+      sting he had inflicted, and was characteristically disregardful
+      of the public applause which the success of his witty endeavours
+      might have so easily elicited. That the school, indeed, did not
+      feel his design, perceive its accomplishment, and participate in
+      his sneer, was, for many anxious months, a riddle I could not
+      resolve. Perhaps the gradation of his copy rendered it not so
+      readily perceptible; or, more possibly, I owed my security to the
+      master air of the copyist, who, disdaining the letter, (which in
+      a painting is all the obtuse can see,) gave but the full spirit
+      of his original for my individual contemplation and chagrin.
+
+      I have already more than once spoken of the disgusting air of
+      patronage which he assumed toward me, and of his frequent
+      officious interference with my will. This interference often took
+      the ungracious character of advice; advice not openly given, but
+      hinted or insinuated. I received it with a repugnance which
+      gained strength as I grew in years. Yet, at this distant day, let
+      me do him the simple justice to acknowledge that I can recall no
+      occasion when the suggestions of my rival were on the side of
+      those errors or follies so usual to his immature age and seeming
+      inexperience; that his moral sense, at least, if not his general
+      talents and worldly wisdom, was far keener than my own; and that
+      I might, to-day, have been a better, and thus a happier man, had
+      I less frequently rejected the counsels embodied in those meaning
+      whispers which I then but too cordially hated and too bitterly
+      despised.
+
+      As it was, I at length grew restive in the extreme under his
+      distasteful supervision, and daily resented more and more openly
+      what I considered his intolerable arrogance. I have said that, in
+      the first years of our connexion as schoolmates, my feelings in
+      regard to him might have been easily ripened into friendship;
+      but, in the latter months of my residence at the academy,
+      although the intrusion of his ordinary manner had, beyond doubt,
+      in some measure, abated, my sentiments, in nearly similar
+      proportion, partook very much of positive hatred. Upon one
+      occasion he saw this, I think, and afterwards avoided, or made a
+      show of avoiding me.
+
+      It was about the same period, if I remember aright, that, in an
+      altercation of violence with him, in which he was more than
+      usually thrown off his guard, and spoke and acted with an
+      openness of demeanor rather foreign to his nature, I discovered,
+      or fancied I discovered, in his accent, his air, and general
+      appearance, a something which first startled, and then deeply
+      interested me, by bringing to mind dim visions of my earliest
+      infancy—wild, confused and thronging memories of a time when
+      memory herself was yet unborn. I cannot better describe the
+      sensation which oppressed me than by saying that I could with
+      difficulty shake off the belief of my having been acquainted with
+      the being who stood before me, at some epoch very long ago—some
+      point of the past even infinitely remote. The delusion, however,
+      faded rapidly as it came; and I mention it at all but to define
+      the day of the last conversation I there held with my singular
+      namesake.
+
+      The huge old house, with its countless subdivisions, had several
+      large chambers communicating with each other, where slept the
+      greater number of the students. There were, however, (as must
+      necessarily happen in a building so awkwardly planned,) many
+      little nooks or recesses, the odds and ends of the structure; and
+      these the economic ingenuity of Dr. Bransby had also fitted up as
+      dormitories; although, being the merest closets, they were
+      capable of accommodating but a single individual. One of these
+      small apartments was occupied by Wilson.
+
+      One night, about the close of my fifth year at the school, and
+      immediately after the altercation just mentioned, finding every
+      one wrapped in sleep, I arose from bed, and, lamp in hand, stole
+      through a wilderness of narrow passages from my own bedroom to
+      that of my rival. I had long been plotting one of those
+      ill-natured pieces of practical wit at his expense in which I had
+      hitherto been so uniformly unsuccessful. It was my intention,
+      now, to put my scheme in operation, and I resolved to make him
+      feel the whole extent of the malice with which I was imbued.
+      Having reached his closet, I noiselessly entered, leaving the
+      lamp, with a shade over it, on the outside. I advanced a step,
+      and listened to the sound of his tranquil breathing. Assured of
+      his being asleep, I returned, took the light, and with it again
+      approached the bed. Close curtains were around it, which, in the
+      prosecution of my plan, I slowly and quietly withdrew, when the
+      bright rays fell vividly upon the sleeper, and my eyes, at the
+      same moment, upon his countenance. I looked;—and a numbness, an
+      iciness of feeling instantly pervaded my frame. My breast heaved,
+      my knees tottered, my whole spirit became possessed with an
+      objectless yet intolerable horror. Gasping for breath, I lowered
+      the lamp in still nearer proximity to the face. Were these—these
+      the lineaments of William Wilson? I saw, indeed, that they were
+      his, but I shook as if with a fit of the ague in fancying they
+      were not. What was there about them to confound me in this
+      manner? I gazed;—while my brain reeled with a multitude of
+      incoherent thoughts. Not thus he appeared—assuredly not thus—in
+      the vivacity of his waking hours. The same name! the same contour
+      of person! the same day of arrival at the academy! And then his
+      dogged and meaningless imitation of my gait, my voice, my habits,
+      and my manner! Was it, in truth, within the bounds of human
+      possibility, that what I now saw was the result, merely, of the
+      habitual practice of this sarcastic imitation? Awe-stricken, and
+      with a creeping shudder, I extinguished the lamp, passed silently
+      from the chamber, and left, at once, the halls of that old
+      academy, never to enter them again.
+
+      After a lapse of some months, spent at home in mere idleness, I
+      found myself a student at Eton. The brief interval had been
+      sufficient to enfeeble my remembrance of the events at Dr.
+      Bransby’s, or at least to effect a material change in the nature
+      of the feelings with which I remembered them. The truth—the
+      tragedy—of the drama was no more. I could now find room to doubt
+      the evidence of my senses; and seldom called up the subject at
+      all but with wonder at extent of human credulity, and a smile at
+      the vivid force of the imagination which I hereditarily
+      possessed. Neither was this species of scepticism likely to be
+      diminished by the character of the life I led at Eton. The vortex
+      of thoughtless folly into which I there so immediately and so
+      recklessly plunged, washed away all but the froth of my past
+      hours, engulfed at once every solid or serious impression, and
+      left to memory only the veriest levities of a former existence.
+
+      I do not wish, however, to trace the course of my miserable
+      profligacy here—a profligacy which set at defiance the laws,
+      while it eluded the vigilance of the institution. Three years of
+      folly, passed without profit, had but given me rooted habits of
+      vice, and added, in a somewhat unusual degree, to my bodily
+      stature, when, after a week of soulless dissipation, I invited a
+      small party of the most dissolute students to a secret carousal
+      in my chambers. We met at a late hour of the night; for our
+      debaucheries were to be faithfully protracted until morning. The
+      wine flowed freely, and there were not wanting other and perhaps
+      more dangerous seductions; so that the gray dawn had already
+      faintly appeared in the east, while our delirious extravagance
+      was at its height. Madly flushed with cards and intoxication, I
+      was in the act of insisting upon a toast of more than wonted
+      profanity, when my attention was suddenly diverted by the
+      violent, although partial unclosing of the door of the apartment,
+      and by the eager voice of a servant from without. He said that
+      some person, apparently in great haste, demanded to speak with me
+      in the hall.
+
+      Wildly excited with wine, the unexpected interruption rather
+      delighted than surprised me. I staggered forward at once, and a
+      few steps brought me to the vestibule of the building. In this
+      low and small room there hung no lamp; and now no light at all
+      was admitted, save that of the exceedingly feeble dawn which made
+      its way through the semi-circular window. As I put my foot over
+      the threshold, I became aware of the figure of a youth about my
+      own height, and habited in a white kerseymere morning frock, cut
+      in the novel fashion of the one I myself wore at the moment. This
+      the faint light enabled me to perceive; but the features of his
+      face I could not distinguish. Upon my entering he strode
+      hurriedly up to me, and, seizing me by the arm with a gesture of
+      petulant impatience, whispered the words “William Wilson!” in my
+      ear.
+
+      I grew perfectly sober in an instant.
+
+      There was that in the manner of the stranger, and in the
+      tremulous shake of his uplifted finger, as he held it between my
+      eyes and the light, which filled me with unqualified amazement;
+      but it was not this which had so violently moved me. It was the
+      pregnancy of solemn admonition in the singular, low, hissing
+      utterance; and, above all, it was the character, the tone, the
+      key, of those few, simple, and familiar, yet whispered syllables,
+      which came with a thousand thronging memories of bygone days, and
+      struck upon my soul with the shock of a galvanic battery. Ere I
+      could recover the use of my senses he was gone.
+
+      Although this event failed not of a vivid effect upon my
+      disordered imagination, yet was it evanescent as vivid. For some
+      weeks, indeed, I busied myself in earnest inquiry, or was wrapped
+      in a cloud of morbid speculation. I did not pretend to disguise
+      from my perception the identity of the singular individual who
+      thus perseveringly interfered with my affairs, and harassed me
+      with his insinuated counsel. But who and what was this
+      Wilson?—and whence came he?—and what were his purposes? Upon
+      neither of these points could I be satisfied; merely
+      ascertaining, in regard to him, that a sudden accident in his
+      family had caused his removal from Dr. Bransby’s academy on the
+      afternoon of the day in which I myself had eloped. But in a brief
+      period I ceased to think upon the subject; my attention being all
+      absorbed in a contemplated departure for Oxford. Thither I soon
+      went; the uncalculating vanity of my parents furnishing me with
+      an outfit and annual establishment, which would enable me to
+      indulge at will in the luxury already so dear to my heart,—to vie
+      in profuseness of expenditure with the haughtiest heirs of the
+      wealthiest earldoms in Great Britain.
+
+      Excited by such appliances to vice, my constitutional temperament
+      broke forth with redoubled ardor, and I spurned even the common
+      restraints of decency in the mad infatuation of my revels. But it
+      were absurd to pause in the detail of my extravagance. Let it
+      suffice, that among spendthrifts I out-Heroded Herod, and that,
+      giving name to a multitude of novel follies, I added no brief
+      appendix to the long catalogue of vices then usual in the most
+      dissolute university of Europe.
+
+      It could hardly be credited, however, that I had, even here, so
+      utterly fallen from the gentlemanly estate, as to seek
+      acquaintance with the vilest arts of the gambler by profession,
+      and, having become an adept in his despicable science, to
+      practise it habitually as a means of increasing my already
+      enormous income at the expense of the weak-minded among my
+      fellow-collegians. Such, nevertheless, was the fact. And the very
+      enormity of this offence against all manly and honourable
+      sentiment proved, beyond doubt, the main if not the sole reason
+      of the impunity with which it was committed. Who, indeed, among
+      my most abandoned associates, would not rather have disputed the
+      clearest evidence of his senses, than have suspected of such
+      courses, the gay, the frank, the generous William Wilson—the
+      noblest and most liberal commoner at Oxford—him whose follies
+      (said his parasites) were but the follies of youth and unbridled
+      fancy—whose errors but inimitable whim—whose darkest vice but a
+      careless and dashing extravagance?
+
+      I had been now two years successfully busied in this way, when
+      there came to the university a young parvenu nobleman,
+      Glendinning—rich, said report, as Herodes Atticus—his riches,
+      too, as easily acquired. I soon found him of weak intellect, and,
+      of course, marked him as a fitting subject for my skill. I
+      frequently engaged him in play, and contrived, with the gambler’s
+      usual art, to let him win considerable sums, the more effectually
+      to entangle him in my snares. At length, my schemes being ripe, I
+      met him (with the full intention that this meeting should be
+      final and decisive) at the chambers of a fellow-commoner, (Mr.
+      Preston,) equally intimate with both, but who, to do him justice,
+      entertained not even a remote suspicion of my design. To give to
+      this a better coloring, I had contrived to have assembled a party
+      of some eight or ten, and was solicitously careful that the
+      introduction of cards should appear accidental, and originate in
+      the proposal of my contemplated dupe himself. To be brief upon a
+      vile topic, none of the low finesse was omitted, so customary
+      upon similar occasions that it is a just matter for wonder how
+      any are still found so besotted as to fall its victim.
+
+      We had protracted our sitting far into the night, and I had at
+      length effected the manoeuvre of getting Glendinning as my sole
+      antagonist. The game, too, was my favorite _écarté!_ The rest of
+      the company, interested in the extent of our play, had abandoned
+      their own cards, and were standing around us as spectators. The
+      _parvenu_, who had been induced by my artifices in the early part
+      of the evening, to drink deeply, now shuffled, dealt, or played,
+      with a wild nervousness of manner for which his intoxication, I
+      thought, might partially, but could not altogether account. In a
+      very short period he had become my debtor to a large amount,
+      when, having taken a long draught of port, he did precisely what
+      I had been coolly anticipating—he proposed to double our already
+      extravagant stakes. With a well-feigned show of reluctance, and
+      not until after my repeated refusal had seduced him into some
+      angry words which gave a color of pique to my compliance, did I
+      finally comply. The result, of course, did but prove how entirely
+      the prey was in my toils: in less than an hour he had quadrupled
+      his debt. For some time his countenance had been losing the
+      florid tinge lent it by the wine; but now, to my astonishment, I
+      perceived that it had grown to a pallor truly fearful. I say to
+      my astonishment. Glendinning had been represented to my eager
+      inquiries as immeasurably wealthy; and the sums which he had as
+      yet lost, although in themselves vast, could not, I supposed,
+      very seriously annoy, much less so violently affect him. That he
+      was overcome by the wine just swallowed, was the idea which most
+      readily presented itself; and, rather with a view to the
+      preservation of my own character in the eyes of my associates,
+      than from any less interested motive, I was about to insist,
+      peremptorily, upon a discontinuance of the play, when some
+      expressions at my elbow from among the company, and an
+      ejaculation evincing utter despair on the part of Glendinning,
+      gave me to understand that I had effected his total ruin under
+      circumstances which, rendering him an object for the pity of all,
+      should have protected him from the ill offices even of a fiend.
+
+      What now might have been my conduct it is difficult to say. The
+      pitiable condition of my dupe had thrown an air of embarrassed
+      gloom over all; and, for some moments, a profound silence was
+      maintained, during which I could not help feeling my cheeks
+      tingle with the many burning glances of scorn or reproach cast
+      upon me by the less abandoned of the party. I will even own that
+      an intolerable weight of anxiety was for a brief instant lifted
+      from my bosom by the sudden and extraordinary interruption which
+      ensued. The wide, heavy folding doors of the apartment were all
+      at once thrown open, to their full extent, with a vigorous and
+      rushing impetuosity that extinguished, as if by magic, every
+      candle in the room. Their light, in dying, enabled us just to
+      perceive that a stranger had entered, about my own height, and
+      closely muffled in a cloak. The darkness, however, was now total;
+      and we could only feel that he was standing in our midst. Before
+      any one of us could recover from the extreme astonishment into
+      which this rudeness had thrown all, we heard the voice of the
+      intruder.
+
+      “Gentlemen,” he said, in a low, distinct, and
+      never-to-be-forgotten whisper which thrilled to the very marrow
+      of my bones, “Gentlemen, I make no apology for this behaviour,
+      because in thus behaving, I am but fulfilling a duty. You are,
+      beyond doubt, uninformed of the true character of the person who
+      has to-night won at _écarté_ a large sum of money from Lord
+      Glendinning. I will therefore put you upon an expeditious and
+      decisive plan of obtaining this very necessary information.
+      Please to examine, at your leisure, the inner linings of the cuff
+      of his left sleeve, and the several little packages which may be
+      found in the somewhat capacious pockets of his embroidered
+      morning wrapper.”
+
+      While he spoke, so profound was the stillness that one might have
+      heard a pin drop upon the floor. In ceasing, he departed at once,
+      and as abruptly as he had entered. Can I—shall I describe my
+      sensations? Must I say that I felt all the horrors of the damned?
+      Most assuredly I had little time given for reflection. Many hands
+      roughly seized me upon the spot, and lights were immediately
+      reprocured. A search ensued. In the lining of my sleeve were
+      found all the court cards essential in _écarté_, and, in the
+      pockets of my wrapper, a number of packs, facsimiles of those
+      used at our sittings, with the single exception that mine were of
+      the species called, technically, arrondees; the honours being
+      slightly convex at the ends, the lower cards slightly convex at
+      the sides. In this disposition, the dupe who cuts, as customary,
+      at the length of the pack, will invariably find that he cuts his
+      antagonist an honor; while the gambler, cutting at the breadth,
+      will, as certainly, cut nothing for his victim which may count in
+      the records of the game.
+
+      Any burst of indignation upon this discovery would have affected
+      me less than the silent contempt, or the sarcastic composure,
+      with which it was received.
+
+      “Mr. Wilson,” said our host, stooping to remove from beneath his
+      feet an exceedingly luxurious cloak of rare furs, “Mr. Wilson,
+      this is your property.” (The weather was cold; and, upon quitting
+      my own room, I had thrown a cloak over my dressing wrapper,
+      putting it off upon reaching the scene of play.) “I presume it is
+      supererogatory to seek here (eyeing the folds of the garment with
+      a bitter smile) for any farther evidence of your skill. Indeed,
+      we have had enough. You will see the necessity, I hope, of
+      quitting Oxford—at all events, of quitting instantly my
+      chambers.”
+
+      Abased, humbled to the dust as I then was, it is probable that I
+      should have resented this galling language by immediate personal
+      violence, had not my whole attention been at the moment arrested
+      by a fact of the most startling character. The cloak which I had
+      worn was of a rare description of fur; how rare, how
+      extravagantly costly, I shall not venture to say. Its fashion,
+      too, was of my own fantastic invention; for I was fastidious to
+      an absurd degree of coxcombry, in matters of this frivolous
+      nature. When, therefore, Mr. Preston reached me that which he had
+      picked up upon the floor, and near the folding doors of the
+      apartment, it was with an astonishment nearly bordering upon
+      terror, that I perceived my own already hanging on my arm, (where
+      I had no doubt unwittingly placed it,) and that the one presented
+      me was but its exact counterpart in every, in even the minutest
+      possible particular. The singular being who had so disastrously
+      exposed me, had been muffled, I remembered, in a cloak; and none
+      had been worn at all by any of the members of our party with the
+      exception of myself. Retaining some presence of mind, I took the
+      one offered me by Preston; placed it, unnoticed, over my own;
+      left the apartment with a resolute scowl of defiance; and, next
+      morning ere dawn of day, commenced a hurried journey from Oxford
+      to the continent, in a perfect agony of horror and of shame.
+
+      I fled in vain. My evil destiny pursued me as if in exultation,
+      and proved, indeed, that the exercise of its mysterious dominion
+      had as yet only begun. Scarcely had I set foot in Paris ere I had
+      fresh evidence of the detestable interest taken by this Wilson in
+      my concerns. Years flew, while I experienced no relief.
+      Villain!—at Rome, with how untimely, yet with how spectral an
+      officiousness, stepped he in between me and my ambition! At
+      Vienna, too—at Berlin—and at Moscow! Where, in truth, had I not
+      bitter cause to curse him within my heart? From his inscrutable
+      tyranny did I at length flee, panic-stricken, as from a
+      pestilence; and to the very ends of the earth I fled in vain.
+
+      And again, and again, in secret communion with my own spirit,
+      would I demand the questions “Who is he?—whence came he?—and what
+      are his objects?” But no answer was there found. And then I
+      scrutinized, with a minute scrutiny, the forms, and the methods,
+      and the leading traits of his impertinent supervision. But even
+      here there was very little upon which to base a conjecture. It
+      was noticeable, indeed, that, in no one of the multiplied
+      instances in which he had of late crossed my path, had he so
+      crossed it except to frustrate those schemes, or to disturb those
+      actions, which, if fully carried out, might have resulted in
+      bitter mischief. Poor justification this, in truth, for an
+      authority so imperiously assumed! Poor indemnity for natural
+      rights of self-agency so pertinaciously, so insultingly denied!
+
+      I had also been forced to notice that my tormentor, for a very
+      long period of time, (while scrupulously and with miraculous
+      dexterity maintaining his whim of an identity of apparel with
+      myself,) had so contrived it, in the execution of his varied
+      interference with my will, that I saw not, at any moment, the
+      features of his face. Be Wilson what he might, this, at least,
+      was but the veriest of affectation, or of folly. Could he, for an
+      instant, have supposed that, in my admonisher at Eton—in the
+      destroyer of my honor at Oxford,—in him who thwarted my ambition
+      at Rome, my revenge at Paris, my passionate love at Naples, or
+      what he falsely termed my avarice in Egypt,—that in this, my
+      arch-enemy and evil genius, could fail to recognise the William
+      Wilson of my school boy days,—the namesake, the companion, the
+      rival,—the hated and dreaded rival at Dr. Bransby’s?
+      Impossible!—But let me hasten to the last eventful scene of the
+      drama.
+
+      Thus far I had succumbed supinely to this imperious domination.
+      The sentiment of deep awe with which I habitually regarded the
+      elevated character, the majestic wisdom, the apparent
+      omnipresence and omnipotence of Wilson, added to a feeling of
+      even terror, with which certain other traits in his nature and
+      assumptions inspired me, had operated, hitherto, to impress me
+      with an idea of my own utter weakness and helplessness, and to
+      suggest an implicit, although bitterly reluctant submission to
+      his arbitrary will. But, of late days, I had given myself up
+      entirely to wine; and its maddening influence upon my hereditary
+      temper rendered me more and more impatient of control. I began to
+      murmur,—to hesitate,—to resist. And was it only fancy which
+      induced me to believe that, with the increase of my own firmness,
+      that of my tormentor underwent a proportional diminution? Be this
+      as it may, I now began to feel the inspiration of a burning hope,
+      and at length nurtured in my secret thoughts a stern and
+      desperate resolution that I would submit no longer to be
+      enslaved.
+
+      It was at Rome, during the Carnival of 18—, that I attended a
+      masquerade in the palazzo of the Neapolitan Duke Di Broglio. I
+      had indulged more freely than usual in the excesses of the
+      wine-table; and now the suffocating atmosphere of the crowded
+      rooms irritated me beyond endurance. The difficulty, too, of
+      forcing my way through the mazes of the company contributed not a
+      little to the ruffling of my temper; for I was anxiously seeking,
+      (let me not say with what unworthy motive) the young, the gay,
+      the beautiful wife of the aged and doting Di Broglio. With a too
+      unscrupulous confidence she had previously communicated to me the
+      secret of the costume in which she would be habited, and now,
+      having caught a glimpse of her person, I was hurrying to make my
+      way into her presence. At this moment I felt a light hand placed
+      upon my shoulder, and that ever-remembered, low, damnable
+      _whisper_ within my ear.
+
+      In an absolute phrenzy of wrath, I turned at once upon him who
+      had thus interrupted me, and seized him violently by the collar.
+      He was attired, as I had expected, in a costume altogether
+      similar to my own; wearing a Spanish cloak of blue velvet, begirt
+      about the waist with a crimson belt sustaining a rapier. A mask
+      of black silk entirely covered his face.
+
+      “Scoundrel!” I said, in a voice husky with rage, while every
+      syllable I uttered seemed as new fuel to my fury, “scoundrel!
+      impostor! accursed villain! you shall not—you shall not dog me
+      unto death! Follow me, or I stab you where you stand!”—and I
+      broke my way from the ball-room into a small ante-chamber
+      adjoining, dragging him unresistingly with me as I went.
+
+      Upon entering, I thrust him furiously from me. He staggered
+      against the wall, while I closed the door with an oath, and
+      commanded him to draw. He hesitated but for an instant; then,
+      with a slight sigh, drew in silence, and put himself upon his
+      defence.
+
+      The contest was brief indeed. I was frantic with every species of
+      wild excitement, and felt within my single arm the energy and
+      power of a multitude. In a few seconds I forced him by sheer
+      strength against the wainscoting, and thus, getting him at mercy,
+      plunged my sword, with brute ferocity, repeatedly through and
+      through his bosom.
+
+      At that instant some person tried the latch of the door. I
+      hastened to prevent an intrusion, and then immediately returned
+      to my dying antagonist. But what human language can adequately
+      portray that astonishment, that horror which possessed me at the
+      spectacle then presented to view? The brief moment in which I
+      averted my eyes had been sufficient to produce, apparently, a
+      material change in the arrangements at the upper or farther end
+      of the room. A large mirror,—so at first it seemed to me in my
+      confusion—now stood where none had been perceptible before; and,
+      as I stepped up to it in extremity of terror, mine own image, but
+      with features all pale and dabbled in blood, advanced to meet me
+      with a feeble and tottering gait.
+
+      Thus it appeared, I say, but was not. It was my antagonist—it was
+      Wilson, who then stood before me in the agonies of his
+      dissolution. His mask and cloak lay, where he had thrown them,
+      upon the floor. Not a thread in all his raiment—not a line in all
+      the marked and singular lineaments of his face which was not,
+      even in the most absolute identity, mine own!
+
+      It was Wilson; but he spoke no longer in a whisper, and I could
+      have fancied that I myself was speaking while he said:
+
+      _“You have conquered, and I yield. Yet, henceforward art thou
+      also dead—dead to the World, to Heaven and to Hope! In me didst
+      thou exist—and, in my death, see by this image, which is thine
+      own, how utterly thou hast murdered thyself.”_
+
+
+
+
+THE TELL-TALE HEART.
+
+
+      True!—nervous—very, very dreadfully nervous I had been and am;
+      but why will you say that I am mad? The disease had sharpened my
+      senses—not destroyed—not dulled them. Above all was the sense of
+      hearing acute. I heard all things in the heaven and in the earth.
+      I heard many things in hell. How, then, am I mad? Hearken! and
+      observe how healthily—how calmly I can tell you the whole story.
+
+      It is impossible to say how first the idea entered my brain; but
+      once conceived, it haunted me day and night. Object there was
+      none. Passion there was none. I loved the old man. He had never
+      wronged me. He had never given me insult. For his gold I had no
+      desire. I think it was his eye! yes, it was this! He had the eye
+      of a vulture—a pale blue eye, with a film over it. Whenever it
+      fell upon me, my blood ran cold; and so by degrees—very
+      gradually—I made up my mind to take the life of the old man, and
+      thus rid myself of the eye forever.
+
+      Now this is the point. You fancy me mad. Madmen know nothing. But
+      you should have seen me. You should have seen how wisely I
+      proceeded—with what caution—with what foresight—with what
+      dissimulation I went to work! I was never kinder to the old man
+      than during the whole week before I killed him. And every night,
+      about midnight, I turned the latch of his door and opened it—oh,
+      so gently! And then, when I had made an opening sufficient for my
+      head, I put in a dark lantern, all closed, closed, that no light
+      shone out, and then I thrust in my head. Oh, you would have
+      laughed to see how cunningly I thrust it in! I moved it
+      slowly—very, very slowly, so that I might not disturb the old
+      man’s sleep. It took me an hour to place my whole head within the
+      opening so far that I could see him as he lay upon his bed.
+      Ha!—would a madman have been so wise as this? And then, when my
+      head was well in the room, I undid the lantern cautiously—oh, so
+      cautiously—cautiously (for the hinges creaked)—I undid it just so
+      much that a single thin ray fell upon the vulture eye. And this I
+      did for seven long nights—every night just at midnight—but I
+      found the eye always closed; and so it was impossible to do the
+      work; for it was not the old man who vexed me, but his Evil Eye.
+      And every morning, when the day broke, I went boldly into the
+      chamber, and spoke courageously to him, calling him by name in a
+      hearty tone, and inquiring how he has passed the night. So you
+      see he would have been a very profound old man, indeed, to
+      suspect that every night, just at twelve, I looked in upon him
+      while he slept.
+
+      Upon the eighth night I was more than usually cautious in opening
+      the door. A watch’s minute hand moves more quickly than did mine.
+      Never before that night had I felt the extent of my own powers—of
+      my sagacity. I could scarcely contain my feelings of triumph. To
+      think that there I was, opening the door, little by little, and
+      he not even to dream of my secret deeds or thoughts. I fairly
+      chuckled at the idea; and perhaps he heard me; for he moved on
+      the bed suddenly, as if startled. Now you may think that I drew
+      back—but no. His room was as black as pitch with the thick
+      darkness, (for the shutters were close fastened, through fear of
+      robbers,) and so I knew that he could not see the opening of the
+      door, and I kept pushing it on steadily, steadily.
+
+      I had my head in, and was about to open the lantern, when my
+      thumb slipped upon the tin fastening, and the old man sprang up
+      in bed, crying out—“Who’s there?”
+
+      I kept quite still and said nothing. For a whole hour I did not
+      move a muscle, and in the meantime I did not hear him lie down.
+      He was still sitting up in the bed listening;—just as I have
+      done, night after night, hearkening to the death watches in the
+      wall.
+
+      Presently I heard a slight groan, and I knew it was the groan of
+      mortal terror. It was not a groan of pain or of grief—oh, no!—it
+      was the low stifled sound that arises from the bottom of the soul
+      when overcharged with awe. I knew the sound well. Many a night,
+      just at midnight, when all the world slept, it has welled up from
+      my own bosom, deepening, with its dreadful echo, the terrors that
+      distracted me. I say I knew it well. I knew what the old man
+      felt, and pitied him, although I chuckled at heart. I knew that
+      he had been lying awake ever since the first slight noise, when
+      he had turned in the bed. His fears had been ever since growing
+      upon him. He had been trying to fancy them causeless, but could
+      not. He had been saying to himself—“It is nothing but the wind in
+      the chimney—it is only a mouse crossing the floor,” or “It is
+      merely a cricket which has made a single chirp.” Yes, he had been
+      trying to comfort himself with these suppositions: but he had
+      found all in vain. All in vain; because Death, in approaching him
+      had stalked with his black shadow before him, and enveloped the
+      victim. And it was the mournful influence of the unperceived
+      shadow that caused him to feel—although he neither saw nor
+      heard—to feel the presence of my head within the room.
+
+      When I had waited a long time, very patiently, without hearing
+      him lie down, I resolved to open a little—a very, very little
+      crevice in the lantern. So I opened it—you cannot imagine how
+      stealthily, stealthily—until, at length a simple dim ray, like
+      the thread of the spider, shot from out the crevice and fell full
+      upon the vulture eye.
+
+      It was open—wide, wide open—and I grew furious as I gazed upon
+      it. I saw it with perfect distinctness—all a dull blue, with a
+      hideous veil over it that chilled the very marrow in my bones;
+      but I could see nothing else of the old man’s face or person: for
+      I had directed the ray as if by instinct, precisely upon the
+      damned spot.
+
+      And have I not told you that what you mistake for madness is but
+      over-acuteness of the sense?—now, I say, there came to my ears a
+      low, dull, quick sound, such as a watch makes when enveloped in
+      cotton. I knew that sound well, too. It was the beating of the
+      old man’s heart. It increased my fury, as the beating of a drum
+      stimulates the soldier into courage.
+
+      But even yet I refrained and kept still. I scarcely breathed. I
+      held the lantern motionless. I tried how steadily I could
+      maintain the ray upon the eye. Meantime the hellish tattoo of the
+      heart increased. It grew quicker and quicker, and louder and
+      louder every instant. The old man’s terror must have been
+      extreme! It grew louder, I say, louder every moment!—do you mark
+      me well? I have told you that I am nervous: so I am. And now at
+      the dead hour of the night, amid the dreadful silence of that old
+      house, so strange a noise as this excited me to uncontrollable
+      terror. Yet, for some minutes longer I refrained and stood still.
+      But the beating grew louder, louder! I thought the heart must
+      burst. And now a new anxiety seized me—the sound would be heard
+      by a neighbour! The old man’s hour had come! With a loud yell, I
+      threw open the lantern and leaped into the room. He shrieked
+      once—once only. In an instant I dragged him to the floor, and
+      pulled the heavy bed over him. I then smiled gaily, to find the
+      deed so far done. But, for many minutes, the heart beat on with a
+      muffled sound. This, however, did not vex me; it would not be
+      heard through the wall. At length it ceased. The old man was
+      dead. I removed the bed and examined the corpse. Yes, he was
+      stone, stone dead. I placed my hand upon the heart and held it
+      there many minutes. There was no pulsation. He was stone dead.
+      His eye would trouble me no more.
+
+      If still you think me mad, you will think so no longer when I
+      describe the wise precautions I took for the concealment of the
+      body. The night waned, and I worked hastily, but in silence.
+      First of all I dismembered the corpse. I cut off the head and the
+      arms and the legs.
+
+      I then took up three planks from the flooring of the chamber, and
+      deposited all between the scantlings. I then replaced the boards
+      so cleverly, so cunningly, that no human eye—not even his—could
+      have detected any thing wrong. There was nothing to wash out—no
+      stain of any kind—no blood-spot whatever. I had been too wary for
+      that. A tub had caught all—ha! ha!
+
+      When I had made an end of these labors, it was four o’clock—still
+      dark as midnight. As the bell sounded the hour, there came a
+      knocking at the street door. I went down to open it with a light
+      heart,—for what had I now to fear? There entered three men, who
+      introduced themselves, with perfect suavity, as officers of the
+      police. A shriek had been heard by a neighbour during the night;
+      suspicion of foul play had been aroused; information had been
+      lodged at the police office, and they (the officers) had been
+      deputed to search the premises.
+
+      I smiled,—for what had I to fear? I bade the gentlemen welcome.
+      The shriek, I said, was my own in a dream. The old man, I
+      mentioned, was absent in the country. I took my visitors all over
+      the house. I bade them search—search well. I led them, at length,
+      to his chamber. I showed them his treasures, secure, undisturbed.
+      In the enthusiasm of my confidence, I brought chairs into the
+      room, and desired them here to rest from their fatigues, while I
+      myself, in the wild audacity of my perfect triumph, placed my own
+      seat upon the very spot beneath which reposed the corpse of the
+      victim.
+
+      The officers were satisfied. My manner had convinced them. I was
+      singularly at ease. They sat, and while I answered cheerily, they
+      chatted of familiar things. But, ere long, I felt myself getting
+      pale and wished them gone. My head ached, and I fancied a ringing
+      in my ears: but still they sat and still chatted. The ringing
+      became more distinct:—it continued and became more distinct: I
+      talked more freely to get rid of the feeling: but it continued
+      and gained definiteness—until, at length, I found that the noise
+      was not within my ears.
+
+      No doubt I now grew _very_ pale;—but I talked more fluently, and
+      with a heightened voice. Yet the sound increased—and what could I
+      do? It was a low, dull, quick sound—much such a sound as a watch
+      makes when enveloped in cotton. I gasped for breath—and yet the
+      officers heard it not. I talked more quickly—more vehemently; but
+      the noise steadily increased. I arose and argued about trifles,
+      in a high key and with violent gesticulations; but the noise
+      steadily increased. Why would they not be gone? I paced the floor
+      to and fro with heavy strides, as if excited to fury by the
+      observations of the men—but the noise steadily increased. Oh God!
+      what could I do? I foamed—I raved—I swore! I swung the chair upon
+      which I had been sitting, and grated it upon the boards, but the
+      noise arose over all and continually increased. It grew
+      louder—louder—louder! And still the men chatted pleasantly, and
+      smiled. Was it possible they heard not? Almighty God!—no, no!
+      They heard!—they suspected!—they knew!—they were making a mockery
+      of my horror!—this I thought, and this I think. But anything was
+      better than this agony! Anything was more tolerable than this
+      derision! I could bear those hypocritical smiles no longer! I
+      felt that I must scream or die! and now—again!—hark! louder!
+      louder! louder! _louder!_
+
+      “Villains!” I shrieked, “dissemble no more! I admit the
+      deed!—tear up the planks!—here, here!—It is the beating of his
+      hideous heart!”
+
+
+
+
+BERENICE
+
+
+     Dicebant mihi sodales, si sepulchrum amicae visitarem, curas meas
+     aliquar tulum fore levatas.—_Ebn Zaiat_.
+
+      Misery is manifold. The wretchedness of earth is multiform.
+      Overreaching the wide horizon as the rainbow, its hues are as
+      various as the hues of that arch—as distinct too, yet as
+      intimately blended. Overreaching the wide horizon as the rainbow!
+      How is it that from beauty I have derived a type of
+      unloveliness?—from the covenant of peace, a simile of sorrow? But
+      as, in ethics, evil is a consequence of good, so, in fact, out of
+      joy is sorrow born. Either the memory of past bliss is the
+      anguish of to-day, or the agonies which _are_, have their origin
+      in the ecstasies which _might have been_.
+
+      My baptismal name is Egaeus; that of my family I will not
+      mention. Yet there are no towers in the land more time-honored
+      than my gloomy, gray, hereditary halls. Our line has been called
+      a race of visionaries; and in many striking particulars—in the
+      character of the family mansion—in the frescos of the chief
+      saloon—in the tapestries of the dormitories—in the chiselling of
+      some buttresses in the armory—but more especially in the gallery
+      of antique paintings—in the fashion of the library chamber—and,
+      lastly, in the very peculiar nature of the library’s
+      contents—there is more than sufficient evidence to warrant the
+      belief.
+
+      The recollections of my earliest years are connected with that
+      chamber, and with its volumes—of which latter I will say no more.
+      Here died my mother. Herein was I born. But it is mere idleness
+      to say that I had not lived before—that the soul has no previous
+      existence. You deny it?—let us not argue the matter. Convinced
+      myself, I seek not to convince. There is, however, a remembrance
+      of aerial forms—of spiritual and meaning eyes—of sounds, musical
+      yet sad—a remembrance which will not be excluded; a memory like a
+      shadow—vague, variable, indefinite, unsteady; and like a shadow,
+      too, in the impossibility of my getting rid of it while the
+      sunlight of my reason shall exist.
+
+      In that chamber was I born. Thus awaking from the long night of
+      what seemed, but was not, nonentity, at once into the very
+      regions of fairy land—into a palace of imagination—into the wild
+      dominions of monastic thought and erudition—it is not singular
+      that I gazed around me with a startled and ardent eye—that I
+      loitered away my boyhood in books, and dissipated my youth in
+      reverie; but it _is_ singular that as years rolled away, and the
+      noon of manhood found me still in the mansion of my fathers—it
+      _is_ wonderful what stagnation there fell upon the springs of my
+      life—wonderful how total an inversion took place in the character
+      of my commonest thought. The realities of the world affected me
+      as visions, and as visions only, while the wild ideas of the land
+      of dreams became, in turn, not the material of my every-day
+      existence, but in very deed that existence utterly and solely in
+      itself.
+
+      Berenice and I were cousins, and we grew up together in my
+      paternal halls. Yet differently we grew—I, ill of health, and
+      buried in gloom—she, agile, graceful, and overflowing with
+      energy; hers, the ramble on the hill-side—mine the studies of the
+      cloister; I, living within my own heart, and addicted, body and
+      soul, to the most intense and painful meditation—she, roaming
+      carelessly through life, with no thought of the shadows in her
+      path, or the silent flight of the raven-winged hours. Berenice!—I
+      call upon her name—Berenice!—and from the gray ruins of memory a
+      thousand tumultuous recollections are startled at the sound! Ah,
+      vividly is her image before me now, as in the early days of her
+      light-heartedness and joy! Oh, gorgeous yet fantastic beauty! Oh,
+      sylph amid the shrubberies of Arnheim! Oh, Naiad among its
+      fountains! And then—then all is mystery and terror, and a tale
+      which should not be told. Disease—a fatal disease, fell like the
+      simoon upon her frame; and, even while I gazed upon her, the
+      spirit of change swept over her, pervading her mind, her habits,
+      and her character, and, in a manner the most subtle and terrible,
+      disturbing even the identity of her person! Alas! the destroyer
+      came and went!—and the victim—where is she? I knew her not—or
+      knew her no longer as Berenice.
+
+      Among the numerous train of maladies superinduced by that fatal
+      and primary one which effected a revolution of so horrible a kind
+      in the moral and physical being of my cousin, may be mentioned as
+      the most distressing and obstinate in its nature, a species of
+      epilepsy not unfrequently terminating in _trance_ itself—trance
+      very nearly resembling positive dissolution, and from which her
+      manner of recovery was in most instances, startlingly abrupt. In
+      the mean time my own disease—for I have been told that I should
+      call it by no other appellation—my own disease, then, grew
+      rapidly upon me, and assumed finally a monomaniac character of a
+      novel and extraordinary form—hourly and momently gaining
+      vigor—and at length obtaining over me the most incomprehensible
+      ascendancy. This monomania, if I must so term it, consisted in a
+      morbid irritability of those properties of the mind in
+      metaphysical science termed the _attentive_. It is more than
+      probable that I am not understood; but I fear, indeed, that it is
+      in no manner possible to convey to the mind of the merely general
+      reader, an adequate idea of that nervous _intensity of interest_
+      with which, in my case, the powers of meditation (not to speak
+      technically) busied and buried themselves, in the contemplation
+      of even the most ordinary objects of the universe.
+
+      To muse for long unwearied hours, with my attention riveted to
+      some frivolous device on the margin, or in the typography of a
+      book; to become absorbed, for the better part of a summer’s day,
+      in a quaint shadow falling aslant upon the tapestry or upon the
+      floor; to lose myself, for an entire night, in watching the
+      steady flame of a lamp, or the embers of a fire; to dream away
+      whole days over the perfume of a flower; to repeat, monotonously,
+      some common word, until the sound, by dint of frequent
+      repetition, ceased to convey any idea whatever to the mind; to
+      lose all sense of motion or physical existence, by means of
+      absolute bodily quiescence long and obstinately persevered in:
+      such were a few of the most common and least pernicious vagaries
+      induced by a condition of the mental faculties, not, indeed,
+      altogether unparalleled, but certainly bidding defiance to
+      anything like analysis or explanation.
+
+      Yet let me not be misapprehended. The undue, earnest, and morbid
+      attention thus excited by objects in their own nature frivolous,
+      must not be confounded in character with that ruminating
+      propensity common to all mankind, and more especially indulged in
+      by persons of ardent imagination. It was not even, as might be at
+      first supposed, an extreme condition, or exaggeration of such
+      propensity, but primarily and essentially distinct and different.
+      In the one instance, the dreamer, or enthusiast, being interested
+      by an object usually _not_ frivolous, imperceptibly loses sight
+      of this object in a wilderness of deductions and suggestions
+      issuing therefrom, until, at the conclusion of a day-dream _often
+      replete with luxury_, he finds the _incitamentum_, or first cause
+      of his musings, entirely vanished and forgotten. In my case, the
+      primary object was _invariably frivolous_, although assuming,
+      through the medium of my distempered vision, a refracted and
+      unreal importance. Few deductions, if any, were made; and those
+      few pertinaciously returning in upon the original object as a
+      centre. The meditations were _never_ pleasurable; and, at the
+      termination of the reverie, the first cause, so far from being
+      out of sight, had attained that supernaturally exaggerated
+      interest which was the prevailing feature of the disease. In a
+      word, the powers of mind more particularly exercised were, with
+      me, as I have said before, the _attentive_, and are, with the
+      day-dreamer, the _speculative_.
+
+      My books, at this epoch, if they did not actually serve to
+      irritate the disorder, partook, it will be perceived, largely, in
+      their imaginative and inconsequential nature, of the
+      characteristic qualities of the disorder itself. I well remember,
+      among others, the treatise of the noble Italian, Coelius Secundus
+      Curio, “_De Amplitudine Beati Regni Dei;_” St. Austin’s great
+      work, the “City of God;” and Tertullian’s “_De Carne Christi_,”
+      in which the paradoxical sentence “_Mortuus est Dei filius;
+      credible est quia ineptum est: et sepultus resurrexit; certum est
+      quia impossibile est,_” occupied my undivided time, for many
+      weeks of laborious and fruitless investigation.
+
+      Thus it will appear that, shaken from its balance only by trivial
+      things, my reason bore resemblance to that ocean-crag spoken of
+      by Ptolemy Hephestion, which steadily resisting the attacks of
+      human violence, and the fiercer fury of the waters and the winds,
+      trembled only to the touch of the flower called Asphodel. And
+      although, to a careless thinker, it might appear a matter beyond
+      doubt, that the alteration produced by her unhappy malady, in the
+      _moral_ condition of Berenice, would afford me many objects for
+      the exercise of that intense and abnormal meditation whose nature
+      I have been at some trouble in explaining, yet such was not in
+      any degree the case. In the lucid intervals of my infirmity, her
+      calamity, indeed, gave me pain, and, taking deeply to heart that
+      total wreck of her fair and gentle life, I did not fail to
+      ponder, frequently and bitterly, upon the wonder-working means by
+      which so strange a revolution had been so suddenly brought to
+      pass. But these reflections partook not of the idiosyncrasy of my
+      disease, and were such as would have occurred, under similar
+      circumstances, to the ordinary mass of mankind. True to its own
+      character, my disorder revelled in the less important but more
+      startling changes wrought in the _physical_ frame of Berenice—in
+      the singular and most appalling distortion of her personal
+      identity.
+
+      During the brightest days of her unparalleled beauty, most surely
+      I had never loved her. In the strange anomaly of my existence,
+      feelings with me, _had never been_ of the heart, and my passions
+      _always were_ of the mind. Through the gray of the early
+      morning—among the trellised shadows of the forest at noonday—and
+      in the silence of my library at night—she had flitted by my eyes,
+      and I had seen her—not as the living and breathing Berenice, but
+      as the Berenice of a dream; not as a being of the earth, earthy,
+      but as the abstraction of such a being; not as a thing to admire,
+      but to analyze; not as an object of love, but as the theme of the
+      most abstruse although desultory speculation. And _now_—now I
+      shuddered in her presence, and grew pale at her approach; yet,
+      bitterly lamenting her fallen and desolate condition, I called to
+      mind that she had loved me long, and, in an evil moment, I spoke
+      to her of marriage.
+
+      And at length the period of our nuptials was approaching, when,
+      upon an afternoon in the winter of the year—one of those
+      unseasonably warm, calm, and misty days which are the nurse of
+      the beautiful Halcyon (*1),—I sat, (and sat, as I thought,
+      alone,) in the inner apartment of the library. But, uplifting my
+      eyes, I saw that Berenice stood before me.
+
+      Was it my own excited imagination—or the misty influence of the
+      atmosphere—or the uncertain twilight of the chamber—or the gray
+      draperies which fell around her figure—that caused in it so
+      vacillating and indistinct an outline? I could not tell. She
+      spoke no word; and I—not for worlds could I have uttered a
+      syllable. An icy chill ran through my frame; a sense of
+      insufferable anxiety oppressed me; a consuming curiosity pervaded
+      my soul; and sinking back upon the chair, I remained for some
+      time breathless and motionless, with my eyes riveted upon her
+      person. Alas! its emaciation was excessive, and not one vestige
+      of the former being lurked in any single line of the contour. My
+      burning glances at length fell upon the face.
+
+      The forehead was high, and very pale, and singularly placid; and
+      the once jetty hair fell partially over it, and overshadowed the
+      hollow temples with innumerable ringlets, now of a vivid yellow,
+      and jarring discordantly, in their fantastic character, with the
+      reigning melancholy of the countenance. The eyes were lifeless,
+      and lustreless, and seemingly pupilless, and I shrank
+      involuntarily from their glassy stare to the contemplation of the
+      thin and shrunken lips. They parted; and in a smile of peculiar
+      meaning, _the teeth_ of the changed Berenice disclosed themselves
+      slowly to my view. Would to God that I had never beheld them, or
+      that, having done so, I had died!
+
+      The shutting of a door disturbed me, and, looking up, I found
+      that my cousin had departed from the chamber. But from the
+      disordered chamber of my brain, had not, alas! departed, and
+      would not be driven away, the white and ghastly _spectrum_ of the
+      teeth. Not a speck on their surface—not a shade on their
+      enamel—not an indenture in their edges—but what that period of
+      her smile had sufficed to brand in upon my memory. I saw them
+      _now_ even more unequivocally than I beheld them _then_. The
+      teeth!—the teeth!—they were here, and there, and everywhere, and
+      visibly and palpably before me; long, narrow, and excessively
+      white, with the pale lips writhing about them, as in the very
+      moment of their first terrible development. Then came the full
+      fury of my _monomania_, and I struggled in vain against its
+      strange and irresistible influence. In the multiplied objects of
+      the external world I had no thoughts but for the teeth. For these
+      I longed with a phrenzied desire. All other matters and all
+      different interests became absorbed in their single
+      contemplation. They—they alone were present to the mental eye,
+      and they, in their sole individuality, became the essence of my
+      mental life. I held them in every light. I turned them in every
+      attitude. I surveyed their characteristics. I dwelt upon their
+      peculiarities. I pondered upon their conformation. I mused upon
+      the alteration in their nature. I shuddered as I assigned to them
+      in imagination a sensitive and sentient power, and even when
+      unassisted by the lips, a capability of moral expression. Of
+      Mademoiselle Salle it has been well said, “_Que tous ses pas
+      etaient des sentiments_,” and of Berenice I more seriously
+      believed _que toutes ses dents etaient des idées_. _Des
+      idées!_—ah here was the idiotic thought that destroyed me! _Des
+      idées!_—ah, _therefore_ it was that I coveted them so madly! I
+      felt that their possession could alone ever restore me to peace,
+      in giving me back to reason.
+
+      And the evening closed in upon me thus—and then the darkness
+      came, and tarried, and went—and the day again dawned—and the
+      mists of a second night were now gathering around—and still I sat
+      motionless in that solitary room—and still I sat buried in
+      meditation—and still the _phantasma_ of the teeth maintained its
+      terrible ascendancy, as, with the most vivid hideous
+      distinctness, it floated about amid the changing lights and
+      shadows of the chamber. At length there broke in upon my dreams a
+      cry as of horror and dismay; and thereunto, after a pause,
+      succeeded the sound of troubled voices, intermingled with many
+      low moanings of sorrow or of pain. I arose from my seat, and
+      throwing open one of the doors of the library, saw standing out
+      in the ante-chamber a servant maiden, all in tears, who told me
+      that Berenice was—no more! She had been seized with epilepsy in
+      the early morning, and now, at the closing in of the night, the
+      grave was ready for its tenant, and all the preparations for the
+      burial were completed.
+
+      I found myself sitting in the library, and again sitting there
+      alone. It seemed that I had newly awakened from a confused and
+      exciting dream. I knew that it was now midnight, and I was well
+      aware, that since the setting of the sun, Berenice had been
+      interred. But of that dreary period which intervened I had no
+      positive, at least no definite comprehension. Yet its memory was
+      replete with horror—horror more horrible from being vague, and
+      terror more terrible from ambiguity. It was a fearful page in the
+      record my existence, written all over with dim, and hideous, and
+      unintelligible recollections. I strived to decypher them, but in
+      vain; while ever and anon, like the spirit of a departed sound,
+      the shrill and piercing shriek of a female voice seemed to be
+      ringing in my ears. I had done a deed—what was it? I asked myself
+      the question aloud, and the whispering echoes of the chamber
+      answered me,—“_What was it?_”
+
+      On the table beside me burned a lamp, and near it lay a little
+      box. It was of no remarkable character, and I had seen it
+      frequently before, for it was the property of the family
+      physician; but how came it _there_, upon my table, and why did I
+      shudder in regarding it? These things were in no manner to be
+      accounted for, and my eyes at length dropped to the open pages of
+      a book, and to a sentence underscored therein. The words were the
+      singular but simple ones of the poet Ebn Zaiat:—“_Dicebant mihi
+      sodales si sepulchrum amicae visitarem, curas meas aliquantulum
+      fore levatas_.” Why then, as I perused them, did the hairs of my
+      head erect themselves on end, and the blood of my body become
+      congealed within my veins?
+
+      There came a light tap at the library door—and, pale as the
+      tenant of a tomb, a menial entered upon tiptoe. His looks were
+      wild with terror, and he spoke to me in a voice tremulous, husky,
+      and very low. What said he?—some broken sentences I heard. He
+      told of a wild cry disturbing the silence of the night—of the
+      gathering together of the household—of a search in the direction
+      of the sound; and then his tones grew thrillingly distinct as he
+      whispered me of a violated grave—of a disfigured body enshrouded,
+      yet still breathing—still palpitating—_still alive_!
+
+      He pointed to garments;—they were muddy and clotted with gore. I
+      spoke not, and he took me gently by the hand: it was indented
+      with the impress of human nails. He directed my attention to some
+      object against the wall. I looked at it for some minutes: it was
+      a spade. With a shriek I bounded to the table, and grasped the
+      box that lay upon it. But I could not force it open; and in my
+      tremor, it slipped from my hands, and fell heavily, and burst
+      into pieces; and from it, with a rattling sound, there rolled out
+      some instruments of dental surgery, intermingled with thirty-two
+      small, white and ivory-looking substances that were scattered to
+      and fro about the floor.
+
+
+
+
+ELEONORA
+
+
+     Sub conservatione formæ specificæ salva anima.
+                    —_Raymond Lully_.
+
+      I am come of a race noted for vigor of fancy and ardor of
+      passion. Men have called me mad; but the question is not yet
+      settled, whether madness is or is not the loftiest
+      intelligence—whether much that is glorious—whether all that is
+      profound—does not spring from disease of thought—from moods of
+      mind exalted at the expense of the general intellect. They who
+      dream by day are cognizant of many things which escape those who
+      dream only by night. In their gray visions they obtain glimpses
+      of eternity, and thrill, in awakening, to find that they have
+      been upon the verge of the great secret. In snatches, they learn
+      something of the wisdom which is of good, and more of the mere
+      knowledge which is of evil. They penetrate, however, rudderless
+      or compassless into the vast ocean of the “light ineffable,” and
+      again, like the adventures of the Nubian geographer, “agressi
+      sunt mare tenebrarum, quid in eo esset exploraturi.”
+
+      We will say, then, that I am mad. I grant, at least, that there
+      are two distinct conditions of my mental existence—the condition
+      of a lucid reason, not to be disputed, and belonging to the
+      memory of events forming the first epoch of my life—and a
+      condition of shadow and doubt, appertaining to the present, and
+      to the recollection of what constitutes the second great era of
+      my being. Therefore, what I shall tell of the earlier period,
+      believe; and to what I may relate of the later time, give only
+      such credit as may seem due, or doubt it altogether, or, if doubt
+      it ye cannot, then play unto its riddle the Oedipus.
+
+      She whom I loved in youth, and of whom I now pen calmly and
+      distinctly these remembrances, was the sole daughter of the only
+      sister of my mother long departed. Eleonora was the name of my
+      cousin. We had always dwelled together, beneath a tropical sun,
+      in the Valley of the Many-Colored Grass. No unguided footstep
+      ever came upon that vale; for it lay away up among a range of
+      giant hills that hung beetling around about it, shutting out the
+      sunlight from its sweetest recesses. No path was trodden in its
+      vicinity; and, to reach our happy home, there was need of putting
+      back, with force, the foliage of many thousands of forest trees,
+      and of crushing to death the glories of many millions of fragrant
+      flowers. Thus it was that we lived all alone, knowing nothing of
+      the world without the valley—I, and my cousin, and her mother.
+
+      From the dim regions beyond the mountains at the upper end of our
+      encircled domain, there crept out a narrow and deep river,
+      brighter than all save the eyes of Eleonora; and, winding
+      stealthily about in mazy courses, it passed away, at length,
+      through a shadowy gorge, among hills still dimmer than those
+      whence it had issued. We called it the “River of Silence”; for
+      there seemed to be a hushing influence in its flow. No murmur
+      arose from its bed, and so gently it wandered along, that the
+      pearly pebbles upon which we loved to gaze, far down within its
+      bosom, stirred not at all, but lay in a motionless content, each
+      in its own old station, shining on gloriously forever.
+
+      The margin of the river, and of the many dazzling rivulets that
+      glided through devious ways into its channel, as well as the
+      spaces that extended from the margins away down into the depths
+      of the streams until they reached the bed of pebbles at the
+      bottom,—these spots, not less than the whole surface of the
+      valley, from the river to the mountains that girdled it in, were
+      carpeted all by a soft green grass, thick, short, perfectly even,
+      and vanilla-perfumed, but so besprinkled throughout with the
+      yellow buttercup, the white daisy, the purple violet, and the
+      ruby-red asphodel, that its exceeding beauty spoke to our hearts
+      in loud tones, of the love and of the glory of God.
+
+      And, here and there, in groves about this grass, like
+      wildernesses of dreams, sprang up fantastic trees, whose tall
+      slender stems stood not upright, but slanted gracefully toward
+      the light that peered at noon-day into the centre of the valley.
+      Their mark was speckled with the vivid alternate splendor of
+      ebony and silver, and was smoother than all save the cheeks of
+      Eleonora; so that, but for the brilliant green of the huge leaves
+      that spread from their summits in long, tremulous lines, dallying
+      with the Zephyrs, one might have fancied them giant serpents of
+      Syria doing homage to their sovereign the Sun.
+
+      Hand in hand about this valley, for fifteen years, roamed I with
+      Eleonora before Love entered within our hearts. It was one
+      evening at the close of the third lustrum of her life, and of the
+      fourth of my own, that we sat, locked in each other’s embrace,
+      beneath the serpent-like trees, and looked down within the water
+      of the River of Silence at our images therein. We spoke no words
+      during the rest of that sweet day, and our words even upon the
+      morrow were tremulous and few. We had drawn the God Eros from
+      that wave, and now we felt that he had enkindled within us the
+      fiery souls of our forefathers. The passions which had for
+      centuries distinguished our race, came thronging with the fancies
+      for which they had been equally noted, and together breathed a
+      delirious bliss over the Valley of the Many-Colored Grass. A
+      change fell upon all things. Strange, brilliant flowers,
+      star-shaped, burn out upon the trees where no flowers had been
+      known before. The tints of the green carpet deepened; and when,
+      one by one, the white daisies shrank away, there sprang up in
+      place of them, ten by ten of the ruby-red asphodel. And life
+      arose in our paths; for the tall flamingo, hitherto unseen, with
+      all gay glowing birds, flaunted his scarlet plumage before us.
+      The golden and silver fish haunted the river, out of the bosom of
+      which issued, little by little, a murmur that swelled, at length,
+      into a lulling melody more divine than that of the harp of
+      Æolus—sweeter than all save the voice of Eleonora. And now, too,
+      a voluminous cloud, which we had long watched in the regions of
+      Hesper, floated out thence, all gorgeous in crimson and gold, and
+      settling in peace above us, sank, day by day, lower and lower,
+      until its edges rested upon the tops of the mountains, turning
+      all their dimness into magnificence, and shutting us up, as if
+      forever, within a magic prison-house of grandeur and of glory.
+
+      The loveliness of Eleonora was that of the Seraphim; but she was
+      a maiden artless and innocent as the brief life she had led among
+      the flowers. No guile disguised the fervor of love which animated
+      her heart, and she examined with me its inmost recesses as we
+      walked together in the Valley of the Many-Colored Grass, and
+      discoursed of the mighty changes which had lately taken place
+      therein.
+
+      At length, having spoken one day, in tears, of the last sad
+      change which must befall Humanity, she thenceforward dwelt only
+      upon this one sorrowful theme, interweaving it into all our
+      converse, as, in the songs of the bard of Schiraz, the same
+      images are found occurring, again and again, in every impressive
+      variation of phrase.
+
+      She had seen that the finger of Death was upon her bosom—that,
+      like the ephemeron, she had been made perfect in loveliness only
+      to die; but the terrors of the grave to her lay solely in a
+      consideration which she revealed to me, one evening at twilight,
+      by the banks of the River of Silence. She grieved to think that,
+      having entombed her in the Valley of the Many-Colored Grass, I
+      would quit forever its happy recesses, transferring the love
+      which now was so passionately her own to some maiden of the outer
+      and everyday world. And, then and there, I threw myself hurriedly
+      at the feet of Eleonora, and offered up a vow, to herself and to
+      Heaven, that I would never bind myself in marriage to any
+      daughter of Earth—that I would in no manner prove recreant to her
+      dear memory, or to the memory of the devout affection with which
+      she had blessed me. And I called the Mighty Ruler of the Universe
+      to witness the pious solemnity of my vow. And the curse which I
+      invoked of Him and of her, a saint in Helusion should I prove
+      traitorous to that promise, involved a penalty the exceeding
+      great horror of which will not permit me to make record of it
+      here. And the bright eyes of Eleonora grew brighter at my words;
+      and she sighed as if a deadly burthen had been taken from her
+      breast; and she trembled and very bitterly wept; but she made
+      acceptance of the vow, (for what was she but a child?) and it
+      made easy to her the bed of her death. And she said to me, not
+      many days afterward, tranquilly dying, that, because of what I
+      had done for the comfort of her spirit she would watch over me in
+      that spirit when departed, and, if so it were permitted her
+      return to me visibly in the watches of the night; but, if this
+      thing were, indeed, beyond the power of the souls in Paradise,
+      that she would, at least, give me frequent indications of her
+      presence, sighing upon me in the evening winds, or filling the
+      air which I breathed with perfume from the censers of the angels.
+      And, with these words upon her lips, she yielded up her innocent
+      life, putting an end to the first epoch of my own.
+
+      Thus far I have faithfully said. But as I pass the barrier in
+      Time’s path, formed by the death of my beloved, and proceed with
+      the second era of my existence, I feel that a shadow gathers over
+      my brain, and I mistrust the perfect sanity of the record. But
+      let me on.—Years dragged themselves along heavily, and still I
+      dwelled within the Valley of the Many-Colored Grass; but a second
+      change had come upon all things. The star-shaped flowers shrank
+      into the stems of the trees, and appeared no more. The tints of
+      the green carpet faded; and, one by one, the ruby-red asphodels
+      withered away; and there sprang up, in place of them, ten by ten,
+      dark, eye-like violets, that writhed uneasily and were ever
+      encumbered with dew. And Life departed from our paths; for the
+      tall flamingo flaunted no longer his scarlet plumage before us,
+      but flew sadly from the vale into the hills, with all the gay
+      glowing birds that had arrived in his company. And the golden and
+      silver fish swam down through the gorge at the lower end of our
+      domain and bedecked the sweet river never again. And the lulling
+      melody that had been softer than the wind-harp of Æolus, and more
+      divine than all save the voice of Eleonora, it died little by
+      little away, in murmurs growing lower and lower, until the stream
+      returned, at length, utterly, into the solemnity of its original
+      silence. And then, lastly, the voluminous cloud uprose, and,
+      abandoning the tops of the mountains to the dimness of old, fell
+      back into the regions of Hesper, and took away all its manifold
+      golden and gorgeous glories from the Valley of the Many-Colored
+      Grass.
+
+      Yet the promises of Eleonora were not forgotten; for I heard the
+      sounds of the swinging of the censers of the angels; and streams
+      of a holy perfume floated ever and ever about the valley; and at
+      lone hours, when my heart beat heavily, the winds that bathed my
+      brow came unto me laden with soft sighs; and indistinct murmurs
+      filled often the night air, and once—oh, but once only! I was
+      awakened from a slumber, like the slumber of death, by the
+      pressing of spiritual lips upon my own.
+
+      But the void within my heart refused, even thus, to be filled. I
+      longed for the love which had before filled it to overflowing. At
+      length the valley pained me through its memories of Eleonora, and
+      I left it for ever for the vanities and the turbulent triumphs of
+      the world.
+
+      I found myself within a strange city, where all things might have
+      served to blot from recollection the sweet dreams I had dreamed
+      so long in the Valley of the Many-Colored Grass. The pomps and
+      pageantries of a stately court, and the mad clangor of arms, and
+      the radiant loveliness of women, bewildered and intoxicated my
+      brain. But as yet my soul had proved true to its vows, and the
+      indications of the presence of Eleonora were still given me in
+      the silent hours of the night. Suddenly these manifestations they
+      ceased, and the world grew dark before mine eyes, and I stood
+      aghast at the burning thoughts which possessed, at the terrible
+      temptations which beset me; for there came from some far, far
+      distant and unknown land, into the gay court of the king I
+      served, a maiden to whose beauty my whole recreant heart yielded
+      at once—at whose footstool I bowed down without a struggle, in
+      the most ardent, in the most abject worship of love. What,
+      indeed, was my passion for the young girl of the valley in
+      comparison with the fervor, and the delirium, and the
+      spirit-lifting ecstasy of adoration with which I poured out my
+      whole soul in tears at the feet of the ethereal Ermengarde?—Oh,
+      bright was the seraph Ermengarde! and in that knowledge I had
+      room for none other. Oh, divine was the angel Ermengarde! and as
+      I looked down into the depths of her memorial eyes, I thought
+      only of them—and of her.
+
+      I wedded—nor dreaded the curse I had invoked; and its bitterness
+      was not visited upon me. And once—but once again in the silence
+      of the night; there came through my lattice the soft sighs which
+      had forsaken me; and they modelled themselves into familiar and
+      sweet voice, saying:
+
+      “Sleep in peace! for the Spirit of Love reigneth and ruleth, and,
+      in taking to thy passionate heart her who is Ermengarde, thou art
+      absolved, for reasons which shall be made known to thee in
+      Heaven, of thy vows unto Eleonora.”


### PR DESCRIPTION
notes:
- The Poe source includes Volume Two of the Complete Works anthology available on Project Gutenberg. This was the volume that contained his short stories/novellas, with less of an emphasis on his poetry or psychological essays. I figured this would give us the most accurate summation of his literary works when compared to Lovecraft's.
- I've included both the original text files from Gutenberg and my own "abridged" versions (the ones noted "authorname"works.txt). The abridged versions exclude the Gutenberg headings and the licensing agreement at the end. In the case of the Lovecraft combined file, it's a compilation of four of his short story/novellas. The Poe file excludes the notes section at the end of the compilation that gave context from the transcribers. Both files come out to a word count of about ~91k each for a roughly equal sample size between the authors. Other than 'trimming the fat' so to say, the content remains unchanged.